### PR TITLE
feat: add controller client to Awaitility to be able to run status requests

### DIFF
--- a/pkg/test/e2e/awaitility.go
+++ b/pkg/test/e2e/awaitility.go
@@ -17,10 +17,11 @@ import (
 
 // Awaitility contains information necessary for verifying availability of resources in both operators
 type Awaitility struct {
-	T        *testing.T
-	Client   framework.FrameworkClient
-	MemberNs string
-	HostNs   string
+	T                *testing.T
+	Client           framework.FrameworkClient
+	ControllerClient client.Client
+	MemberNs         string
+	HostNs           string
 }
 
 // SingleAwaitility contains information necessary for verifying availability of resources in a single operator

--- a/pkg/test/e2e/kubefed.go
+++ b/pkg/test/e2e/kubefed.go
@@ -129,10 +129,11 @@ func InitializeOperators(t *testing.T, obj runtime.Object, clusterType cluster.T
 	require.NoError(t, err, "failed while waiting for member operator deployment")
 
 	awaitility := &Awaitility{
-		T:        t,
-		Client:   f.Client,
-		HostNs:   hostNs,
-		MemberNs: memberNs,
+		T:                t,
+		Client:           f.Client,
+		ControllerClient: f.Client.Client,
+		HostNs:           hostNs,
+		MemberNs:         memberNs,
 	}
 
 	err = awaitility.WaitForReadyKubeFedClusters()


### PR DESCRIPTION
add controller client to Awaitility to be able to run status requests, otherwise, it's not possible to trigger status sync from host