### PR TITLE
Adding usersignups email

### DIFF
--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -87,6 +87,20 @@ func WithExpClaim(exp time.Time) ExtraClaim {
 	}
 }
 
+// WithSubClaim sets the `sub` claim in the token to generate
+func WithSubClaim(sub string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).Subject = sub
+	}
+}
+
+// WithNotBeforeClaim sets the `nbf` claim in the token to generate
+func WithNotBeforeClaim(nbf time.Time) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).NotBefore = nbf.Unix()
+	}
+}
+
 // Identity is a user identity
 type Identity struct {
 	ID       uuid.UUID

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"k8s.io/apimachinery/pkg/runtime"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	errs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/toolchain/label_value.go
+++ b/pkg/toolchain/label_value.go
@@ -1,0 +1,8 @@
+package toolchain
+
+import "strings"
+
+// ToValidValue takes a string and converts it to a compliant DNS-1123 value.
+func ToValidValue(value string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(value, "@", "-at-"), ".", "-")
+}

--- a/pkg/toolchain/label_value_test.go
+++ b/pkg/toolchain/label_value_test.go
@@ -9,17 +9,15 @@ import (
 )
 
 func TestLabelValue(t *testing.T) {
-	t.Run("string to valid value", func(t *testing.T) {
-		value := toolchain.ToValidValue("johndoe")
-		assert.Equal(t, value, "johndoe")
+	value := toolchain.ToValidValue("johndoe")
+	assert.Equal(t, value, "johndoe")
 
-		value = toolchain.ToValidValue("johndoe-at-test-dot-com")
-		assert.Equal(t, value, "johndoe-at-test-dot-com")
+	value = toolchain.ToValidValue("johndoe-at-test-dot-com")
+	assert.Equal(t, value, "johndoe-at-test-dot-com")
 
-		value = toolchain.ToValidValue("johndoe@test.com")
-		assert.Equal(t, value, "johndoe-at-test-com")
+	value = toolchain.ToValidValue("johndoe@test.com")
+	assert.Equal(t, value, "johndoe-at-test-com")
 
-		value = toolchain.ToValidValue("john.jane.doe@test.com")
-		assert.Equal(t, value, "john-jane-doe-at-test-com")
-	})
+	value = toolchain.ToValidValue("john.jane.doe@test.com")
+	assert.Equal(t, value, "john-jane-doe-at-test-com")
 }

--- a/pkg/toolchain/label_value_test.go
+++ b/pkg/toolchain/label_value_test.go
@@ -1,0 +1,25 @@
+package toolchain_test
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/toolchain"
+
+	"gotest.tools/assert"
+)
+
+func TestLabelValue(t *testing.T) {
+	t.Run("string to valid value", func(t *testing.T) {
+		value := toolchain.ToValidValue("johndoe")
+		assert.Equal(t, value, "johndoe")
+
+		value = toolchain.ToValidValue("johndoe-at-test-dot-com")
+		assert.Equal(t, value, "johndoe-at-test-dot-com")
+
+		value = toolchain.ToValidValue("johndoe@test.com")
+		assert.Equal(t, value, "johndoe-at-test-com")
+
+		value = toolchain.ToValidValue("john.jane.doe@test.com")
+		assert.Equal(t, value, "john-jane-doe-at-test-com")
+	})
+}


### PR DESCRIPTION
As an admin, I want to see the user email when approving an account. This makes my work easier as I can see where the user is coming from (e.g. redhat.com).

Relates to:
jira - https://jira.coreos.com/browse/CRT-374
api - codeready-toolchain/api#69
host - codeready-toolchain/host-operator#115
e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/55
reg - codeready-toolchain/registration-service#78

This PR also adds a way to override other claims required for registration-service tests