### PR TITLE
feat: add localName label to KubeFedCluster CR

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,10 +25,7 @@ $ oc apply -f deploy/user.yaml
 === add-cluster.sh
 
 The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
-To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes two arguments:
-
-1. type of the cluster to be added
-2. name of the cluster to be added
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes one argument - type of the cluster to be added.
 
 The script is working with Minishift profiles and expects that there are two clusters (profiles) called `host` and `member`.
 To be able to run the script, you need to have both clusters prepared, which means:
@@ -36,11 +33,12 @@ To be able to run the script, you need to have both clusters prepared, which mea
 - created CRDs
 - created ServiceAccount with ClusterRole/ClusterRoleBinding
 
-When the script is executed with parameters `add-cluster.sh member member-cluster` then it does these steps:
+When the script is executed with parameters `add-cluster.sh member` then it does these steps:
 
 1. goes to the `member` profile
 2. takes a secret of the SA (from the `member`)
-3. takes API endpoint of the `member` cluster from Kube config
+3. takes API endpoint and cluster name of the `member` cluster from Kube config
 4. goes to `host` profile
+5. takes cluster name of the `host` cluster from Kube config
 5. creates a secret with the SA token taken from the `member`
 6. creates `KubeFedCluster` CR representing the added `member`

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -25,6 +25,11 @@ type FedCluster struct {
 	OperatorNamespace string
 	// ClusterStatus is the cluster result as of the last health check probe.
 	ClusterStatus *v1beta1.KubeFedClusterStatus
+	// LocalName keeps the name of the cluster the KubeFedCluster resource is created in
+	// eg. if this KubeFedCluster identifies a Host cluster (and thus is created in Member)
+	// then the LocalName has a name of the member - it has to be same name as the name
+	// that is used for identifying the member in a Host cluster
+	LocalName string
 }
 
 func (c *kubeFedClusterClients) addFedCluster(cluster *FedCluster) {

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -25,11 +25,11 @@ type FedCluster struct {
 	OperatorNamespace string
 	// ClusterStatus is the cluster result as of the last health check probe.
 	ClusterStatus *v1beta1.KubeFedClusterStatus
-	// LocalName keeps the name of the cluster the KubeFedCluster resource is created in
+	// OwnerClusterName keeps the name of the cluster the KubeFedCluster resource is created in
 	// eg. if this KubeFedCluster identifies a Host cluster (and thus is created in Member)
-	// then the LocalName has a name of the member - it has to be same name as the name
+	// then the OwnerClusterName has a name of the member - it has to be same name as the name
 	// that is used for identifying the member in a Host cluster
-	LocalName string
+	OwnerClusterName string
 }
 
 func (c *kubeFedClusterClients) addFedCluster(cluster *FedCluster) {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -15,9 +15,9 @@ import (
 )
 
 const (
-	labelType      = "type"
-	labelNamespace = "namespace"
-	labelLocalName = "localName"
+	labelType             = "type"
+	labelNamespace        = "namespace"
+	labelOwnerClusterName = "ownerClusterName"
 
 	defaultHostOperatorNamespace   = "toolchain-host-operator"
 	defaultMemberOperatorNamespace = "toolchain-member-operator"
@@ -64,7 +64,7 @@ func (s *KubeFedClusterService) addKubeFedCluster(fedCluster *v1beta1.KubeFedClu
 		ClusterStatus:     &fedCluster.Status,
 		Type:              Type(fedCluster.Labels[labelType]),
 		OperatorNamespace: fedCluster.Labels[labelNamespace],
-		LocalName:         fedCluster.Labels[labelLocalName],
+		OwnerClusterName:  fedCluster.Labels[labelOwnerClusterName],
 	}
 	if cluster.Type == "" {
 		cluster.Type = Member

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -17,6 +17,7 @@ import (
 const (
 	labelType      = "type"
 	labelNamespace = "namespace"
+	labelLocalName = "localName"
 
 	defaultHostOperatorNamespace   = "toolchain-host-operator"
 	defaultMemberOperatorNamespace = "toolchain-member-operator"
@@ -63,6 +64,7 @@ func (s *KubeFedClusterService) addKubeFedCluster(fedCluster *v1beta1.KubeFedClu
 		ClusterStatus:     &fedCluster.Status,
 		Type:              Type(fedCluster.Labels[labelType]),
 		OperatorNamespace: fedCluster.Labels[labelNamespace],
+		LocalName:         fedCluster.Labels[labelLocalName],
 	}
 	if cluster.Type == "" {
 		cluster.Type = Member

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -15,6 +15,11 @@ import (
 	"testing"
 )
 
+const (
+	nameHost   = "dsaas"
+	nameMember = "east"
+)
+
 func newKubeFedCluster(name, secName string, status v1beta1.KubeFedClusterStatus, labels map[string]string) (*v1beta1.KubeFedCluster, *corev1.Secret) {
 	logf.SetLogger(zap.Logger())
 	gock.New("http://cluster.com").
@@ -55,9 +60,9 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 	defer gock.Off()
 	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
 	memberLabels := []map[string]string{
-		labels("", ""),
-		labels(cluster.Member, ""),
-		labels(cluster.Member, "member-ns")}
+		labels("", "", nameHost),
+		labels(cluster.Member, "", nameHost),
+		labels(cluster.Member, "member-ns", nameHost),}
 	for _, labels := range memberLabels {
 
 		t.Run("add member KubeFedCluster", func(t *testing.T) {
@@ -79,6 +84,7 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
+			assert.Equal(t, nameHost, fedCluster.LocalName)
 		})
 	}
 }
@@ -88,8 +94,8 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 	defer gock.Off()
 	status := newClusterStatus(common.ClusterReady, corev1.ConditionFalse)
 	memberLabels := []map[string]string{
-		labels(cluster.Host, ""),
-		labels(cluster.Host, "host-ns")}
+		labels(cluster.Host, "", nameMember),
+		labels(cluster.Host, "host-ns", nameMember)}
 	for _, labels := range memberLabels {
 
 		t.Run("add host KubeFedCluster", func(t *testing.T) {
@@ -111,6 +117,7 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
+			assert.Equal(t, nameMember, fedCluster.LocalName)
 		})
 	}
 }
@@ -119,7 +126,7 @@ func TestAddKubeFedClusterFailsBecauseOfMissingSecret(t *testing.T) {
 	// given
 	defer gock.Off()
 	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status, labels("", ""))
+	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status, labels("", "", nameHost))
 	cl := fake.NewFakeClient()
 	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
 
@@ -136,7 +143,8 @@ func TestAddKubeFedClusterFailsBecauseOfEmptySecret(t *testing.T) {
 	// given
 	defer gock.Off()
 	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status, labels("", ""))
+	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status,
+		labels("", "", nameHost))
 	secret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "secret",
@@ -158,9 +166,11 @@ func TestUpdateKubeFedCluster(t *testing.T) {
 	// given
 	defer gock.Off()
 	statusTrue := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster1, sec1 := newKubeFedCluster("east", "secret1", statusTrue, labels("", ""))
+	kubeFedCluster1, sec1 := newKubeFedCluster("east", "secret1", statusTrue,
+		labels("", "", nameMember))
 	statusFalse := newClusterStatus(common.ClusterReady, corev1.ConditionFalse)
-	kubeFedCluster2, sec2 := newKubeFedCluster("east", "secret2", statusFalse, labels(cluster.Host, ""))
+	kubeFedCluster2, sec2 := newKubeFedCluster("east", "secret2", statusFalse,
+		labels(cluster.Host, "", nameMember))
 	cl := fake.NewFakeClient(sec1, sec2)
 	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
 	defer service.DeleteKubeFedCluster(kubeFedCluster2)
@@ -175,13 +185,15 @@ func TestUpdateKubeFedCluster(t *testing.T) {
 	assert.Equal(t, cluster.Host, fedCluster.Type)
 	assert.Equal(t, "toolchain-host-operator", fedCluster.OperatorNamespace)
 	assert.Equal(t, statusFalse, *fedCluster.ClusterStatus)
+	assert.Equal(t, nameMember, fedCluster.LocalName)
 }
 
 func TestDeleteKubeFedCluster(t *testing.T) {
 	// given
 	defer gock.Off()
 	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, sec := newKubeFedCluster("east", "sec", status, labels("", ""))
+	kubeFedCluster, sec := newKubeFedCluster("east", "sec", status,
+		labels("", "", nameHost))
 	cl := fake.NewFakeClient(sec)
 	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
 	service.AddKubeFedCluster(kubeFedCluster)
@@ -204,7 +216,7 @@ func newClusterStatus(conType common.ClusterConditionType, conStatus corev1.Cond
 	}
 }
 
-func labels(clType cluster.Type, ns string) map[string]string {
+func labels(clType cluster.Type, ns, localName string) map[string]string {
 	labels := map[string]string{}
 	if clType != "" {
 		labels["type"] = string(clType)
@@ -212,5 +224,6 @@ func labels(clType cluster.Type, ns string) map[string]string {
 	if ns != "" {
 		labels["namespace"] = ns
 	}
+	labels["localName"] = localName
 	return labels
 }

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -62,7 +62,7 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 	memberLabels := []map[string]string{
 		labels("", "", nameHost),
 		labels(cluster.Member, "", nameHost),
-		labels(cluster.Member, "member-ns", nameHost),}
+		labels(cluster.Member, "member-ns", nameHost)}
 	for _, labels := range memberLabels {
 
 		t.Run("add member KubeFedCluster", func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
-			assert.Equal(t, nameHost, fedCluster.LocalName)
+			assert.Equal(t, nameHost, fedCluster.OwnerClusterName)
 		})
 	}
 }
@@ -117,7 +117,7 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
-			assert.Equal(t, nameMember, fedCluster.LocalName)
+			assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
 		})
 	}
 }
@@ -185,7 +185,7 @@ func TestUpdateKubeFedCluster(t *testing.T) {
 	assert.Equal(t, cluster.Host, fedCluster.Type)
 	assert.Equal(t, "toolchain-host-operator", fedCluster.OperatorNamespace)
 	assert.Equal(t, statusFalse, *fedCluster.ClusterStatus)
-	assert.Equal(t, nameMember, fedCluster.LocalName)
+	assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
 }
 
 func TestDeleteKubeFedCluster(t *testing.T) {
@@ -216,7 +216,7 @@ func newClusterStatus(conType common.ClusterConditionType, conStatus corev1.Cond
 	}
 }
 
-func labels(clType cluster.Type, ns, localName string) map[string]string {
+func labels(clType cluster.Type, ns, ownerClusterName string) map[string]string {
 	labels := map[string]string{}
 	if clType != "" {
 		labels["type"] = string(clType)
@@ -224,6 +224,6 @@ func labels(clType cluster.Type, ns, localName string) map[string]string {
 	if ns != "" {
 		labels["namespace"] = ns
 	}
-	labels["localName"] = localName
+	labels["ownerClusterName"] = ownerClusterName
 	return labels
 }

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -2,7 +2,6 @@
 
 
 JOINING_CLUSTER_TYPE=$1
-JOINING_CLUSTER_NAME=$2
 OPERATOR_NS=${OPERATOR_NAMESPACE:toolchain-member-operator}
 SA_NAME=${JOINING_CLUSTER_TYPE}"-operator"
 
@@ -22,22 +21,25 @@ SA_TOKEN=`oc get secret ${SA_SECRET} -o json | jq -r '.data["token"]' | base64 -
 SA_CA_CRT=`oc get secret ${SA_SECRET} -o json | jq -r '.data["ca.crt"]'`
 
 API_ENDPOINT=`oc config view --raw --minify -o json | jq -r '.clusters[0].cluster["server"]'`
+JOINING_CLUSTER_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
 
 echo "Switching to profile ${CLUSTER_JOIN_TO}"
 minishift profile set ${CLUSTER_JOIN_TO}
 oc login -u=system:admin
 oc project "toolchain-${CLUSTER_JOIN_TO}-operator"
 
+CLUSTER_JOIN_TO_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
 oc create secret generic ${SA_NAME}-${JOINING_CLUSTER_NAME} --from-literal=token="${SA_TOKEN}" --from-literal=ca.crt="${SA_CA_CRT}"
 
 KUBEFEDCLUSTER_CRD="apiVersion: core.kubefed.k8s.io/v1beta1
 kind: KubeFedCluster
 metadata:
-  name: ${JOINING_CLUSTER_NAME}
+  name: ${JOINING_CLUSTER_TYPE}-${JOINING_CLUSTER_NAME}
   namespace: ${OPERATOR_NS}
   labels:
     type: ${JOINING_CLUSTER_TYPE}
     namespace: toolchain-${JOINING_CLUSTER_TYPE}-operator
+    localName: ${CLUSTER_JOIN_TO}-${CLUSTER_JOIN_TO_NAME}
 spec:
   apiEndpoint: ${API_ENDPOINT}
   caBundle: ${SA_CA_CRT}

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -39,7 +39,7 @@ metadata:
   labels:
     type: ${JOINING_CLUSTER_TYPE}
     namespace: toolchain-${JOINING_CLUSTER_TYPE}-operator
-    localName: ${CLUSTER_JOIN_TO}-${CLUSTER_JOIN_TO_NAME}
+    ownerClusterName: ${CLUSTER_JOIN_TO}-${CLUSTER_JOIN_TO_NAME}
 spec:
   apiEndpoint: ${API_ENDPOINT}
   caBundle: ${SA_CA_CRT}


### PR DESCRIPTION
the label `localName` will help members to identify themselves in the host. 
The script takes a name of the cluster from the kube config - this is kind of temporary solution for minishift until we will be able to use `clusterID` in OS 4 