### PR TITLE
Update README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ image:https://codecov.io/gh/codeready-toolchain/toolchain-common/branch/master/g
 
 This repo is for controllers, libs, scripts, make files, etc to be shared between host and member operators.
 
-== Setting Up and Connecting Host and Member Operators
+== Setting Up and Connecting Host and Member Clusters
 
 In a new terminal, navigate to codeready-toolchain/host-operator directory and execute the following commands
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -36,7 +36,7 @@ $ make up-local
 Now that we are setup, we can add resources and watch the logs on the member-operator! To do so, open a new terminal and run the following commands
 ```
 $ oc project toolchain-host-operator
-$ oc apply -f '/path/to/masteruserreord.yaml'
+$ oc apply -f '/path/to/masteruserrecord.yaml'
 $ oc project toolchain-member-operator
 $ oc apply -f '/path/to/useraccount.yaml'
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -13,7 +13,6 @@ In a new terminal, execute the following commands
 $ cd $GOPATH/github.com/codeready-toolchain/host-operator
 $ minishift start --profile host
 $ make up-local
-^C
 ```
 
 ```
@@ -28,8 +27,10 @@ $ make up-local
 
 Now that we are setup, we can add resources and watch the logs on the member-operator! To do so, open a new terminal and run the following commands
 ```
+$ cd $GOPATH/github.com/codeready-toolchain/host-operator
 $ oc project toolchain-host-operator
 $ oc apply -f '/path/to/masteruserrecord.yaml'
+$ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ oc project toolchain-member-operator
 $ oc apply -f '/path/to/useraccount.yaml'
 ```

--- a/README.adoc
+++ b/README.adoc
@@ -46,6 +46,8 @@ $ oc apply -f '/path/to/useraccount.yaml'
 ```
 
 **Example masteruserrecord.yaml:**
+
+_Note:_ The `targetCluster` field must contain the correct IP address of the member cluster.
 ```
 apiVersion: toolchain.dev.openshift.com/v1alpha1
 kind: MasterUserRecord

--- a/README.adoc
+++ b/README.adoc
@@ -41,6 +41,61 @@ $ oc project toolchain-member-operator
 $ oc apply -f '/path/to/useraccount.yaml'
 ```
 
+**Example masteruserrecord.yaml:**
+```
+apiVersion: toolchain.dev.openshift.com/v1alpha1
+kind: MasterUserRecord
+metadata:
+  name: example
+spec:
+  disabled: false
+  deprovisioned: false
+  userID: 86505192-a386-11e9-ad56-525400ad2b23
+  userAccounts:
+  - targetCluster: member-192-168-42-61-8443
+    syncIndex: 86505192-a386-11e9-ad56-525400ad2b23
+    spec:
+      nsLimit: admin
+      userID: 86505192-a386-11e9-ad56-525400ad2b23
+      nsTemplateSet:
+        tierName: basic
+        namespaces:
+        - type: ide
+          revision: abcdef
+        - type: cicd
+          revision: abcdef
+status:
+  conditions:
+  - type: Ready
+    status: True
+  userAccounts:
+  - targetCluster: target-member-cluster
+    syncIndex: 86505192-a386-11e9-ad56-525400ad2b23
+```
+
+**Example useraccount.yaml:**
+```
+apiVersion: toolchain.dev.openshift.com/v1alpha1
+kind: UserAccount
+metadata:
+  name: example
+spec:
+  userID: 86505192-a386-11e9-ad56-525400ad2b23
+  disabled: false
+  nsLimit: admin
+  nsTemplateSet:
+    tierName: basic
+    namespaces:
+    - type: ide
+      revision: abcdef
+    - type: cicd
+      revision: abcdef
+status:
+  conditions:
+  - type: Ready
+    status: True
+```
+
 == Configuring developers.redhat.com Authentication in OpenShift 4 Cluster
 
 Create a secret with Identity Provider credentials:

--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,7 @@ $ minishift start --profile member
 $ make up-local
 ^C
 $ make add-member-to-host
+$ make add-host-to-member
 $ make up-local
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -8,24 +8,28 @@ This repo is for controllers, libs, scripts, make files, etc to be shared betwee
 
 == Setting Up and Connecting Host and Member Clusters
 
-In a new terminal, navigate to codeready-toolchain/host-operator directory and execute the following commands
+In a new terminal, execute the following commands
 ```
+$ cd $GOPATH/github.com/codeready-toolchain/host-operator
 $ minishift start --profile toolchain
 $ make up-local
 ^C
 ```
-In the same terminal, navigate to codeready-toolchain/member-operator directory and execute the following commands
+
 ```
+$ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ make up-local
 ^C
 $ make add-member-to-host
 ```
-In the same terminal, navigate back to codeready-toolchain/host-operator directory and execute the following commands
+
 ```
+$ cd $GOPATH/github.com/codeready-toolchain/host-operator
 make add-host-to-member
 ```
-In the same terminal, navigate back to codeready-toolchain/member-operator directory and execute the following commands
+
 ```
+$ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ make up-local
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -30,7 +30,7 @@ $ make add-host-to-member
 $ make build
 $ make vendor
 $ export OPERATOR_NAMESPACE=toolchain-member-operator
-$ operator-sdk up local --namespace=toolcha-member-operator --verbose
+$ operator-sdk up local --namespace=toolchain-member-operator --verbose
 ```
 
 Now that we are setup, we can add resources and watch the logs on the member-operator! To do so, open a new terminal and run the following commands

--- a/README.adoc
+++ b/README.adoc
@@ -11,25 +11,17 @@ This repo is for controllers, libs, scripts, make files, etc to be shared betwee
 In a new terminal, execute the following commands
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/host-operator
-$ minishift start --profile toolchain
+$ minishift start --profile host
 $ make up-local
 ^C
 ```
 
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/member-operator
+$ minishift start --profile member
 $ make up-local
 ^C
 $ make add-member-to-host
-```
-
-```
-$ cd $GOPATH/github.com/codeready-toolchain/host-operator
-make add-host-to-member
-```
-
-```
-$ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ make up-local
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -47,7 +47,7 @@ $ oc apply -f '/path/to/useraccount.yaml'
 
 **Example masteruserrecord.yaml:**
 
-_Note:_ The `targetCluster` field must contain the correct IP address of the member cluster.
+_Note:_ The `targetCluster` field must contain the correct member cluster name.
 ```
 apiVersion: toolchain.dev.openshift.com/v1alpha1
 kind: MasterUserRecord

--- a/README.adoc
+++ b/README.adoc
@@ -12,27 +12,36 @@ In a new terminal, execute the following commands
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/host-operator
 $ minishift start --profile host
-$ make up-local
+$ make login-as-admin 
+$ make create-namespace 
+$ make deploy-rbac
+$ make deploy-crd
 ```
 
-In another new terminal, execute the following commands
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ minishift start --profile member
-$ make up-local
-^C
+$ make login-as-admin 
+$ make create-namespace 
+$ make deploy-rbac
+$ make deploy-crd
 $ make add-member-to-host
 $ make add-host-to-member
-$ make up-local
+$ make build
+$ make vendor
+$ export OPERATOR_NAMESPACE=toolchain-member-operator
+$ operator-sdk up local --namespace=toolcha-member-operator --verbose
 ```
 
 Now that we are setup, we can add resources and watch the logs on the member-operator! To do so, open a new terminal and run the following commands
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/host-operator
-$ oc project toolchain-host-operator
+$ minishift profile set host
+$ make use-namespace
 $ oc apply -f '/path/to/masteruserrecord.yaml'
 $ cd $GOPATH/github.com/codeready-toolchain/member-operator
-$ oc project toolchain-member-operator
+$ minishift profile set member
+$ make use-namespace
 $ oc apply -f '/path/to/useraccount.yaml'
 ```
 
@@ -48,7 +57,7 @@ spec:
   userID: 86505192-a386-11e9-ad56-525400ad2b23
   userAccounts:
   - targetCluster: member-192-168-42-61-8443
-    syncIndex: 86505192-a386-11e9-ad56-525400ad2b23
+    syncIndex: 86505a
     spec:
       nsLimit: admin
       userID: 86505192-a386-11e9-ad56-525400ad2b23

--- a/README.adoc
+++ b/README.adoc
@@ -57,13 +57,6 @@ spec:
           revision: abcdef
         - type: cicd
           revision: abcdef
-status:
-  conditions:
-  - type: Ready
-    status: True
-  userAccounts:
-  - targetCluster: target-member-cluster
-    syncIndex: 86505192-a386-11e9-ad56-525400ad2b23
 ```
 
 **Example useraccount.yaml:**
@@ -83,10 +76,6 @@ spec:
       revision: abcdef
     - type: cicd
       revision: abcdef
-status:
-  conditions:
-  - type: Ready
-    status: True
 ```
 
 == Configuring developers.redhat.com Authentication in OpenShift 4 Cluster

--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,7 @@ $ minishift start --profile host
 $ make up-local
 ```
 
+In another new terminal, execute the following commands
 ```
 $ cd $GOPATH/github.com/codeready-toolchain/member-operator
 $ minishift start --profile member

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,37 @@ image:https://codecov.io/gh/codeready-toolchain/toolchain-common/branch/master/g
 
 This repo is for controllers, libs, scripts, make files, etc to be shared between host and member operators.
 
+== Setting Up Host and Member Operators
+
+In a new terminal, navigate to codeready-toolchain/host-operator directory and execute the following commands
+```
+$ minishift start --profile toolchain
+$ make up-local
+^C
+```
+In the same terminal, navigate to codeready-toolchain/member-operator directory and execute the following commands
+```
+$ make up-local
+^C
+$ make add-member-to-host
+```
+In the same terminal, navigate back to codeready-toolchain/host-operator directory and execute the following commands
+```
+make add-host-to-member
+```
+In the same terminal, navigate back to codeready-toolchain/member-operator directory and execute the following commands
+```
+$ make up-local
+```
+
+Now that we are setup, we can add resources and watch the logs on the member-operator! To do so, open a new terminal and run the following commands
+```
+$ oc project toolchain-host-operator
+$ oc apply -f '/path/to/masteruserreord.yaml'
+$ oc project toolchain-member-operator
+$ oc apply -f '/path/to/useraccount.yaml'
+```
+
 == Configuring developers.redhat.com Authentication in OpenShift 4 Cluster
 
 Create a secret with Identity Provider credentials:

--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ image:https://codecov.io/gh/codeready-toolchain/toolchain-common/branch/master/g
 
 This repo is for controllers, libs, scripts, make files, etc to be shared between host and member operators.
 
-== Setting Up Host and Member Operators
+== Setting Up and Connecting Host and Member Operators
 
 In a new terminal, navigate to codeready-toolchain/host-operator directory and execute the following commands
 ```


### PR DESCRIPTION
Adding instructions on how to run and connect host and member operators.

**Please note**: UserProvisionRequest has been renamed to UserSignup in codeready-toolchain/api, however, this name change has not yet been merged in codeready-toolchain/host-operator (PR:  https://github.com/codeready-toolchain/host-operator/pull/27) in order to try out the new steps added to the README.adoc you must use codeready-toolchain/api revision 5b2c0d42be1b085bdeea3fd899b9f5d89692be69 until codeready-toolchain/host-operator#27 has been merged. 

You will also need to do apply the UserProvisionRequest manually for the time being as follows: 
`oc apply -f deploy/crds/toolchain_v1alpha1_userprovisionrequest.yaml`

Relates to: https://jira.coreos.com/browse/CRT-178