### PR TITLE
feat: move apply to client and assign labels when applying

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -134,3 +134,39 @@ func (p ApplyClient) createObj(newResource runtime.Object, metaNew v1.Object, ow
 	}
 	return p.cl.Create(context.TODO(), newResource)
 }
+
+// Apply applies the objects, ie, creates or updates them on the cluster
+// returns `true, nil` if at least one of the objects was created or modified,
+// `false, nil` if nothing changed, and `false, err` if an error occurred
+func (p ApplyClient) Apply(objs []runtime.RawExtension, newLabels map[string]string) (bool, error) {
+	createdOrUpdated := false
+	for _, rawObj := range objs {
+		obj := rawObj.Object
+		if obj == nil {
+			continue
+		}
+
+		acc, err := meta.Accessor(obj)
+		if err != nil {
+			return false, errors.Wrapf(err, "unable to get the accessor interface of the object '%v'", rawObj.Object)
+		}
+
+		// set newLabels
+		labels := acc.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		for key, value := range newLabels {
+			labels[key] = value
+		}
+		acc.SetLabels(labels)
+
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		result, err := p.CreateOrUpdateObject(obj, true, nil)
+		if err != nil {
+			return false, errors.Wrapf(err, "unable to create resource of kind: %s, version: %s", gvk.Kind, gvk.Version)
+		}
+		createdOrUpdated = createdOrUpdated || result
+	}
+	return createdOrUpdated, nil
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,13 +2,18 @@ package client_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis"
 	applyCl "github.com/codeready-toolchain/toolchain-common/pkg/client"
+	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	authv1 "github.com/openshift/api/authorization/v1"
 	"github.com/stretchr/testify/assert"
@@ -181,6 +186,310 @@ func TestApplySingle(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "second-value", configMap.Data["first-param"])
 	})
+}
+
+func TestProcessAndApply(t *testing.T) {
+
+	commit := getNameWithTimestamp("sha")
+	user := getNameWithTimestamp("user")
+
+	s := addToScheme(t)
+	codecFactory := serializer.NewCodecFactory(s)
+	decoder := codecFactory.UniversalDeserializer()
+
+	values := map[string]string{
+		"USERNAME": user,
+		"COMMIT":   commit,
+	}
+
+	t.Run("should create namespace alone", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(Namespace), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+		labels := newLabels("", "john", "")
+
+		// when
+		createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		assertNamespaceExists(t, cl, user, labels, commit)
+	})
+
+	t.Run("should create role binding alone", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(RoleBinding), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+		labels := newLabels("basic", "john", "dev")
+
+		// when
+		createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		assertRoleBindingExists(t, cl, user, labels)
+	})
+
+	t.Run("should create namespace and role binding", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(Namespace, RoleBinding), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+		labels := newLabels("", "john", "dev")
+
+		// when
+		createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		assertNamespaceExists(t, cl, user, labels, commit)
+		assertRoleBindingExists(t, cl, user, labels)
+	})
+
+	t.Run("should update existing role binding", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		cl.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+			meta, err := meta.Accessor(obj)
+			require.NoError(t, err)
+			meta.SetResourceVersion("1")
+			return cl.Client.Create(ctx, obj, opts...)
+		}
+		cl.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+			meta, err := meta.Accessor(obj)
+			require.NoError(t, err)
+			t.Logf("updating resource of kind %s with version %s\n", obj.GetObjectKind().GroupVersionKind().Kind, meta.GetResourceVersion())
+			if obj.GetObjectKind().GroupVersionKind().Kind == "RoleBinding" && meta.GetResourceVersion() != "1" {
+				return fmt.Errorf("invalid resource version: %q", meta.GetResourceVersion())
+			}
+			return cl.Client.Update(ctx, obj, opts...)
+		}
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(RoleBinding), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+		witoutType := newLabels("basic", "john", "")
+
+		createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, witoutType)
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		assertRoleBindingExists(t, cl, user, witoutType)
+
+		// when rolebinding changes
+		tmpl, err = DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(Namespace, RoleBindingWithExtraUser), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err = p.Process(tmpl, values)
+		require.NoError(t, err)
+		complete := newLabels("advanced", "john", "dev")
+		createdOrUpdated, err = applyCl.NewApplyClient(cl, s).Apply(objs, complete)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		binding := assertRoleBindingExists(t, cl, user, complete)
+		require.Len(t, binding.Subjects, 2)
+		assert.Equal(t, "User", binding.Subjects[0].Kind)
+		assert.Equal(t, user, binding.Subjects[0].Name)
+		assert.Equal(t, "User", binding.Subjects[1].Kind)
+		assert.Equal(t, "extraUser", binding.Subjects[1].Name)
+	})
+
+	t.Run("should not create or update existing namespace and role binding", func(t *testing.T) {
+		// given
+		cl := NewFakeClient(t)
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(Namespace, RoleBinding), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+		labels := newLabels("basic", "john", "dev")
+		created, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+		require.NoError(t, err)
+		assert.True(t, created)
+		assertNamespaceExists(t, cl, user, labels, commit)
+		assertRoleBindingExists(t, cl, user, labels)
+
+		// when apply the same template again
+		updated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+
+		// then
+		require.NoError(t, err)
+		assert.False(t, updated)
+	})
+
+	t.Run("failures", func(t *testing.T) {
+
+		t.Run("should fail to create template object", func(t *testing.T) {
+			// given
+			cl := NewFakeClient(t)
+			p := template.NewProcessor(s)
+			cl.MockCreate = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+				return errors.New("failed to create resource")
+			}
+			tmpl, err := DecodeTemplate(decoder,
+				CreateTemplate(WithObjects(RoleBinding), WithParams(UsernameParam, CommitParam)))
+			require.NoError(t, err)
+
+			// when
+			objs, err := p.Process(tmpl, values)
+			require.NoError(t, err)
+			createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, newLabels("", "", ""))
+
+			// then
+			require.Error(t, err)
+			assert.False(t, createdOrUpdated)
+		})
+
+		t.Run("should fail to update template object", func(t *testing.T) {
+			// given
+			cl := NewFakeClient(t)
+			p := template.NewProcessor(s)
+			cl.MockUpdate = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+				return errors.New("failed to update resource")
+			}
+			tmpl, err := DecodeTemplate(decoder,
+				CreateTemplate(WithObjects(RoleBinding), WithParams(UsernameParam, CommitParam)))
+			require.NoError(t, err)
+			objs, err := p.Process(tmpl, values)
+			require.NoError(t, err)
+			labels := newLabels("", "", "")
+			createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+			require.NoError(t, err)
+			assert.True(t, createdOrUpdated)
+
+			// when
+			tmpl, err = DecodeTemplate(decoder,
+				CreateTemplate(WithObjects(RoleBindingWithExtraUser), WithParams(UsernameParam, CommitParam)))
+			require.NoError(t, err)
+			objs, err = p.Process(tmpl, values)
+			require.NoError(t, err)
+			createdOrUpdated, err = applyCl.NewApplyClient(cl, s).Apply(objs, newLabels("advanced", "john", "dev"))
+
+			// then
+			assert.Error(t, err)
+			assert.False(t, createdOrUpdated)
+		})
+	})
+
+	t.Run("should create with extra newLabels and ownerref", func(t *testing.T) {
+
+		// given
+		values := map[string]string{
+			"USERNAME": user,
+			"COMMIT":   commit,
+		}
+		cl := NewFakeClient(t)
+		p := template.NewProcessor(s)
+		tmpl, err := DecodeTemplate(decoder,
+			CreateTemplate(WithObjects(Namespace, RoleBinding), WithParams(UsernameParam, CommitParam)))
+		require.NoError(t, err)
+		objs, err := p.Process(tmpl, values)
+		require.NoError(t, err)
+
+		// when adding newLabels and an owner reference
+		obj := objs[0]
+		meta, err := meta.Accessor(obj.Object)
+		require.NoError(t, err)
+		meta.SetOwnerReferences([]metav1.OwnerReference{
+			{
+				APIVersion: "crt/v1",
+				Kind:       "NSTemplateSet",
+				Name:       "foo",
+			},
+		})
+		labels := newLabels("basic", "john", "dev")
+		createdOrUpdated, err := applyCl.NewApplyClient(cl, s).Apply(objs, labels)
+
+		// then
+		require.NoError(t, err)
+		assert.True(t, createdOrUpdated)
+		ns := assertNamespaceExists(t, cl, user, labels, commit)
+		// verify owner refs
+		assert.Equal(t, []metav1.OwnerReference{
+			{
+				APIVersion: "crt/v1",
+				Kind:       "NSTemplateSet",
+				Name:       "foo",
+			},
+		}, ns.OwnerReferences)
+	})
+}
+
+func assertNamespaceExists(t *testing.T, c client.Client, nsName string, labels map[string]string, version string) corev1.Namespace {
+	// check that the namespace was created
+	var ns corev1.Namespace
+	err := c.Get(context.TODO(), types.NamespacedName{Name: nsName, Namespace: ""}, &ns) // assert namespace is cluster-scoped
+	require.NoError(t, err)
+	assert.Equal(t, expectedLabels(labels, version), ns.GetLabels())
+	return ns
+}
+
+func expectedLabels(labels map[string]string, version string) map[string]string {
+	expLabels := map[string]string{
+		"extra": "something-extra",
+	}
+	if version != "" {
+		expLabels["version"] = version
+	}
+	for k, v := range labels {
+		expLabels[k] = v
+	}
+	return expLabels
+}
+
+func assertRoleBindingExists(t *testing.T, c client.Client, ns string, labels map[string]string) authv1.RoleBinding {
+	// check that the rolebinding is created in the namespace
+	// (the fake client just records the request but does not perform any consistency check)
+	var rb authv1.RoleBinding
+	err := c.Get(context.TODO(), types.NamespacedName{
+		Namespace: ns,
+		Name:      fmt.Sprintf("%s-edit", ns),
+	}, &rb)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedLabels(labels, ""), rb.GetLabels())
+	return rb
+}
+
+func newLabels(tier, username, nsType string) map[string]string {
+	labels := map[string]string{
+		"toolchain.dev.openshift.com/provider": "codeready-toolchain",
+	}
+	if tier != "" {
+		labels["toolchain.dev.openshift.com/tier"] = tier
+	}
+	if username != "" {
+		labels["toolchain.dev.openshift.com/owner"] = username
+	}
+	if nsType != "" {
+		labels["toolchain.dev.openshift.com/type"] = nsType
+	}
+	return labels
+}
+
+func getNameWithTimestamp(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
 }
 
 func newClient(t *testing.T, s *runtime.Scheme) (*applyCl.ApplyClient, *test.FakeClient) {

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -393,7 +393,7 @@ func TestMultipleActionsInParallel(t *testing.T) {
 	}
 
 	for _, clusterToTest := range []*FedCluster{memberCluster, hostCluster} {
-		for i := 0; i < 10000; i++ {
+		for i := 0; i < 1000; i++ {
 			waitForFinished.Add(4)
 			go func() {
 				defer waitForFinished.Done()

--- a/pkg/cluster/kubefedcluster_assets.go
+++ b/pkg/cluster/kubefedcluster_assets.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -304,7 +305,7 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"core.kubefed.io_kubefedclusters.yaml": &bintree{coreKubefedIo_kubefedclustersYaml, map[string]*bintree{}},
+	"core.kubefed.io_kubefedclusters.yaml": {coreKubefedIo_kubefedclustersYaml, map[string]*bintree{}},
 }}
 
 // RestoreAsset restores an asset under the given directory

--- a/pkg/test/template.go
+++ b/pkg/test/template.go
@@ -94,7 +94,7 @@ const (
       openshift.io/display-name: ${USERNAME}
       openshift.io/requester: ${USERNAME}
     labels:
-      provider: codeready-toolchain
+      extra: something-extra
       version: ${COMMIT}
     name: ${USERNAME}`
 
@@ -103,7 +103,7 @@ const (
   kind: ServiceAccount
   metadata:
     labels:
-      provider: codeready-toolchain
+      extra: something-extra
     name: registration-service
     namespace: ${NAMESPACE}`
 
@@ -113,6 +113,8 @@ const (
   metadata:
     name: ${USERNAME}-edit
     namespace: ${USERNAME}
+    labels:
+      extra: something-extra
   roleRef:
     kind: ClusterRole
     name: edit
@@ -126,6 +128,8 @@ const (
   metadata:
     name: ${USERNAME}-edit
     namespace: ${USERNAME}
+    labels:
+      extra: something-extra
   roleRef:
     kind: ClusterRole
     name: edit
@@ -142,7 +146,7 @@ const (
     name: registration-service
     namespace: ${NAMESPACE}
     labels:
-      provider: codeready-toolchain
+      extra: something-extra
       run: registration-service
   spec:
     selector:
@@ -153,7 +157,7 @@ const (
   apiVersion: v1
   metadata:
     labels:
-      provider: codeready-toolchain
+      extra: something-extra
     name: registration-service
     namespace: ${NAMESPACE}
   type: Opaque
@@ -170,7 +174,7 @@ const (
 			"openshift.io/requester": "{{ .Username }}"
 		},
 		"labels": {
-			"provider": "codeready-toolchain",
+			"extra": "something-extra",
 			"version": "{{ .Commit }}"
 		},
 		"name": "{{ .Username }}"
@@ -182,7 +186,10 @@ const (
 	"kind": "RoleBinding",
 	"metadata": {
 		"name": "{{ .Username }}-edit",
-    	"namespace": "{{ .Username }}"
+    	"namespace": "{{ .Username }}",
+		"labels": {
+			"extra": "something-extra"
+		}
 	},
 	"roleRef": {
 		"kind": "ClusterRole",


### PR DESCRIPTION
proposed changes:
* moved apply method from processor to client - it makes more sense to have it there
* also moved the related tests
* added "labels" parameter to the apply method so we can let the client take care of it and we can make the NSTemplateSet controller a bit simpler :-) 
* decreased a bit the concurrent test of fedcluster cache - it was too much and my PC had problems with the number of concurrent goroutines 