### PR TITLE
fix: only pass generation when resource wasn't updated

### DIFF
--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -135,6 +135,8 @@ func (c *FakeClient) Update(ctx context.Context, obj runtime.Object, opts ...cli
 
 	if !reflect.DeepEqual(updatingMap, currentMap) {
 		updatingMeta.SetGeneration(currentMeta.GetGeneration() + 1)
+	} else {
+		updatingMeta.SetGeneration(currentMeta.GetGeneration())
 	}
 	return c.Client.Update(ctx, obj, opts...)
 }

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -51,6 +51,14 @@ func TestNewClient(t *testing.T) {
 			assert.EqualValues(t, 2, retrieved.Generation) // Generation updated
 		})
 
+		t.Run("update object with the same stringData", func(t *testing.T) {
+			created, retrieved := createAndGetSecret(t, fclient)
+			assert.NoError(t, fclient.Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			assert.Equal(t, "value", retrieved.StringData["key"])
+			assert.EqualValues(t, 1, retrieved.Generation) // Generation updated
+		})
+
 		t.Run("update object with data", func(t *testing.T) {
 			key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
 			data := make(map[string][]byte)
@@ -93,6 +101,15 @@ func TestNewClient(t *testing.T) {
 			require.NotNil(t, retrieved.Spec.Replicas)
 			assert.EqualValues(t, 10, *retrieved.Spec.Replicas)
 			assert.EqualValues(t, 2, retrieved.Generation) // Generation updated
+		})
+
+		t.Run("update object with same spec", func(t *testing.T) {
+			created, retrieved := createAndGetDeployment(t, fclient)
+			assert.NoError(t, fclient.Update(context.TODO(), created))
+			assert.NoError(t, fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved))
+			require.NotNil(t, retrieved.Spec.Replicas)
+			assert.EqualValues(t, 1, *retrieved.Spec.Replicas)
+			assert.EqualValues(t, 1, retrieved.Generation) // Generation updated
 		})
 
 		t.Run("status update", func(t *testing.T) {


### PR DESCRIPTION
If the resource is not updated, then we should just pass the generation value.
related member-operator PR: https://github.com/codeready-toolchain/member-operator/pull/149
there is no need to change in host-operator repo