### PR TITLE
adding extra claims for notification service messages

### DIFF
--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -73,6 +73,27 @@ func WithEmailClaim(email string) ExtraClaim {
 	}
 }
 
+// WithCompanyClaim sets the `company` claim in the token to generate
+func WithCompanyClaim(company string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).Company = company
+	}
+}
+
+// WithGivenNameClaim sets the `givenName` claim in the token to generate
+func WithGivenNameClaim(givenName string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).GivenName = givenName
+	}
+}
+
+// WithFamilyNameClaim sets the `familyName` claim in the token to generate
+func WithFamilyNameClaim(familyName string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).FamilyName = familyName
+	}
+}
+
 // WithIATClaim sets the `iat` claim in the token to generate
 func WithIATClaim(iat time.Time) ExtraClaim {
 	return func(token *jwt.Token) {

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -201,6 +201,64 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.Equal(t, identity0.ID.String(), claims.Subject)
 		require.Equal(t, nbfTime.Unix(), claims.NotBefore)
 	})
+	t.Run("create token with given name extra claim", func(t *testing.T) {
+		username := uuid.NewV4().String()
+		identity0 := &Identity{
+			ID:       uuid.NewV4(),
+			Username: username,
+		}
+		// generate the token
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithGivenNameClaim("jane"))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.NoError(t, err)
+		require.True(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, "jane", claims.GivenName)
+
+	})
+	t.Run("create token with family name extra claim", func(t *testing.T) {
+		username := uuid.NewV4().String()
+		identity0 := &Identity{
+			ID:       uuid.NewV4(),
+			Username: username,
+		}
+		// generate the token
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithFamilyNameClaim("doe"))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.NoError(t, err)
+		require.True(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, "doe", claims.FamilyName)
+	})
+	t.Run("create token with company extra claim", func(t *testing.T) {
+		username := uuid.NewV4().String()
+		identity0 := &Identity{
+			ID:       uuid.NewV4(),
+			Username: username,
+		}
+		// generate the token
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithCompanyClaim("red hat"))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.NoError(t, err)
+		require.True(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, "red hat", claims.Company)
+	})
 	t.Run("create token with near future iat claim to test validation workaround", func(t *testing.T) {
 		username := uuid.NewV4().String()
 		identity0 := &Identity{


### PR DESCRIPTION
adding extra claims that will be used when writing e2e-tests for the additional fields that the notification service messages require.

jira: https://issues.redhat.com/browse/CRT-518