### PR TITLE
Fix flaky cluster cache test

### DIFF
--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -72,8 +72,8 @@ func TestMemberClusters(t *testing.T) {
 
 	// then
 	require.Len(t, returnedFedClusters, 2)
-	assert.Equal(t, returnedFedClusters[0], member1)
-	assert.Equal(t, returnedFedClusters[1], member2)
+	assert.Contains(t, returnedFedClusters, member1)
+	assert.Contains(t, returnedFedClusters, member2)
 }
 
 func TestGetClusterWhenIsEmpty(t *testing.T) {


### PR DESCRIPTION
Because the cluster cache is stored as a map we can't guarantee the order of stored clusters. And we have to take it into account when testing.