### PR TITLE
upload report on PR merge

### DIFF
--- a/make/test.mk
+++ b/make/test.mk
@@ -24,22 +24,33 @@ test-with-coverage:
 # Uploads the test coverage reports to codecov.io. 
 # DO NOT USE LOCALLY: must only be called by OpenShift CI when processing new PR and when a PR is merged! 
 upload-codecov-report: 
-	@echo "uploading test coverage report..."
 	# Upload coverage to codecov.io. Since we don't run on a supported CI platform (Jenkins, Travis-ci, etc.), 
 	# we need to provide the PR metadata explicitely using env vars used coming from https://github.com/openshift/test-infra/blob/master/prow/jobs.md#job-environment-variables
 	# 
 	# Also: not using the `-F unittests` flag for now as it's temporarily disabled in the codecov UI 
 	# (see https://docs.codecov.io/docs/flags#section-flags-in-the-codecov-ui)
+ifneq ($(PR_COMMIT), null)
+	@echo "uploading test coverage report for pull-request #$(PULL_NUMBER)..."
 	bash <(curl -s https://codecov.io/bash) \
 		-t $(CODECOV_TOKEN) \
 		-f $(COV_DIR)/coverage.txt \
-		-C $(COMMIT) \
+		-C $(PR_COMMIT) \
 		-r $(REPO_OWNER)/$(REPO_NAME) \
 		-P $(PULL_NUMBER) \
 		-Z
+else
+	@echo "uploading test coverage report after PR was merged..."
+	bash <(curl -s https://codecov.io/bash) \
+		-t $(CODECOV_TOKEN) \
+		-f $(COV_DIR)/coverage.txt \
+		-C $(BASE_COMMIT) \
+		-r $(REPO_OWNER)/$(REPO_NAME) \
+		-Z
+endif
 
 CODECOV_TOKEN := "543cc327-510b-4e3e-9574-2c9cba1f2bc7"
-COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].sha')
 REPO_OWNER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].org')
 REPO_NAME := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].repo')
+BASE_COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].base_sha')
+PR_COMMIT := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].sha')
 PULL_NUMBER := $(shell echo $$CLONEREFS_OPTIONS | jq '.refs[0].pulls[0].number')


### PR DESCRIPTION
use 'ifneq' condition to distinguish the case where the job
is building a PR or after the PR was merged on master, in which
case the commit is not the same (and there is no PR number)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>