### PR TITLE
Update Generation in Fake client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-common
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20200310091613-eb1bd0c28840
+	github.com/codeready-toolchain/api v0.0.0-20200313034016-bd3872e24562
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-logr/logr v0.1.0
 	github.com/gofrs/uuid v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1w
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/codegangsta/negroni v1.0.0/go.mod h1:v0y3T5G7Y1UlFfyxFn/QLRU4a2EuNau2iZY63YTKWo0=
-github.com/codeready-toolchain/api v0.0.0-20200310091613-eb1bd0c28840 h1:IxoggXq/AANd8rp6/mXpMrdkdyLzVsk/LuXIbKizmzI=
-github.com/codeready-toolchain/api v0.0.0-20200310091613-eb1bd0c28840/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
+github.com/codeready-toolchain/api v0.0.0-20200313034016-bd3872e24562 h1:63IwzuDJsT3jVHItV9+cBLjO2e7y5Zg2wpwiwMej1H4=
+github.com/codeready-toolchain/api v0.0.0-20200313034016-bd3872e24562/go.mod h1:w07CIyd2cCp1i38hdPrG4aZPbwISzMkxOmtCWE4EtdY=
 github.com/container-storage-interface/spec v1.1.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
 github.com/containerd/console v0.0.0-20170925154832-84eeaae905fa/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.0.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -148,7 +148,7 @@ func cleanObject(obj runtime.Object) (runtime.Object, error) {
 		return nil, err
 	}
 
-	for k, _ := range m {
+	for k := range m {
 		if k != "metadata" && k != "kind" && k != "apiVersion" {
 			m[k] = nil
 		}

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
@@ -32,166 +33,256 @@ func TestNewClient(t *testing.T) {
 	assert.Nil(t, fclient.MockStatusUpdate)
 	assert.Nil(t, fclient.MockStatusPatch)
 
-	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename"}
-
 	t.Run("default methods OK", func(t *testing.T) {
-		data := make(map[string]string)
-		data["key"] = "value"
-		created := &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "somename",
-				Namespace: "somenamespace",
-			},
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Secret",
-				APIVersion: "v1",
-			},
-			StringData: data,
-		}
-
-		// Create
-		assert.NoError(t, fclient.Create(context.TODO(), created))
-
-		// Get
-		secret := &v1.Secret{}
-		assert.NoError(t, fclient.Get(context.TODO(), key, secret))
-		assert.Equal(t, created, secret)
-
-		// List
-		secretList := &v1.SecretList{}
-		assert.NoError(t, fclient.List(context.TODO(), secretList, client.InNamespace("somenamespace")))
-		require.Len(t, secretList.Items, 1)
-		assert.Equal(t, *created, secretList.Items[0])
-
-		// Update
-		created.StringData["key"] = "updated"
-		assert.NoError(t, fclient.Update(context.TODO(), created))
-		assert.NoError(t, fclient.Get(context.TODO(), key, secret))
-		assert.Equal(t, "updated", secret.StringData["key"])
-
-		// Status Update
-		assert.NoError(t, fclient.Status().Update(context.TODO(), created))
-
-		// Patch
-		annotations := make(map[string]string)
-		annotations["foo"] = "bar"
-
-		mergePatch, err := json.Marshal(map[string]interface{}{
-			"metadata": map[string]interface{}{
-				"annotations": annotations,
-			},
+		t.Run("list", func(t *testing.T) {
+			created, _ := createAndGetSecret(t, fclient)
+			secretList := &v1.SecretList{}
+			assert.NoError(t, fclient.List(context.TODO(), secretList, client.InNamespace("somenamespace")))
+			require.Len(t, secretList.Items, 1)
+			assert.Equal(t, *created, secretList.Items[0])
 		})
-		require.NoError(t, err)
-		assert.NoError(t, fclient.Patch(context.TODO(), created, client.ConstantPatch(types.MergePatchType, mergePatch)))
-		assert.NoError(t, fclient.Get(context.TODO(), key, secret))
-		assert.Equal(t, annotations, secret.GetObjectMeta().GetAnnotations())
 
-		// Status Patch
-		dep := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "somenamespace",
-				Namespace: "somename",
-				Labels: map[string]string{
-					"foo": "bar",
+		t.Run("update object with stringData", func(t *testing.T) {
+			created, retrieved := createAndGetSecret(t, fclient)
+			created.StringData["key"] = "updated"
+			assert.NoError(t, fclient.Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			assert.Equal(t, "updated", retrieved.StringData["key"])
+			assert.EqualValues(t, 2, retrieved.Generation) // Generation updated
+		})
+
+		t.Run("update object with data", func(t *testing.T) {
+			key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+			data := make(map[string][]byte)
+			data["key"] = []byte("value")
+			created := &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
 				},
-			}}
-		assert.NoError(t, fclient.Create(context.TODO(), dep))
-		depPatch := client.MergeFrom(dep.DeepCopy())
-		dep.Status.Replicas = 1
-		assert.NoError(t, fclient.Status().Patch(context.TODO(), dep, depPatch))
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+				Data: data,
+			}
+			// Create
+			assert.NoError(t, fclient.Create(context.TODO(), created))
+			// Get
+			secret := &v1.Secret{}
+			assert.NoError(t, fclient.Get(context.TODO(), key, secret))
+			assert.Equal(t, created, secret)
+			assert.EqualValues(t, 1, secret.Generation)
 
-		// Delete
-		assert.NoError(t, fclient.Delete(context.TODO(), created))
-		err = fclient.Get(context.TODO(), key, secret)
-		require.Error(t, err)
-		assert.True(t, errs.IsNotFound(err))
+			data = make(map[string][]byte)
+			data["key"] = []byte("updated")
+			created.Data = data
+			assert.NoError(t, fclient.Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, secret))
+			assert.Equal(t, []byte("updated"), secret.Data["key"])
+			assert.EqualValues(t, 2, secret.Generation) // Generation updated
+		})
 
-		// DeleteAllOf
-		dep2 := dep.DeepCopy()
-		dep2.Name = dep2.Name + "-2"
-		assert.NoError(t, fclient.Create(context.TODO(), dep2))
+		t.Run("update object with spec", func(t *testing.T) {
+			created, retrieved := createAndGetDeployment(t, fclient)
+			newReplicas := int32(10)
+			created.Spec.Replicas = &newReplicas
+			assert.NoError(t, fclient.Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			require.NotNil(t, retrieved.Spec.Replicas)
+			assert.EqualValues(t, 10, *retrieved.Spec.Replicas)
+			assert.EqualValues(t, 2, retrieved.Generation) // Generation updated
+		})
 
-		assert.NoError(t, fclient.DeleteAllOf(context.TODO(), dep, client.InNamespace("somenamespace"), client.MatchingLabels(dep.ObjectMeta.Labels)))
-		err = fclient.Get(context.TODO(), key, dep)
-		require.Error(t, err)
-		assert.True(t, errs.IsNotFound(err))
+		t.Run("status update", func(t *testing.T) {
+			created, retrieved := createAndGetSecret(t, fclient)
+			assert.NoError(t, fclient.Status().Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			assert.EqualValues(t, 1, retrieved.Generation) // Generation not changed
+		})
 
-		err = fclient.Get(context.TODO(), key, dep2)
-		require.Error(t, err)
-		assert.True(t, errs.IsNotFound(err))
+		t.Run("patch", func(t *testing.T) {
+			created, retrieved := createAndGetSecret(t, fclient)
+			annotations := make(map[string]string)
+			annotations["foo"] = "bar"
+
+			mergePatch, err := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": annotations,
+				},
+			})
+			require.NoError(t, err)
+			assert.NoError(t, fclient.Patch(context.TODO(), created, client.RawPatch(types.MergePatchType, mergePatch)))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			assert.Equal(t, annotations, retrieved.GetObjectMeta().GetAnnotations())
+		})
+
+		t.Run("status patch", func(t *testing.T) {
+			_, retrieved := createAndGetDeployment(t, fclient)
+			depPatch := client.MergeFrom(retrieved.DeepCopy())
+			retrieved.Status.Replicas = 1
+			assert.NoError(t, fclient.Status().Patch(context.TODO(), retrieved, depPatch))
+		})
+
+		t.Run("delete", func(t *testing.T) {
+			created, retrieved := createAndGetSecret(t, fclient)
+			assert.NoError(t, fclient.Delete(context.TODO(), created))
+			err := fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved)
+			require.Error(t, err)
+			assert.True(t, errs.IsNotFound(err))
+		})
+
+		t.Run("deleteAllOf", func(t *testing.T) {
+			created, retrieved := createAndGetDeployment(t, fclient)
+			dep2 := retrieved.DeepCopy()
+			dep2.Name = dep2.Name + "-2"
+			assert.NoError(t, fclient.Create(context.TODO(), dep2))
+
+			assert.NoError(t, fclient.DeleteAllOf(context.TODO(), retrieved, client.InNamespace("somenamespace"), client.MatchingLabels(retrieved.ObjectMeta.Labels)))
+			err := fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved)
+			require.Error(t, err)
+			assert.True(t, errs.IsNotFound(err))
+
+			err = fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: dep2.Name}, dep2)
+			require.Error(t, err)
+			assert.True(t, errs.IsNotFound(err))
+		})
 	})
 
-	expectedErr := errors.New("oopsie woopsie")
+	t.Run("mock methods OK", func(t *testing.T) {
+		expectedErr := errors.New("oopsie woopsie")
+		created, _ := createAndGetSecret(t, fclient)
 
-	t.Run("mock Get", func(t *testing.T) {
-		defer func() { fclient.MockGet = nil }()
-		fclient.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.Get(context.TODO(), key, &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock Get", func(t *testing.T) {
+			defer func() { fclient.MockGet = nil }()
+			fclient.MockGet = func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock List", func(t *testing.T) {
-		defer func() { fclient.MockList = nil }()
-		fclient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.List(context.TODO(), &v1.SecretList{}, client.InNamespace("somenamespace")), expectedErr.Error())
-	})
+		t.Run("mock List", func(t *testing.T) {
+			defer func() { fclient.MockList = nil }()
+			fclient.MockList = func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.List(context.TODO(), &v1.SecretList{}, client.InNamespace("somenamespace")), expectedErr.Error())
+		})
 
-	t.Run("mock Create", func(t *testing.T) {
-		defer func() { fclient.MockCreate = nil }()
-		fclient.MockCreate = func(ctx context.Context, obj runtime.Object, option ...client.CreateOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.Create(context.TODO(), &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock Create", func(t *testing.T) {
+			defer func() { fclient.MockCreate = nil }()
+			fclient.MockCreate = func(ctx context.Context, obj runtime.Object, option ...client.CreateOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.Create(context.TODO(), &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock Update", func(t *testing.T) {
-		defer func() { fclient.MockUpdate = nil }()
-		fclient.MockUpdate = func(ctx context.Context, obj runtime.Object, option ...client.UpdateOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.Update(context.TODO(), &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock Update", func(t *testing.T) {
+			defer func() { fclient.MockUpdate = nil }()
+			fclient.MockUpdate = func(ctx context.Context, obj runtime.Object, option ...client.UpdateOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.Update(context.TODO(), &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock Patch", func(t *testing.T) {
-		defer func() { fclient.MockPatch = nil }()
-		fclient.MockPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.Patch(context.TODO(), &v1.Secret{}, client.ConstantPatch(types.MergePatchType, []byte{})), expectedErr.Error())
-	})
+		t.Run("mock Patch", func(t *testing.T) {
+			defer func() { fclient.MockPatch = nil }()
+			fclient.MockPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.Patch(context.TODO(), &v1.Secret{}, client.RawPatch(types.MergePatchType, []byte{})), expectedErr.Error())
+		})
 
-	t.Run("mock Delete", func(t *testing.T) {
-		defer func() { fclient.MockDelete = nil }()
-		fclient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.Delete(context.TODO(), &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock Delete", func(t *testing.T) {
+			defer func() { fclient.MockDelete = nil }()
+			fclient.MockDelete = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.Delete(context.TODO(), &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock DeleteAllOf", func(t *testing.T) {
-		defer func() { fclient.MockDeleteAllOf = nil }()
-		fclient.MockDeleteAllOf = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.DeleteAllOf(context.TODO(), &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock DeleteAllOf", func(t *testing.T) {
+			defer func() { fclient.MockDeleteAllOf = nil }()
+			fclient.MockDeleteAllOf = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.DeleteAllOf(context.TODO(), &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock Status Update", func(t *testing.T) {
-		defer func() { fclient.MockStatusUpdate = nil }()
-		fclient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.MockStatusUpdate(context.TODO(), &v1.Secret{}), expectedErr.Error())
-	})
+		t.Run("mock Status Update", func(t *testing.T) {
+			defer func() { fclient.MockStatusUpdate = nil }()
+			fclient.MockStatusUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.MockStatusUpdate(context.TODO(), &v1.Secret{}), expectedErr.Error())
+		})
 
-	t.Run("mock Status Patch", func(t *testing.T) {
-		defer func() { fclient.MockStatusPatch = nil }()
-		fclient.MockStatusPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
-			return expectedErr
-		}
-		assert.EqualError(t, fclient.MockStatusPatch(context.TODO(), &v1.Secret{}, client.ConstantPatch(types.MergePatchType, []byte{})), expectedErr.Error())
+		t.Run("mock Status Patch", func(t *testing.T) {
+			defer func() { fclient.MockStatusPatch = nil }()
+			fclient.MockStatusPatch = func(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+				return expectedErr
+			}
+			assert.EqualError(t, fclient.MockStatusPatch(context.TODO(), &v1.Secret{}, client.RawPatch(types.MergePatchType, []byte{})), expectedErr.Error())
+		})
 	})
+}
+
+func createAndGetSecret(t *testing.T, fclient *FakeClient) (*v1.Secret, *v1.Secret) {
+	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+	data := make(map[string]string)
+	data["key"] = "value"
+	created := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		StringData: data,
+	}
+
+	// Create
+	assert.NoError(t, fclient.Create(context.TODO(), created))
+
+	// Get
+	secret := &v1.Secret{}
+	assert.NoError(t, fclient.Get(context.TODO(), key, secret))
+	assert.Equal(t, created, secret)
+	assert.EqualValues(t, 1, secret.Generation)
+
+	return created, secret
+}
+
+func createAndGetDeployment(t *testing.T, fclient *FakeClient) (*appsv1.Deployment, *appsv1.Deployment) {
+	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+	replicas := int32(1)
+	created := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels: map[string]string{
+				"foo": "bar",
+			},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	}
+
+	// Create
+	assert.NoError(t, fclient.Create(context.TODO(), created))
+
+	// Get
+	dep := &appsv1.Deployment{}
+	assert.NoError(t, fclient.Get(context.TODO(), key, dep))
+	assert.Equal(t, created, dep)
+	assert.EqualValues(t, 1, dep.Generation)
+
+	return created, dep
 }

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -75,11 +75,12 @@ func TestNewClient(t *testing.T) {
 			assert.EqualValues(t, 1, secret.Generation)
 
 			data = make(map[string][]byte)
-			data["key"] = []byte("updated")
+			data["newkey"] = []byte("newvalue")
 			created.Data = data
 			assert.NoError(t, fclient.Update(context.TODO(), created))
 			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, secret))
-			assert.Equal(t, []byte("updated"), secret.Data["key"])
+			assert.Equal(t, []byte("value"), secret.Data["key"])
+			assert.Equal(t, []byte("newvalue"), secret.Data["newkey"])
 			assert.EqualValues(t, 2, secret.Generation) // Generation updated
 		})
 


### PR DESCRIPTION
Some existing tests relay on resource Generation changes which is currently are ignored by the fake client.
This PR https://github.com/codeready-toolchain/toolchain-common/pull/88/files#diff-fb87476fa66849c8514ba700e715b4b6R108
fixed a bug in `ApplyClient` which actually broke some of our tests (sounds weird I know).
Let's add generation updates in our fake client so it's available in all our tests.