### PR TITLE
add methods to test.T interface

### DIFF
--- a/pkg/test/masteruserrecord/master_user_record_test.go
+++ b/pkg/test/masteruserrecord/master_user_record_test.go
@@ -112,11 +112,18 @@ func NewMockT() *MockT {
 	return &MockT{}
 }
 
+var _ test.T = &MockT{}
+
 type MockT struct {
 	logfCount    int
 	errorfCount  int
 	fatalfCount  int
 	failnowCount int
+	failCount    int
+}
+
+func (t *MockT) Log(args ...interface{}) {
+	t.logfCount++
 }
 
 func (t *MockT) Logf(format string, args ...interface{}) {
@@ -134,6 +141,10 @@ func (t *MockT) Fatalf(format string, args ...interface{}) {
 
 func (t *MockT) FailNow() {
 	t.failnowCount++
+}
+
+func (t *MockT) Fail() {
+	t.failCount++
 }
 
 func (t *MockT) CalledLogf() bool {

--- a/pkg/test/testing_t.go
+++ b/pkg/test/testing_t.go
@@ -2,8 +2,10 @@ package test
 
 // T our minimal testing interface for our custom assertions
 type T interface {
+	Log(args ...interface{})
 	Logf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 	FailNow()
+	Fail()
 	Fatalf(format string, args ...interface{})
 }


### PR DESCRIPTION
this allows for casting the current `testing.T`
with `assert.T` in https://github.com/stretchr/testify/assert

Updates https://issues.redhat.com/browse/CRT-459

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>