### PR TITLE
feat: add func returning first cluster client from cache

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -46,9 +46,23 @@ func (c *kubeFedClusterClients) getFedCluster(name string) (*FedCluster, bool) {
 	return cluster, ok
 }
 
+func (c *kubeFedClusterClients) getFirstFedCluster() (*FedCluster, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	for _, cluster := range c.clusters {
+		return cluster, true
+	}
+	return nil, false
+}
+
 // GetFedCluster returns a kube client for the cluster (with the given name) and info if the client exists
 func GetFedCluster(name string) (*FedCluster, bool) {
 	return clusterCache.getFedCluster(name)
+}
+
+// GetFirstFedCluster returns a first kube client from the cache of clusters and info if such a client exists
+func GetFirstFedCluster() (*FedCluster, bool) {
+	return clusterCache.getFirstFedCluster()
 }
 
 // Type is a cluster type (either host or member)

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -12,6 +12,9 @@ import (
 var getFedClusterFuncs = []func(name string) (*FedCluster, bool){
 	clusterCache.getFedCluster, GetFedCluster}
 
+var getFirstFedClusterFuncs = []func() (*FedCluster, bool){
+	clusterCache.getFirstFedCluster, GetFirstFedCluster}
+
 func TestAddCluster(t *testing.T) {
 	// given
 	defer resetClusterCache()
@@ -43,6 +46,23 @@ func TestGetCluster(t *testing.T) {
 	}
 }
 
+func TestGetFirstCluster(t *testing.T) {
+	// given
+	defer resetClusterCache()
+	fedCluster := newTestFedCluster("testCluster", v1.ConditionTrue)
+	clusterCache.addFedCluster(fedCluster)
+
+	for _, getFirstFedCluster := range getFirstFedClusterFuncs {
+
+		// when
+		returnedFedCluster, ok := getFirstFedCluster()
+
+		// then
+		assert.True(t, ok)
+		assert.Equal(t, fedCluster, returnedFedCluster)
+	}
+}
+
 func TestGetClusterWhenIsEmpty(t *testing.T) {
 	// given
 	resetClusterCache()
@@ -51,6 +71,21 @@ func TestGetClusterWhenIsEmpty(t *testing.T) {
 
 		// when
 		returnedFedCluster, ok := getFedCluster("testCluster")
+
+		// then
+		assert.False(t, ok)
+		assert.Nil(t, returnedFedCluster)
+	}
+}
+
+func TestGetFirstClusterWhenIsEmpty(t *testing.T) {
+	// given
+	resetClusterCache()
+
+	for _, getFirstFedCluster := range getFirstFedClusterFuncs {
+
+		// when
+		returnedFedCluster, ok := getFirstFedCluster()
 
 		// then
 		assert.False(t, ok)


### PR DESCRIPTION
the function is going to be used in a member operator to get a client of a host cluster - the member doesn't know the name of the cluster and there should be only one `KubeFedCluster` CR in the namespace 