### PR TITLE
Add Get and List to fake client

### DIFF
--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -19,39 +19,39 @@ func NewFakeClient(t *testing.T, initObjs ...runtime.Object) *FakeClient {
 type FakeClient struct {
 	client.Client
 	T                *testing.T
-	MockGet          func(key client.ObjectKey, obj runtime.Object) error
-	MockList         func(opts *client.ListOptions, list runtime.Object) error
-	MockCreate       func(obj runtime.Object) error
-	MockUpdate       func(obj runtime.Object) error
-	MockStatusUpdate func(obj runtime.Object) error
-	MockDelete       func(obj runtime.Object, opts ...client.DeleteOptionFunc) error
+	MockGet          func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
+	MockList         func(ctx context.Context, opts *client.ListOptions, list runtime.Object) error
+	MockCreate       func(ctx context.Context, obj runtime.Object) error
+	MockUpdate       func(ctx context.Context, obj runtime.Object) error
+	MockStatusUpdate func(ctx context.Context, obj runtime.Object) error
+	MockDelete       func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error
 }
 
 type mockStatusUpdate struct {
-	mockUpdate func(obj runtime.Object) error
+	mockUpdate func(ctx context.Context, obj runtime.Object) error
 }
 
 func (m *mockStatusUpdate) Update(ctx context.Context, obj runtime.Object) error {
-	return m.mockUpdate(obj)
+	return m.mockUpdate(ctx, obj)
 }
 
 func (c *FakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
 	if c.MockGet != nil {
-		return c.MockGet(key, obj)
+		return c.MockGet(ctx, key, obj)
 	}
 	return c.Client.Get(ctx, key, obj)
 }
 
 func (c *FakeClient) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
 	if c.MockList != nil {
-		return c.MockList(opts, list)
+		return c.MockList(ctx, opts, list)
 	}
 	return c.Client.List(ctx, opts, list)
 }
 
 func (c *FakeClient) Create(ctx context.Context, obj runtime.Object) error {
 	if c.MockCreate != nil {
-		return c.MockCreate(obj)
+		return c.MockCreate(ctx, obj)
 	}
 	return c.Client.Create(ctx, obj)
 }
@@ -65,14 +65,14 @@ func (c *FakeClient) Status() client.StatusWriter {
 
 func (c *FakeClient) Update(ctx context.Context, obj runtime.Object) error {
 	if c.MockUpdate != nil {
-		return c.MockUpdate(obj)
+		return c.MockUpdate(ctx, obj)
 	}
 	return c.Client.Update(ctx, obj)
 }
 
 func (c *FakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error {
 	if c.MockDelete != nil {
-		return c.MockDelete(obj, opts...)
+		return c.MockDelete(ctx, obj, opts...)
 	}
 	return c.Client.Delete(ctx, obj, opts...)
 }

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -10,15 +10,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// NewFakeClient creates a fake K8s client with ability to override specific Create/Update/Delete functions
+// NewFakeClient creates a fake K8s client with ability to override specific Get/List/Create/Update/StatusUpdate/Delete functions
 func NewFakeClient(t *testing.T, initObjs ...runtime.Object) *FakeClient {
 	client := fake.NewFakeClientWithScheme(scheme.Scheme, initObjs...)
-	return &FakeClient{client, t, nil, nil, nil, nil}
+	return &FakeClient{client, t, nil, nil, nil, nil, nil, nil}
 }
 
 type FakeClient struct {
 	client.Client
 	T                *testing.T
+	MockGet          func(key client.ObjectKey, obj runtime.Object) error
+	MockList         func(opts *client.ListOptions, list runtime.Object) error
 	MockCreate       func(obj runtime.Object) error
 	MockUpdate       func(obj runtime.Object) error
 	MockStatusUpdate func(obj runtime.Object) error
@@ -31,6 +33,20 @@ type mockStatusUpdate struct {
 
 func (m *mockStatusUpdate) Update(ctx context.Context, obj runtime.Object) error {
 	return m.mockUpdate(obj)
+}
+
+func (c *FakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	if c.MockGet != nil {
+		return c.MockGet(key, obj)
+	}
+	return c.Client.Get(ctx, key, obj)
+}
+
+func (c *FakeClient) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
+	if c.MockList != nil {
+		return c.MockList(opts, list)
+	}
+	return c.Client.List(ctx, opts, list)
 }
 
 func (c *FakeClient) Create(ctx context.Context, obj runtime.Object) error {

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -1,0 +1,121 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	errs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNewClient(t *testing.T) {
+	fclient := NewFakeClient(t)
+	require.NotNil(t, fclient)
+
+	assert.Nil(t, fclient.MockGet)
+	assert.Nil(t, fclient.MockList)
+	assert.Nil(t, fclient.MockUpdate)
+	assert.Nil(t, fclient.MockDelete)
+	assert.Nil(t, fclient.MockCreate)
+	assert.Nil(t, fclient.MockStatusUpdate)
+
+	key := types.NamespacedName{"somenamespace", "somename"}
+
+	t.Run("default methods OK", func(t *testing.T) {
+		data := make(map[string]string)
+		data["key"] = "value"
+		created := &v1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "somename",
+				Namespace: "somenamespace",
+			},
+			StringData: data,
+		}
+
+		// Create
+		assert.NoError(t, fclient.Create(context.TODO(), created))
+
+		// Get
+		secret := &v1.Secret{}
+		assert.NoError(t, fclient.Get(context.TODO(), key, secret))
+		assert.Equal(t, created, secret)
+
+		// List
+		secretList := &v1.SecretList{}
+		assert.NoError(t, fclient.List(context.TODO(), &client.ListOptions{Namespace: "somenamespace"}, secretList))
+		require.Len(t, secretList.Items, 1)
+		assert.Equal(t, *created, secretList.Items[0])
+
+		// Update
+		created.StringData["key"] = "updated"
+		assert.NoError(t, fclient.Update(context.TODO(), created))
+		assert.NoError(t, fclient.Get(context.TODO(), key, secret))
+		assert.Equal(t, "updated", secret.StringData["key"])
+
+		// Status Update
+		assert.NoError(t, fclient.Status().Update(context.TODO(), created))
+
+		// Delete
+		assert.NoError(t, fclient.Delete(context.TODO(), created))
+		err := fclient.Get(context.TODO(), key, secret)
+		require.Error(t, err)
+		assert.True(t, errs.IsNotFound(err))
+	})
+
+	expectedErr := errors.New("oopsie woopsie")
+
+	t.Run("mock Get", func(t *testing.T) {
+		defer func() { fclient.MockGet = nil }()
+		fclient.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.Get(context.TODO(), key, &v1.Secret{}), expectedErr.Error())
+	})
+
+	t.Run("mock List", func(t *testing.T) {
+		defer func() { fclient.MockList = nil }()
+		fclient.MockList = func(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.List(context.TODO(), &client.ListOptions{Namespace: "somenamespace"}, &v1.SecretList{}), expectedErr.Error())
+	})
+
+	t.Run("mock Create", func(t *testing.T) {
+		defer func() { fclient.MockCreate = nil }()
+		fclient.MockCreate = func(ctx context.Context, obj runtime.Object) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.Create(context.TODO(), &v1.Secret{}), expectedErr.Error())
+	})
+
+	t.Run("mock Update", func(t *testing.T) {
+		defer func() { fclient.MockUpdate = nil }()
+		fclient.MockUpdate = func(ctx context.Context, obj runtime.Object) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.Update(context.TODO(), &v1.Secret{}), expectedErr.Error())
+	})
+
+	t.Run("mock Delete", func(t *testing.T) {
+		defer func() { fclient.MockDelete = nil }()
+		fclient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.Delete(context.TODO(), &v1.Secret{}), expectedErr.Error())
+	})
+
+	t.Run("mock Status Update", func(t *testing.T) {
+		defer func() { fclient.MockStatusUpdate = nil }()
+		fclient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object) error {
+			return expectedErr
+		}
+		assert.EqualError(t, fclient.MockStatusUpdate(context.TODO(), &v1.Secret{}), expectedErr.Error())
+	})
+}

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -26,7 +26,7 @@ func TestNewClient(t *testing.T) {
 	assert.Nil(t, fclient.MockCreate)
 	assert.Nil(t, fclient.MockStatusUpdate)
 
-	key := types.NamespacedName{"somenamespace", "somename"}
+	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename"}
 
 	t.Run("default methods OK", func(t *testing.T) {
 		data := make(map[string]string)


### PR DESCRIPTION
This PR introduces `Get()` and `List()` mock functions to the mock client.

Also it adds `ctx context.Context` param to all mock functions because sometimes it's needed in our tests. This change breaks API but it's pretty easy to fix the existing tests to support `ctx` param.