### PR TITLE
fix: refresh cluster cach when a cluster is not found

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -11,7 +11,7 @@ var clusterCache = kubeFedClusterClients{clusters: map[string]*FedCluster{}}
 
 type kubeFedClusterClients struct {
 	sync.RWMutex
-	clusters map[string]*FedCluster
+	clusters     map[string]*FedCluster
 	refreshCache func()
 }
 

--- a/pkg/cluster/kubefedcluster_assets.go
+++ b/pkg/cluster/kubefedcluster_assets.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -302,7 +303,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"core.kubefed.io_kubefedclusters.yaml": &bintree{coreKubefedIo_kubefedclustersYaml, map[string]*bintree{}},
+	"core.kubefed.io_kubefedclusters.yaml": {coreKubefedIo_kubefedclustersYaml, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -2,73 +2,31 @@ package cluster_test
 
 import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
-	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	"testing"
 )
-
-const (
-	nameHost   = "dsaas"
-	nameMember = "east"
-)
-
-func newKubeFedCluster(name, secName string, status v1beta1.KubeFedClusterStatus, labels map[string]string) (*v1beta1.KubeFedCluster, *corev1.Secret) {
-	logf.SetLogger(zap.Logger())
-	gock.New("http://cluster.com").
-		Get("api").
-		Persist().
-		Reply(200).
-		BodyString("{}")
-	secret := &corev1.Secret{
-		ObjectMeta: v1.ObjectMeta{
-			Name:      secName,
-			Namespace: "test-namespace",
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			"token": []byte("mycooltoken"),
-		},
-	}
-
-	return &v1beta1.KubeFedCluster{
-		Spec: v1beta1.KubeFedClusterSpec{
-			SecretRef: v1beta1.LocalSecretReference{
-				Name: secName,
-			},
-			APIEndpoint: "http://cluster.com",
-			CABundle:    []byte{},
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      name,
-			Namespace: "test-namespace",
-			Labels:    labels,
-		},
-		Status: status,
-	}, secret
-}
 
 func TestAddKubeFedClusterAsMember(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
 	memberLabels := []map[string]string{
-		labels("", "", nameHost),
-		labels(cluster.Member, "", nameHost),
-		labels(cluster.Member, "member-ns", nameHost)}
+		labels("", "", test.NameHost),
+		labels(cluster.Member, "", test.NameHost),
+		labels(cluster.Member, "member-ns", test.NameHost)}
 	for _, labels := range memberLabels {
 
 		t.Run("add member KubeFedCluster", func(t *testing.T) {
-			kubeFedCluster, sec := newKubeFedCluster("east", "secret", status, labels)
-			cl := fake.NewFakeClient(sec)
-			service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+			kubeFedCluster, sec := test.NewKubeFedCluster("east", "secret", status, labels)
+			cl := test.NewFakeClient(t, sec)
+			service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 			defer service.DeleteKubeFedCluster(kubeFedCluster)
 
 			// when
@@ -84,7 +42,7 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
-			assert.Equal(t, nameHost, fedCluster.OwnerClusterName)
+			assert.Equal(t, test.NameHost, fedCluster.OwnerClusterName)
 			assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 		})
 	}
@@ -93,16 +51,16 @@ func TestAddKubeFedClusterAsMember(t *testing.T) {
 func TestAddKubeFedClusterAsHost(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := newClusterStatus(common.ClusterReady, corev1.ConditionFalse)
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionFalse)
 	memberLabels := []map[string]string{
-		labels(cluster.Host, "", nameMember),
-		labels(cluster.Host, "host-ns", nameMember)}
+		labels(cluster.Host, "", test.NameMember),
+		labels(cluster.Host, "host-ns", test.NameMember)}
 	for _, labels := range memberLabels {
 
 		t.Run("add host KubeFedCluster", func(t *testing.T) {
-			kubeFedCluster, sec := newKubeFedCluster("east", "secret", status, labels)
-			cl := fake.NewFakeClient(sec)
-			service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+			kubeFedCluster, sec := test.NewKubeFedCluster("east", "secret", status, labels)
+			cl := test.NewFakeClient(t, sec)
+			service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 			defer service.DeleteKubeFedCluster(kubeFedCluster)
 
 			// when
@@ -118,7 +76,7 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 				assert.Equal(t, labels["namespace"], fedCluster.OperatorNamespace)
 			}
 			assert.Equal(t, status, *fedCluster.ClusterStatus)
-			assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
+			assert.Equal(t, test.NameMember, fedCluster.OwnerClusterName)
 			assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 		})
 	}
@@ -127,10 +85,10 @@ func TestAddKubeFedClusterAsHost(t *testing.T) {
 func TestAddKubeFedClusterFailsBecauseOfMissingSecret(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status, labels("", "", nameHost))
-	cl := fake.NewFakeClient()
-	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	kubeFedCluster, _ := test.NewKubeFedCluster("east", "secret", status, labels("", "", test.NameHost))
+	cl := test.NewFakeClient(t, )
+	service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 
 	// when
 	service.AddKubeFedCluster(kubeFedCluster)
@@ -144,16 +102,16 @@ func TestAddKubeFedClusterFailsBecauseOfMissingSecret(t *testing.T) {
 func TestAddKubeFedClusterFailsBecauseOfEmptySecret(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, _ := newKubeFedCluster("east", "secret", status,
-		labels("", "", nameHost))
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	kubeFedCluster, _ := test.NewKubeFedCluster("east", "secret", status,
+		labels("", "", test.NameHost))
 	secret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "test-namespace",
 		}}
-	cl := fake.NewFakeClient(secret)
-	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+	cl := test.NewFakeClient(t, secret)
+	service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 
 	// when
 	service.AddKubeFedCluster(kubeFedCluster)
@@ -167,14 +125,14 @@ func TestAddKubeFedClusterFailsBecauseOfEmptySecret(t *testing.T) {
 func TestUpdateKubeFedCluster(t *testing.T) {
 	// given
 	defer gock.Off()
-	statusTrue := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster1, sec1 := newKubeFedCluster("east", "secret1", statusTrue,
-		labels("", "", nameMember))
-	statusFalse := newClusterStatus(common.ClusterReady, corev1.ConditionFalse)
-	kubeFedCluster2, sec2 := newKubeFedCluster("east", "secret2", statusFalse,
-		labels(cluster.Host, "", nameMember))
-	cl := fake.NewFakeClient(sec1, sec2)
-	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+	statusTrue := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	kubeFedCluster1, sec1 := test.NewKubeFedCluster("east", "secret1", statusTrue,
+		labels("", "", test.NameMember))
+	statusFalse := test.NewClusterStatus(common.ClusterReady, corev1.ConditionFalse)
+	kubeFedCluster2, sec2 := test.NewKubeFedCluster("east", "secret2", statusFalse,
+		labels(cluster.Host, "", test.NameMember))
+	cl := test.NewFakeClient(t, sec1, sec2)
+	service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 	defer service.DeleteKubeFedCluster(kubeFedCluster2)
 	service.AddKubeFedCluster(kubeFedCluster1)
 
@@ -187,18 +145,18 @@ func TestUpdateKubeFedCluster(t *testing.T) {
 	assert.Equal(t, cluster.Host, fedCluster.Type)
 	assert.Equal(t, "toolchain-host-operator", fedCluster.OperatorNamespace)
 	assert.Equal(t, statusFalse, *fedCluster.ClusterStatus)
-	assert.Equal(t, nameMember, fedCluster.OwnerClusterName)
+	assert.Equal(t, test.NameMember, fedCluster.OwnerClusterName)
 	assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
 }
 
 func TestDeleteKubeFedCluster(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := newClusterStatus(common.ClusterReady, corev1.ConditionTrue)
-	kubeFedCluster, sec := newKubeFedCluster("east", "sec", status,
-		labels("", "", nameHost))
-	cl := fake.NewFakeClient(sec)
-	service := cluster.KubeFedClusterService{Log: logf.Log, Client: cl}
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	kubeFedCluster, sec := test.NewKubeFedCluster("east", "sec", status,
+		labels("", "", test.NameHost))
+	cl := test.NewFakeClient(t, sec)
+	service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 	service.AddKubeFedCluster(kubeFedCluster)
 
 	// when
@@ -208,15 +166,6 @@ func TestDeleteKubeFedCluster(t *testing.T) {
 	fedCluster, ok := cluster.GetFedCluster("east")
 	require.False(t, ok)
 	assert.Nil(t, fedCluster)
-}
-
-func newClusterStatus(conType common.ClusterConditionType, conStatus corev1.ConditionStatus) v1beta1.KubeFedClusterStatus {
-	return v1beta1.KubeFedClusterStatus{
-		Conditions: []v1beta1.ClusterCondition{{
-			Type:   conType,
-			Status: conStatus,
-		}},
-	}
 }
 
 func labels(clType cluster.Type, ns, ownerClusterName string) map[string]string {

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -87,7 +87,7 @@ func TestAddKubeFedClusterFailsBecauseOfMissingSecret(t *testing.T) {
 	defer gock.Off()
 	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
 	kubeFedCluster, _ := test.NewKubeFedCluster("east", "secret", status, labels("", "", test.NameHost))
-	cl := test.NewFakeClient(t, )
+	cl := test.NewFakeClient(t)
 	service := cluster.NewKubeFedClusterService(cl, logf.Log, "test-namespace")
 
 	// when

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	"testing"

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -49,7 +49,6 @@ func TestRefreshCacheInService(t *testing.T) {
 		assertMemberCluster(t, fedCluster, status)
 	})
 
-
 	t.Run("the host cluster should not be retrieved", func(t *testing.T) {
 		// given
 		_, ok := clusterCache.clusters["east"]
@@ -64,7 +63,6 @@ func TestRefreshCacheInService(t *testing.T) {
 		assert.Nil(t, fedCluster)
 	})
 }
-
 
 func assertMemberCluster(t *testing.T, fedCluster *FedCluster, status v1beta1.KubeFedClusterStatus) {
 	assert.Equal(t, Member, fedCluster.Type)

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -1,0 +1,74 @@
+package cluster
+
+import (
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/h2non/gock.v1"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/kubefed/pkg/apis/core/common"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+	"testing"
+)
+
+func TestRefreshCacheInService(t *testing.T) {
+	// given
+	defer gock.Off()
+	status := test.NewClusterStatus(common.ClusterReady, corev1.ConditionTrue)
+	kubeFedCluster, sec := test.NewKubeFedCluster("east", "secret", status, map[string]string{"ownerClusterName": test.NameMember})
+	cl := test.NewFakeClient(t, kubeFedCluster, sec)
+	service := NewKubeFedClusterService(cl, logf.Log, "test-namespace")
+
+	t.Run("the member cluster should be retrieved when refreshCache func is called", func(t *testing.T) {
+		// given
+		_, ok := clusterCache.clusters["east"]
+		require.False(t, ok)
+		defer service.DeleteKubeFedCluster(kubeFedCluster)
+
+		// when
+		service.refreshCache()
+
+		// then
+		fedCluster, ok := GetFedCluster(test.NameMember)
+		require.True(t, ok)
+		assertMemberCluster(t, fedCluster, status)
+	})
+
+	t.Run("the member cluster should be retrieved when GetFedCluster func is called", func(t *testing.T) {
+		// given
+		_, ok := clusterCache.clusters["east"]
+		require.False(t, ok)
+		defer service.DeleteKubeFedCluster(kubeFedCluster)
+
+		// when
+		fedCluster, ok := GetFedCluster(test.NameMember)
+
+		// then
+		require.True(t, ok)
+		assertMemberCluster(t, fedCluster, status)
+	})
+
+
+	t.Run("the host cluster should not be retrieved", func(t *testing.T) {
+		// given
+		_, ok := clusterCache.clusters["east"]
+		require.False(t, ok)
+		defer service.DeleteKubeFedCluster(kubeFedCluster)
+
+		// when
+		fedCluster, ok := GetFedCluster(test.NameHost)
+
+		// then
+		require.False(t, ok)
+		assert.Nil(t, fedCluster)
+	})
+}
+
+
+func assertMemberCluster(t *testing.T, fedCluster *FedCluster, status v1beta1.KubeFedClusterStatus) {
+	assert.Equal(t, Member, fedCluster.Type)
+	assert.Equal(t, status, *fedCluster.ClusterStatus)
+	assert.Equal(t, test.NameMember, fedCluster.OwnerClusterName)
+	assert.Equal(t, "http://cluster.com", fedCluster.APIEndpoint)
+}

--- a/pkg/controller/kubefedcluster_caching.go
+++ b/pkg/controller/kubefedcluster_caching.go
@@ -11,10 +11,7 @@ import (
 
 func StartCachingController(mgr manager.Manager, namespace string, stopChan <-chan struct{}) error {
 	cntrlName := "controller_kubefedcluster_with_cache"
-	clusterCacheService := cluster.KubeFedClusterService{
-		Client: mgr.GetClient(),
-		Log:    logf.Log.WithName(cntrlName),
-	}
+	clusterCacheService := cluster.NewKubeFedClusterService(mgr.GetClient(), logf.Log.WithName(cntrlName), namespace)
 
 	_, clusterController, err := util.NewGenericInformerWithEventHandler(
 		mgr.GetConfig(),

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -2,6 +2,8 @@ package test
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kubefed/pkg/apis"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -12,7 +14,10 @@ import (
 
 // NewFakeClient creates a fake K8s client with ability to override specific Get/List/Create/Update/StatusUpdate/Delete functions
 func NewFakeClient(t *testing.T, initObjs ...runtime.Object) *FakeClient {
-	client := fake.NewFakeClientWithScheme(scheme.Scheme, initObjs...)
+	s := scheme.Scheme
+	err := apis.AddToScheme(s)
+	require.NoError(t, err)
+	client := fake.NewFakeClientWithScheme(s, initObjs...)
 	return &FakeClient{Client: client, T: t}
 }
 

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -5,7 +5,7 @@ import (
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 )

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -1,0 +1,62 @@
+package test
+
+import (
+	"github.com/operator-framework/operator-sdk/pkg/log/zap"
+	"gopkg.in/h2non/gock.v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/kubefed/pkg/apis/core/common"
+	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+)
+
+const (
+	NameHost   = "dsaas"
+	NameMember = "east"
+)
+
+func NewKubeFedCluster(name, secName string, status v1beta1.KubeFedClusterStatus, labels map[string]string) (*v1beta1.KubeFedCluster, *corev1.Secret) {
+	logf.SetLogger(zap.Logger())
+	gock.New("http://cluster.com").
+		Get("api").
+		Persist().
+		Reply(200).
+		BodyString("{}")
+	secret := &corev1.Secret{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      secName,
+			Namespace: "test-namespace",
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			"token": []byte("mycooltoken"),
+		},
+	}
+
+	return &v1beta1.KubeFedCluster{
+		Spec: v1beta1.KubeFedClusterSpec{
+			SecretRef: v1beta1.LocalSecretReference{
+				Name: secName,
+			},
+			APIEndpoint: "http://cluster.com",
+			CABundle:    []byte{},
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-namespace",
+			Labels:    labels,
+		},
+		Status: status,
+	}, secret
+}
+
+func NewClusterStatus(conType common.ClusterConditionType, conStatus corev1.ConditionStatus) v1beta1.KubeFedClusterStatus {
+	return v1beta1.KubeFedClusterStatus{
+		Conditions: []v1beta1.ClusterCondition{{
+			Type:   conType,
+			Status: conStatus,
+		}},
+	}
+}
+
+

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -58,5 +58,3 @@ func NewClusterStatus(conType common.ClusterConditionType, conStatus corev1.Cond
 		}},
 	}
 }
-
-


### PR DESCRIPTION
Refresh KubeFedCluster cache when a cluster is not found to avoid a situation that the cache could miss any cluster added before or during the deployment startup