### PR TITLE
add kubeconfig option to avoid prompt

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ $ oc apply -f deploy/user.yaml
 === add-cluster.sh
 
 The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
-To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`. However you can see all these options by using `./scripts/add-cluster.sh -h`
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--minishift`. However you can see all these options by using `./scripts/add-cluster.sh -h`
 
 ==== host and member clusters using host and member profiles on minishift
 Make sure that you have started minishift as different profiles. You can use following commands for it.

--- a/README.adoc
+++ b/README.adoc
@@ -218,8 +218,8 @@ in respective namespace with all requires resources like Service Account, (Clust
     . creates a secret in `toolchain-member-operator` namespace with the SA token taken from the `toolchain-host-operator` ns
     . creates `KubeFedCluster` in `toolchain-member-operator` namespace CR representing the added `host`
 
-==== Using a different clusters for host and member operators
-Make sure to have two different clusters ready and available. To setup Toolchain, you'll have to run `host-operator` and `registration-service` on host cluster and `member-operator` on member cluster.
+==== Using different clusters for host and member operators
+Make sure you have two different clusters ready and available where the `host-operator` should be running in the host cluster and `member-operator` in the member cluster.
 
 To do either you can pass kube-config using `-kc` flag with kubeconfig having `host-admin` and `member-admin` contexts or if you don't have kubeconfig you can provide required detail of cluster when promted for cluster URL and token.
 

--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ $ oc apply -f deploy/user.yaml
 === add-cluster.sh
 
 The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
-To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--minishift`, `--kube-config`. However you can see all these options by using `./scripts/add-cluster.sh -h`
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--kube-config`. However you can see all these options by using `./scripts/add-cluster.sh -h`
 
 ==== host and member clusters using host and member profiles on minishift
 Make sure that you have started minishift as different profiles. You can use following commands for it.

--- a/README.adoc
+++ b/README.adoc
@@ -218,6 +218,54 @@ in respective namespace with all requires resources like Service Account, (Clust
     . creates a secret in `toolchain-member-operator` namespace with the SA token taken from the `toolchain-host-operator` ns
     . creates `KubeFedCluster` in `toolchain-member-operator` namespace CR representing the added `host`
 
+==== Using a different clusters for host and member operators
+Make sure to have two different clusters ready and available. To setup Toolchain, you'll have to run `host-operator` and `registration-service` on host cluster and `member-operator` on member cluster.
+
+To do either you can pass kube-config using `-kc` flag with kubeconfig having `host-admin` and `member-admin` contexts or if you don't have kubeconfig you can provide required detail of cluster when promted for cluster URL and token.
+
+===== Sample Kubeconfig
+[source,bash]
+----
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: REDACTED
+    server: https://api.host-1573997449.devcluster.openshift.com:6443
+  name: host-1573997449
+- cluster:
+    certificate-authority-data: REDACTED
+    server: https://api.member-1573997449.devcluster.openshift.com:6443
+  name: member-1573997449
+contexts:
+- context:
+    cluster: host-1573997449
+    user: host-admin
+  name: host-admin
+- context:
+    cluster: member-1573997449
+    user: member-admin
+  name: member-admin
+current-context: host-admin
+kind: Config
+preferences: {}
+users:
+- name: host-admin
+  user:
+    client-certificate-data: REDACTED
+    client-key-data: REDACTED
+- name: member-admin
+  user:
+    client-certificate-data: REDACTED
+    client-key-data: REDACTED
+----
+
+[source,bash]
+----
+export KUBECONFIG=kubeconfig
+./scripts/add-cluster.sh -t host -s  -t member -mn ${MEMBER_OPERATOR_NS} -hn ${HOST_OPERATOR_NS} -kc ${KUBECONFIG}
+./scripts/add-cluster.sh -t member -s  -t member -mn ${MEMBER_OPERATOR_NS} -hn ${HOST_OPERATOR_NS} -kc ${KUBECONFIG}
+----
+
 ==== overwriting default namespaces for member-operator and host-operator
 
 If you are running `member-operator` and `host-operator` in different namespaces other than default (i.e. not in `toolchain-member-operator` or `toolchain-host-operator`), you can do it passing `-mn or -hs` flags

--- a/README.adoc
+++ b/README.adoc
@@ -124,7 +124,7 @@ $ oc apply -f deploy/user.yaml
 === add-cluster.sh
 
 The CodeReady Toolchain architecture contains two types of clusters `host` and `member`.
-To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--minishift`. However you can see all these options by using `./scripts/add-cluster.sh -h`
+To connect these two clusters together it is necessary to run a script link:scripts/add-cluster.sh[] that takes multiple flags like, `--type`, `--member-ns`, `--host-ns`, `--single-cluster`, `--minishift`, `--kube-config`. However you can see all these options by using `./scripts/add-cluster.sh -h`
 
 ==== host and member clusters using host and member profiles on minishift
 Make sure that you have started minishift as different profiles. You can use following commands for it.

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -13,7 +13,7 @@ user_help () {
 
 login_to_cluster() {
     if [[ ${SINGLE_CLUSTER} != "true" ]]; then
-        if [[ -z "$IS_MINISHIFT" ]]; then
+        if [[ -z "${IS_MINISHIFT}" ]]; then
           if [[ -z ${KUBECONFIG} ]]; then
             echo "Write the server url for the cluster type: $1:"
             read -p '> ' CLUSTER_URL

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -69,7 +69,7 @@ while test $# -gt 0; do
             *)
                echo "$1 is not a recognized flag!"
                user_help
-               exit 1
+               exit -1
                ;;
       esac
 done
@@ -104,8 +104,8 @@ SA_SECRET=`oc get sa ${SA_NAME} -n ${OPERATOR_NS} -o json | jq -r .secrets[].nam
 SA_TOKEN=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS}  -o json | jq -r '.data["token"]' | base64 --decode`
 SA_CA_CRT=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS} -o json | jq -r '.data["ca.crt"]'`
 
-# openshift 4 has long name for cluster i.e.> 63 characters if read from config which is not allowed by k8s/openshift
-if [[ -n "$IS_MINISHIFT" ]]; then
+# the api endpoint and name retrieve from kubeconfig only for minishift, in case of OS4 use the oc infrastructure cluster command
+if [[ -n "${IS_MINISHIFT}" ]]; then
     echo "Running locally in minishift environment"
     API_ENDPOINT=`oc config view --raw --minify -o json | jq -r '.clusters[0].cluster["server"]'`
     JOINING_CLUSTER_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
@@ -117,8 +117,8 @@ fi
 
 login_to_cluster ${CLUSTER_JOIN_TO}
 
-# openshift ci has long name for cluster i.e.> 63 characters if read from config which is not allowed by k8s/openshift
-if [[ -n "$IS_MINISHIFT" ]]; then
+# the api endpoint and name retrieve from kubeconfig only for minishift, in case of OS4 use the oc infrastructure cluster command
+if [[ -n "${IS_MINISHIFT}" ]]; then
     echo "Running locally in minishift environment"
     CLUSTER_JOIN_TO_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
 else

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -109,13 +109,13 @@ SA_TOKEN=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS}  -o json | jq -r '.data["
 SA_CA_CRT=`oc get secret ${SA_SECRET} -n ${OPERATOR_NS} -o json | jq -r '.data["ca.crt"]'`
 
 # this env variable is set in openshift-ci environment.
-# openshift ci has long name for cluster i.e.> 63 characters if read from config which is not allowed by k8s/openshift
-if [[ -z ${OPENSHIFT_BUILD_NAMESPACE} ]]; then
+# openshift 4 has long name for cluster i.e.> 63 characters if read from config which is not allowed by k8s/openshift
+if [[ ${MINISHIFT} == "true" ]]; then
     echo "Running locally in minishift environment"
     API_ENDPOINT=`oc config view --raw --minify -o json | jq -r '.clusters[0].cluster["server"]'`
     JOINING_CLUSTER_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
 else
-    echo "Running in openshift-ci environment with openshift 4.x cluster"
+    echo "Running in openshift 4.x cluster"
     API_ENDPOINT=`oc get infrastructure cluster -o jsonpath='{.status.apiServerURL}'`
     JOINING_CLUSTER_NAME=`oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}'`
 fi
@@ -124,11 +124,11 @@ login_to_cluster ${CLUSTER_JOIN_TO}
 
 # this env variable is set in openshift-ci environment.
 # openshift ci has long name for cluster i.e.> 63 characters if read from config which is not allowed by k8s/openshift
-if [[ -z ${OPENSHIFT_BUILD_NAMESPACE} ]]; then
+if [[ ${MINISHIFT} == "true" ]]; then
     echo "Running locally in minishift environment"
     CLUSTER_JOIN_TO_NAME=`oc config view --raw --minify -o json | jq -r '.clusters[0].name' | sed 's/[^[:alnum:]._-]/-/g'`
 else
-    echo "Running in openshift-ci environment with openshift 4.x cluster"
+    echo "Running in openshift 4.x cluster"
     CLUSTER_JOIN_TO_NAME=`oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}'`
 fi
 

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -8,18 +8,23 @@ user_help () {
     echo "-hn, --host-ns        namespace where host-operator is running"
     echo "-s,  --single-cluster running both operators on single cluster"
     echo "-m,  --minishift      in case of using minishift"
+    echo "-kc,  --kube-config   kubeconfig for managing multiple clusters"
     exit 0
 }
 
 login_to_cluster() {
     if [[ ${SINGLE_CLUSTER} != "true" ]]; then
         if [[ ${MINISHIFT} != "true" ]]; then
+          if [[ -z ${KUBECONFIG} ]]; then
             echo "Write the server url for the cluster type: $1:"
             read -p '> ' CLUSTER_URL
             echo "Provide the token to log in to the cluster ${CLUSTER_URL}:"
             read -sp '> ' CLUSTER_TOKEN
             echo ""
             oc login --token=${CLUSTER_TOKEN} --server=${CLUSTER_URL}
+          else
+            oc config use-context "$1-admin"
+          fi
         else
             echo "Switching to profile $1"
             minishift profile set $1
@@ -53,6 +58,11 @@ while test $# -gt 0; do
                 HOST_OPERATOR_NS=$1
                 shift
                 ;;
+            -kc|--kube-config)
+                shift
+                KUBECONFIG=$1
+                shift
+                ;;
             -s|--single-cluster)
                 SINGLE_CLUSTER=true
                 shift
@@ -64,7 +74,7 @@ while test $# -gt 0; do
             *)
                echo "$1 is not a recognized flag!"
                user_help
-               exit -1
+               exit 0
                ;;
       esac
 done


### PR DESCRIPTION
Currently, we are working on infrastructure setup script, which will do the following
- Creates host and member cluster
- Setup IDP
- Create all admin users
- Deploy operators
- Setup KubeFed

For the last point, we need two different cluster credentials kubeconfig to be provided to switch the context and login to respective cluster using context.

This script assumes that if user is passing kubeconfig then it needs to have context with `host-admin` and `member-admin`
