### PR TITLE
fix: watch KubeFedCluster only within operator namespace

### DIFF
--- a/pkg/controller/kubefedcluster_caching.go
+++ b/pkg/controller/kubefedcluster_caching.go
@@ -9,7 +9,7 @@ import (
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
 
-func StartCachingController(mgr manager.Manager, stopChan <-chan struct{}) error {
+func StartCachingController(mgr manager.Manager, namespace string, stopChan <-chan struct{}) error {
 	cntrlName := "controller_kubefedcluster_with_cache"
 	clusterCacheService := cluster.KubeFedClusterService{
 		Client: mgr.GetClient(),
@@ -18,7 +18,7 @@ func StartCachingController(mgr manager.Manager, stopChan <-chan struct{}) error
 
 	_, clusterController, err := util.NewGenericInformerWithEventHandler(
 		mgr.GetConfig(),
-		"",
+		namespace,
 		&v1beta1.KubeFedCluster{},
 		util.NoResyncPeriod,
 		&cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
watch KubeFedCluster only within operator namespace so it doesn't register instances in other namespaces. Mainly when there are a running member and host operators in the same cluster. 
modification of e2e tests in both clusters will follow