### PR TITLE
chore: support separated clusters when registering host and member

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ $ oc apply -f deploy/user.yaml
 === add-cluster.sh
 
 The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
-To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`. However you can see all these options by using `./scripts/add-cluster.sh -h`
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--minishift`. However you can see all these options by using `./scripts/add-cluster.sh -h`
 
 ==== host and member clusters using host and member profiles on minishift
 Make sure that you have started minishift as different profiles. You can use following commands for it.


### PR DESCRIPTION
#### Problem that is trying to solve
In case we need to register two separated clusters as a member and a host, we need to specify the target URLs and login to them.

#### Solution
Introduced a new parameter `--minishift` - if the parameter is not set and the parameter `--single-cluster` neither, then the script asks for cluster URL and the token:
```
Write the server url for the cluster type: host:
> https://api.host.crt-stage.com:6443
Provide the token to log in to the cluster https://api.host.crt-stage.com:6443:
> 
Logged into "https://api.host.crt-stage.com:6443" as "mjobanek-crtadmin" using the token provided.
```
similarly for the member cluster