### PR TITLE
feat(CRT-165,CRT-202): add skeleton for KubeFedCluster e2e test & add test doubles for running e2e test with both operators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/codeready-toolchain/toolchain-common
 
 require (
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
-	github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1
+	github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1 h1:CJMZwz83ihcWnV4OdYQUWlSV+Ss0s4J8I6SkmI5lJzg=
 github.com/codeready-toolchain/api v0.0.0-20190709160753-31636807b6f1/go.mod h1:THipEIgxvhBvngWP2bmD5TXoCuQ1v2cz0IwAwQaaoPE=
+github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28 h1:+ndo0pFuFuy10St4EDltsITtrj4iOLArBvLXwj2Z4Fo=
+github.com/codeready-toolchain/api v0.0.0-20190812113906-bd1f09d19c28/go.mod h1:jHr8IvmLGTxmgD+jc1bBbucP4bSbT2JHnM+HdAw6N2g=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -86,6 +88,7 @@ github.com/go-toolsmith/typep v1.0.0 h1:zKymWyA1TRYvqYrYDrfEMZULyrhcnGY3x7LDKU2X
 github.com/go-toolsmith/typep v1.0.0/go.mod h1:JSQCQMUPdRlMZFswiq3TGpNp1GMktqkR2Ns5AIQkATU=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.6.15/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
+github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/pkg/test/e2e/awaitility.go
+++ b/pkg/test/e2e/awaitility.go
@@ -83,9 +83,9 @@ func (a *SingleAwaitility) WaitForKubeFedCluster(expNs string, clusterType clust
 	})
 }
 
-// WaitForKubeFedClusterWithName waits until there is a KubeFedCluster with the given name
+// WaitForKubeFedClusterConditionWithName waits until there is a KubeFedCluster with the given name
 // and with the given ClusterCondition (if it the condition is nil, then it skips this check)
-func (a *SingleAwaitility) WaitForKubeFedClusterWithName(name string, condition *v1beta1.ClusterCondition) error {
+func (a *SingleAwaitility) WaitForKubeFedClusterConditionWithName(name string, condition *v1beta1.ClusterCondition) error {
 	timeout := Timeout
 	if condition != nil {
 		timeout = (util.DefaultClusterHealthCheckPeriod + 5) * time.Second

--- a/pkg/test/e2e/awaitility.go
+++ b/pkg/test/e2e/awaitility.go
@@ -1,0 +1,136 @@
+package e2e
+
+import (
+	"context"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/kubefed/pkg/apis/core/common"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/kubefed/pkg/controller/util"
+	"testing"
+	"time"
+)
+
+// Awaitility contains information necessary for verifying availability of resources in both operators
+type Awaitility struct {
+	T        *testing.T
+	Client   framework.FrameworkClient
+	MemberNs string
+	HostNs   string
+}
+
+// SingleAwaitility contains information necessary for verifying availability of resources in a single operators
+type SingleAwaitility struct {
+	T      *testing.T
+	Client framework.FrameworkClient
+	Ns     string
+}
+
+// Member creates SingleAwaitility for the member operator
+func (a *Awaitility) Member() *SingleAwaitility {
+	return &SingleAwaitility{
+		T:      a.T,
+		Client: a.Client,
+		Ns:     a.MemberNs,
+	}
+}
+
+// Host creates SingleAwaitility for the host operator
+func (a *Awaitility) Host() *SingleAwaitility {
+	return &SingleAwaitility{
+		T:      a.T,
+		Client: a.Client,
+		Ns:     a.HostNs,
+	}
+}
+
+// ReadyKubeFedCluster is a ClusterCondition that represents cluster that is ready
+var ReadyKubeFedCluster = &v1beta1.ClusterCondition{
+	Type:   common.ClusterReady,
+	Status: v1.ConditionTrue,
+}
+
+// WaitForReadyKubeFedClusters waits until both KubeFedClusters (host and member) exist and has ready ClusterCondition
+func (a *Awaitility) WaitForReadyKubeFedClusters() error {
+	if err := a.Host().WaitForKubeFedCluster(a.MemberNs, cluster.Member, ReadyKubeFedCluster); err != nil {
+		return err
+	}
+	if err := a.Member().WaitForKubeFedCluster(a.HostNs, cluster.Host, ReadyKubeFedCluster); err != nil {
+		return err
+	}
+	return nil
+}
+
+// WaitForKubeFedCluster waits until there is a KubeFedCluster representing a operator of the given type
+// and running in the given expected namespace. If the given condition is not nil, then it also checks
+// if the CR has the ClusterCondition
+func (a *SingleAwaitility) WaitForKubeFedCluster(expNs string, clusterType cluster.Type, condition *v1beta1.ClusterCondition) error {
+	timeout := Timeout
+	if condition != nil {
+		timeout = (util.DefaultClusterHealthCheckPeriod + 5) * time.Second
+	}
+	return wait.Poll(RetryInterval, timeout, func() (done bool, err error) {
+		_, ok, err := a.GetKubeFedCluster(expNs, clusterType, condition)
+		if ok {
+			return true, nil
+		}
+		a.T.Logf("waiting for availability of %s KubeFedCluster CR (in namespace %s) representing operator running in namespace '%s'", clusterType, a.Ns, expNs)
+		return false, err
+	})
+}
+
+// WaitForKubeFedClusterWithName waits until there is a KubeFedCluster with the given name
+// and with the given ClusterCondition (if it the condition is nil, then it skips this check)
+func (a *SingleAwaitility) WaitForKubeFedClusterWithName(name string, condition *v1beta1.ClusterCondition) error {
+	timeout := Timeout
+	if condition != nil {
+		timeout = (util.DefaultClusterHealthCheckPeriod + 5) * time.Second
+	}
+	return wait.Poll(RetryInterval, timeout, func() (done bool, err error) {
+		cluster := &v1beta1.KubeFedCluster{}
+		if err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: a.Ns, Name: name}, cluster); err != nil {
+			return false, err
+		}
+		if containsClusterCondition(cluster.Status.Conditions, condition) {
+			a.T.Logf("found %s KubeFedCluster", name)
+			return true, nil
+		}
+		a.T.Logf("waiting for %s KubeFedCluster having the expected condition", name)
+		return false, err
+	})
+}
+
+// GetKubeFedCluster retrieves and returns a KubeFedCluster representing a operator of the given type
+// and running in the given expected namespace. If the given condition is not nil, then it also checks
+// if the CR has the ClusterCondition
+func (a *SingleAwaitility) GetKubeFedCluster(expNs string, clusterType cluster.Type, condition *v1beta1.ClusterCondition) (v1beta1.KubeFedCluster, bool, error) {
+	clusters := &v1beta1.KubeFedClusterList{}
+	if err := a.Client.List(context.TODO(), &client.ListOptions{Namespace: a.Ns}, clusters); err != nil {
+		return v1beta1.KubeFedCluster{}, false, err
+	}
+	for _, cl := range clusters.Items {
+		if cl.Labels["namespace"] == expNs && cluster.Type(cl.Labels["type"]) == clusterType {
+			if containsClusterCondition(cl.Status.Conditions, condition) {
+				a.T.Logf("found %s KubeFedCluster running in namespace '%s'", clusterType, expNs)
+				return cl, true, nil
+			}
+		}
+	}
+	return v1beta1.KubeFedCluster{}, false, nil
+}
+
+func containsClusterCondition(conditions []v1beta1.ClusterCondition, contains *v1beta1.ClusterCondition) bool {
+	if contains == nil {
+		return true
+	}
+	for _, c := range conditions {
+		if c.Type == contains.Type {
+			return contains.Status == c.Status
+		}
+	}
+	return false
+}

--- a/pkg/test/e2e/awaitility.go
+++ b/pkg/test/e2e/awaitility.go
@@ -23,7 +23,7 @@ type Awaitility struct {
 	HostNs   string
 }
 
-// SingleAwaitility contains information necessary for verifying availability of resources in a single operators
+// SingleAwaitility contains information necessary for verifying availability of resources in a single operator
 type SingleAwaitility struct {
 	T      *testing.T
 	Client framework.FrameworkClient

--- a/pkg/test/e2e/doubles.go
+++ b/pkg/test/e2e/doubles.go
@@ -1,0 +1,8 @@
+package e2e
+
+import framework "github.com/operator-framework/operator-sdk/pkg/test"
+
+// CleanupOptions returns a CleanupOptions for the given test context and set with CleanupTimeout and CleanupRetryInterval
+func CleanupOptions(ctx *framework.TestCtx) *framework.CleanupOptions {
+	return &framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval}
+}

--- a/pkg/test/e2e/kubefed.go
+++ b/pkg/test/e2e/kubefed.go
@@ -1,0 +1,174 @@
+package e2e
+
+import (
+	"context"
+	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"os"
+	"sigs.k8s.io/kubefed/pkg/apis/core/common"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	OperatorRetryInterval = time.Second * 5
+	OperatorTimeout       = time.Second * 60
+	RetryInterval         = time.Millisecond * 100
+	Timeout               = time.Second * 3
+	CleanupRetryInterval  = time.Second * 1
+	CleanupTimeout        = time.Second * 5
+	MemberNsVar           = "MEMBER_NS"
+	HostNsVar             = "HOST_NS"
+)
+
+// VerifyKubeFedCluster verifies existence and correct conditions of KubeFedCluster CRD
+// in the target cluster type operator
+func VerifyKubeFedCluster(t *testing.T, targetClusterType cluster.Type) {
+	// given
+	fedClusterList := &v1beta1.KubeFedClusterList{}
+	ctx, awaitility := InitializeOperators(t, fedClusterList, targetClusterType)
+	defer ctx.Cleanup()
+
+	var kubeFedClusterType cluster.Type
+	var singleAwait *SingleAwaitility
+	var expNs string
+
+	if targetClusterType == cluster.Host {
+		kubeFedClusterType = cluster.Member
+		singleAwait = awaitility.Host()
+		expNs = awaitility.MemberNs
+	} else {
+		kubeFedClusterType = cluster.Host
+		singleAwait = awaitility.Member()
+		expNs = awaitility.HostNs
+	}
+
+	current, ok, err := singleAwait.GetKubeFedCluster(expNs, kubeFedClusterType, nil)
+	require.NoError(awaitility.T, err)
+	require.True(awaitility.T, ok, "KubeFedCluster should exist")
+	labels := KubeFedLabels(kubeFedClusterType, current.Labels["namespace"], current.Labels["ownerClusterName"])
+
+	t.Run("create new KubeFedCluster with correct data and expect to be ready", func(t *testing.T) {
+		// given
+		newName := "new-ready-" + string(kubeFedClusterType)
+		newFedCluster := NewKubeFedCluster(singleAwait.Ns, newName, current.Spec.CABundle,
+			current.Spec.APIEndpoint, current.Spec.SecretRef.Name, labels)
+
+		// when
+		err := awaitility.Client.Create(context.TODO(), newFedCluster, CleanupOptions(ctx))
+
+		// then the KubeFedCluster should not be ready
+		require.NoError(t, err)
+		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, ReadyKubeFedCluster)
+		require.NoError(t, err)
+		err = awaitility.WaitForReadyKubeFedClusters()
+		require.NoError(t, err)
+		err = singleAwait.WaitForKubeFedClusterWithName(current.Name, ReadyKubeFedCluster)
+		require.NoError(t, err)
+	})
+	t.Run("create new KubeFedCluster with incorrect data and expect to be offline", func(t *testing.T) {
+		// given
+		newName := "new-offline-" + string(kubeFedClusterType)
+		newFedCluster := NewKubeFedCluster(singleAwait.Ns, newName, current.Spec.CABundle,
+			"https://1.2.3.4:8443", current.Spec.SecretRef.Name, labels)
+
+		// when
+		err := awaitility.Client.Create(context.TODO(), newFedCluster, CleanupOptions(ctx))
+
+		// then
+		require.NoError(t, err)
+		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, &v1beta1.ClusterCondition{
+			Type:   common.ClusterOffline,
+			Status: corev1.ConditionTrue,
+		})
+		require.NoError(t, err)
+		err = awaitility.WaitForReadyKubeFedClusters()
+		require.NoError(t, err)
+	})
+}
+
+// InitializeOperators initializes test context, registers schemes and waits until both operators (host, member)
+// and corresponding KubeFedCluster CRDs are present, running and ready. Based on the given cluster type
+// that represents the current operator that is the target of the e2e test it retrieves namespace names.
+// Returns the test context and an instance of Awaitility that contains all necessary information
+func InitializeOperators(t *testing.T, obj runtime.Object, clusterType cluster.Type) (*framework.TestCtx, *Awaitility) {
+	err := framework.AddToFrameworkScheme(apis.AddToSchemes.AddToScheme, obj)
+	require.NoError(t, err, "failed to add custom resource scheme to framework")
+
+	ctx := framework.NewTestCtx(t)
+
+	err = ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: CleanupTimeout, RetryInterval: CleanupRetryInterval})
+	require.NoError(t, err, "failed to initialize cluster resources")
+	t.Log("Initialized cluster resources")
+
+	hostNs, err := ctx.GetNamespace()
+	memberNs := os.Getenv(MemberNsVar)
+	require.NoError(t, err, "failed to get namespace where operator needs to run")
+	if clusterType == cluster.Member {
+		memberNs = hostNs
+		hostNs = os.Getenv(HostNsVar)
+	}
+
+	// get global framework variables
+	f := framework.Global
+
+	// wait for host operator to be ready
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, hostNs, "host-operator", 1, OperatorRetryInterval, OperatorTimeout)
+	require.NoError(t, err, "failed while waiting for host operator deployment")
+
+	// wait for member operator to be ready
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, memberNs, "member-operator", 1, OperatorRetryInterval, OperatorTimeout)
+	require.NoError(t, err, "failed while waiting for member operator deployment")
+
+	awaitility := &Awaitility{
+		T:        t,
+		Client:   f.Client,
+		HostNs:   hostNs,
+		MemberNs: memberNs,
+	}
+
+	err = awaitility.WaitForReadyKubeFedClusters()
+	require.NoError(t, err)
+
+	t.Log("both operators ar ready and in running state")
+	return ctx, awaitility
+}
+
+// NewKubeFedCluster creates KubeFedCluster CR object with the given values
+func NewKubeFedCluster(ns, name string, caBundle []byte, apiEndpoint, secretRef string, labels map[string]string) *v1beta1.KubeFedCluster {
+	return &v1beta1.KubeFedCluster{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: ns,
+			Name:      name,
+			Labels:    labels,
+		},
+		Spec: v1beta1.KubeFedClusterSpec{
+			CABundle:    caBundle,
+			APIEndpoint: apiEndpoint,
+			SecretRef: v1beta1.LocalSecretReference{
+				Name: secretRef,
+			},
+		},
+	}
+}
+
+// KubeFedLabels takes the label values and returns a key-value map containing label names key and values
+func KubeFedLabels(clType cluster.Type, ns, ownerClusterName string) map[string]string {
+	labels := map[string]string{}
+	if clType != "" {
+		labels["type"] = string(clType)
+	}
+	if ns != "" {
+		labels["namespace"] = ns
+	}
+	labels["ownerClusterName"] = ownerClusterName
+	return labels
+}

--- a/pkg/test/e2e/kubefed.go
+++ b/pkg/test/e2e/kubefed.go
@@ -67,11 +67,11 @@ func VerifyKubeFedCluster(t *testing.T, targetClusterType cluster.Type) {
 
 		// then the KubeFedCluster should be ready
 		require.NoError(t, err)
-		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, ReadyKubeFedCluster)
+		err = singleAwait.WaitForKubeFedClusterConditionWithName(newFedCluster.Name, ReadyKubeFedCluster)
 		require.NoError(t, err)
 		err = awaitility.WaitForReadyKubeFedClusters()
 		require.NoError(t, err)
-		err = singleAwait.WaitForKubeFedClusterWithName(current.Name, ReadyKubeFedCluster)
+		err = singleAwait.WaitForKubeFedClusterConditionWithName(current.Name, ReadyKubeFedCluster)
 		require.NoError(t, err)
 	})
 	t.Run("create new KubeFedCluster with incorrect data and expect to be offline", func(t *testing.T) {
@@ -85,7 +85,7 @@ func VerifyKubeFedCluster(t *testing.T, targetClusterType cluster.Type) {
 
 		// then the KubeFedCluster should be offline
 		require.NoError(t, err)
-		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, &v1beta1.ClusterCondition{
+		err = singleAwait.WaitForKubeFedClusterConditionWithName(newFedCluster.Name, &v1beta1.ClusterCondition{
 			Type:   common.ClusterOffline,
 			Status: corev1.ConditionTrue,
 		})

--- a/pkg/test/e2e/kubefed.go
+++ b/pkg/test/e2e/kubefed.go
@@ -138,7 +138,7 @@ func InitializeOperators(t *testing.T, obj runtime.Object, clusterType cluster.T
 	err = awaitility.WaitForReadyKubeFedClusters()
 	require.NoError(t, err)
 
-	t.Log("both operators ar ready and in running state")
+	t.Log("both operators are ready and in running state")
 	return ctx, awaitility
 }
 

--- a/pkg/test/e2e/kubefed.go
+++ b/pkg/test/e2e/kubefed.go
@@ -65,7 +65,7 @@ func VerifyKubeFedCluster(t *testing.T, targetClusterType cluster.Type) {
 		// when
 		err := awaitility.Client.Create(context.TODO(), newFedCluster, CleanupOptions(ctx))
 
-		// then the KubeFedCluster should not be ready
+		// then the KubeFedCluster should be ready
 		require.NoError(t, err)
 		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, ReadyKubeFedCluster)
 		require.NoError(t, err)
@@ -83,7 +83,7 @@ func VerifyKubeFedCluster(t *testing.T, targetClusterType cluster.Type) {
 		// when
 		err := awaitility.Client.Create(context.TODO(), newFedCluster, CleanupOptions(ctx))
 
-		// then
+		// then the KubeFedCluster should be offline
 		require.NoError(t, err)
 		err = singleAwait.WaitForKubeFedClusterWithName(newFedCluster.Name, &v1beta1.ClusterCondition{
 			Type:   common.ClusterOffline,


### PR DESCRIPTION
This PR adds:
* function for setting up e2e test that uses both operators (host and member)
* doubles that help with waiting for the availability of KubeFedCluster CRs
* skeleton for KubeFedCluster e2e test that will be used in both repositories host and member