### PR TITLE
Add APIEndpoint to FedCluster

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -18,8 +18,11 @@ type kubeFedClusterClients struct {
 type FedCluster struct {
 	// Client is the kube client for the cluster.
 	Client client.Client
-	// Name is a name of the cluster. Has to be unique - is used as a key in a map.
+	// Name is the name of the cluster. Has to be unique - is used as a key in a map.
 	Name string
+	// APIEndpoint is the API endpoint of the corresponding FedKubeCluster. This can be a hostname,
+	// hostname:port, IP or IP:port.
+	APIEndpoint string
 	// Type is a type of the cluster (either host or member)
 	Type Type
 	// OperatorNamespace is a name of a namespace (in the cluster) the operator is running in

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"k8s.io/api/core/v1"
@@ -60,6 +61,7 @@ func (s *KubeFedClusterService) addKubeFedCluster(fedCluster *v1beta1.KubeFedClu
 
 	cluster := &FedCluster{
 		Name:              fedCluster.Name,
+		APIEndpoint:       fedCluster.Spec.APIEndpoint,
 		Client:            cl,
 		ClusterStatus:     &fedCluster.Status,
 		Type:              Type(fedCluster.Labels[labelType]),

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -85,6 +85,7 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
 			assert.Equal(t, nameHost, fedCluster.OwnerClusterName)
+			assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 		})
 	}
 }
@@ -118,6 +119,7 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
 			assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
+			assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 		})
 	}
 }
@@ -186,6 +188,7 @@ func TestUpdateKubeFedCluster(t *testing.T) {
 	assert.Equal(t, "toolchain-host-operator", fedCluster.OperatorNamespace)
 	assert.Equal(t, statusFalse, *fedCluster.ClusterStatus)
 	assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
+	assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 }
 
 func TestDeleteKubeFedCluster(t *testing.T) {


### PR DESCRIPTION
Required for https://jira.coreos.com/browse/CRT-348

This APIEndpoint from KubeFedCluster will be used by MUR controller to properly setup user account status. See https://github.com/codeready-toolchain/api/pull/59