### PR TITLE
feat: when no FedCluster is found then refresh the cache

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -114,7 +114,13 @@ var HostCluster GetHostClusterFunc = GetHostCluster
 func GetHostCluster() (*FedCluster, bool) {
 	clusters := clusterCache.getFedClustersByType(Host)
 	if len(clusters) == 0 {
-		return nil, false
+		if clusterCache.refreshCache != nil {
+			clusterCache.refreshCache()
+		}
+		clusters = clusterCache.getFedClustersByType(Host)
+		if len(clusters) == 0 {
+			return nil, false
+		}
 	}
 	return clusters[0], true
 }
@@ -127,7 +133,14 @@ var MemberClusters GetMemberClustersFunc = GetMemberClusters
 
 // GetMemberClusters returns the kube clients for the host clusters from the cache of the clusters
 func GetMemberClusters(conditions ...Condition) []*FedCluster {
-	return clusterCache.getFedClustersByType(Member, conditions...)
+	clusters := clusterCache.getFedClustersByType(Member, conditions...)
+	if len(clusters) == 0 {
+		if clusterCache.refreshCache != nil {
+			clusterCache.refreshCache()
+		}
+		clusters = clusterCache.getFedClustersByType(Member, conditions...)
+	}
+	return clusters
 }
 
 // Type is a cluster type (either host or member)


### PR DESCRIPTION
When no FedCluster of the given type is found, then refresh the cache. This is for the cases 
* when there is a rolling update 
* when a pod panicked and a new one started 

so the member operator can immediately start operating with the already existing resources. 
Otherwise, the provisioning/update may fail with an error: `unable to connect to the host cluster: unknown cluster`

paired PRs:
https://github.com/codeready-toolchain/host-operator/pull/185
https://github.com/codeready-toolchain/member-operator/pull/145