### PR TITLE
Switch to go 1.13 in builder image

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -9,15 +9,14 @@ ENV LANG=en_US.utf8 \
     PATH=$PATH:$GOPATH/bin \
     GIT_COMMITTER_NAME=devtools \
     GIT_COMMITTER_EMAIL=devtools@redhat.com \
-    OPERATOR_SDK_VERSION=v0.8.1
 
 ARG GO_PACKAGE_PATH=github.com/codeready-toolchain/toolchain-common
 
 RUN yum install epel-release -y \
+    && yum install  https://centos7.iuscommunity.org/ius-release.rpm -y \
     && yum install --enablerepo=centosplus install -y --quiet \
     findutils \
-    git \
-    golang \
+    git2u-all \
     make \
     procps-ng \
     tar \
@@ -30,8 +29,17 @@ RUN yum install epel-release -y \
     jq \
     && yum clean all
 
-# download, verify and install openshift client tools (oc and kubectl)
 WORKDIR /tmp
+
+# download, verify and install golang
+ENV PATH=$PATH:/usr/local/go/bin
+RUN curl -Lo go1.13.4.linux-amd64.tar.gz https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz \
+    && echo "692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c go1.13.4.linux-amd64.tar.gz" > go1.13.4.linux-amd64.sha256 \
+    && sha256sum -c go1.13.4.linux-amd64.sha256 \
+    && tar xzf go1.13.4.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.13.4.linux-amd64.tar.gz \
+    && rm -f go1.13.4.linux-amd64.tar.gz \
+    && go version
 
 RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
 


### PR DESCRIPTION
There is checksum mismatch for operator-sdk binary between go 1.12 and go 1.13. To fix this issue we need to switch our builder image to go 1.13.

Required for https://github.com/codeready-toolchain/toolchain-common/pull/48