### PR TITLE
overriding sub and nbf claims

### DIFF
--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -87,6 +87,20 @@ func WithExpClaim(exp time.Time) ExtraClaim {
 	}
 }
 
+// WithSubClaim sets the `sub` claim in the token to generate
+func WithSubClaim(sub string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).Subject = sub
+	}
+}
+
+// WithNotBeforeClaim sets the `nbf` claim in the token to generate
+func WithNotBeforeClaim(nbf time.Time) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).NotBefore = nbf.Unix()
+	}
+}
+
 // Identity is a user identity
 type Identity struct {
 	ID       uuid.UUID

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -160,6 +160,46 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.Equal(t, identity0.ID.String(), claims.Subject)
 		require.Equal(t, expTime.Unix(), claims.ExpiresAt)
 	})
+	t.Run("create token with sub extra claim", func(t *testing.T) {
+		username := uuid.NewV4().String()
+		identity0 := &Identity{
+			ID:       uuid.NewV4(),
+			Username: username,
+		}
+		// generate the token
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithSubClaim("test"))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.True(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, "test", claims.Subject)
+	})
+	t.Run("create token with nbf extra claim", func(t *testing.T) {
+		username := uuid.NewV4().String()
+		identity0 := &Identity{
+			ID:       uuid.NewV4(),
+			Username: username,
+		}
+		// generate the token
+		nbfTime := time.Now().Add(60 * time.Second)
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithNotBeforeClaim(nbfTime))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "token is not valid yet")
+		require.False(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, identity0.ID.String(), claims.Subject)
+		require.Equal(t, nbfTime.Unix(), claims.NotBefore)
+	})
 	t.Run("create token with near future iat claim to test validation workaround", func(t *testing.T) {
 		username := uuid.NewV4().String()
 		identity0 := &Identity{

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -173,6 +173,7 @@ func TestTokenManagerTokens(t *testing.T) {
 		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
 			return &(key0.PublicKey), nil
 		})
+		require.NoError(t, err)
 		require.True(t, decodedToken.Valid)
 		claims, ok := decodedToken.Claims.(*MyClaims)
 		require.True(t, ok)


### PR DESCRIPTION
in order to update registration-service to use the latest common we need to provide a way to override the sub and nbf claims. 

relates to: https://github.com/codeready-toolchain/registration-service/pull/79