### PR TITLE
Use toolchainv1alpha1.Condition type for toolchain component status

### DIFF
--- a/pkg/status/componentconditions.go
+++ b/pkg/status/componentconditions.go
@@ -34,7 +34,7 @@ func NewComponentErrorCondition(reason, msg string) *toolchainv1alpha1.Condition
 }
 
 // ValidateComponentConditionReady checks whether the provided conditions signal that the component is ready, returns an error otherwise
-func ValidateComponentConditionReady(conditions []toolchainv1alpha1.Condition) error {
+func ValidateComponentConditionReady(conditions ...toolchainv1alpha1.Condition) error {
 	c, found := condition.FindConditionByType(conditions, toolchainv1alpha1.ConditionReady)
 	if !found {
 		return fmt.Errorf("a ready condition was not found")

--- a/pkg/status/componentconditions.go
+++ b/pkg/status/componentconditions.go
@@ -1,10 +1,13 @@
 package status
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"fmt"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewComponentReadyCondition(reason string) *toolchainv1alpha1.Condition {
@@ -28,4 +31,16 @@ func NewComponentErrorCondition(reason, msg string) *toolchainv1alpha1.Condition
 		LastTransitionTime: currentTime,
 		LastUpdatedTime:    &currentTime,
 	}
+}
+
+// ValidateComponentConditionReady checks whether the provided conditions signal that the component is ready, returns an error otherwise
+func ValidateComponentConditionReady(conditions []toolchainv1alpha1.Condition) error {
+	c, found := condition.FindConditionByType(conditions, toolchainv1alpha1.ConditionReady)
+	if !found {
+		return fmt.Errorf("a ready condition was not found")
+	} else if c.Status != corev1.ConditionTrue {
+		return fmt.Errorf(c.Message) // return an error with the message from the condition
+	}
+
+	return nil
 }

--- a/pkg/status/componentconditions_test.go
+++ b/pkg/status/componentconditions_test.go
@@ -1,0 +1,86 @@
+package status
+
+import (
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestValidateComponentConditionReady(t *testing.T) {
+
+	conditionReady := toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionTrue,
+		Reason:  "DeploymentReady",
+		Message: "",
+	}
+
+	conditionNotReady := toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionFalse,
+		Reason:  "DeploymentNotReady",
+		Message: "deployment has unready status conditions: Available",
+	}
+
+	conditionOtherType := toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.MasterUserRecordProvisioning,
+		Status:  corev1.ConditionTrue,
+		Reason:  "Provisioned",
+		Message: "",
+	}
+
+	conditionOtherType2 := toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.MasterUserRecordUserProvisionedNotificationCreated,
+		Status:  corev1.ConditionTrue,
+		Reason:  "NotificationCreated",
+		Message: "",
+	}
+
+	t.Run("single conditions", func(t *testing.T) {
+
+		t.Run("no ready condition", func(t *testing.T) {
+			err := ValidateComponentConditionReady(conditionOtherType)
+			require.Error(t, err)
+			assert.EqualError(t, err, "a ready condition was not found")
+		})
+
+		t.Run("condition not ready", func(t *testing.T) {
+			err := ValidateComponentConditionReady(conditionNotReady)
+			require.Error(t, err)
+			assert.EqualError(t, err, "deployment has unready status conditions: Available")
+		})
+
+		t.Run("condition ready", func(t *testing.T) {
+			err := ValidateComponentConditionReady(conditionReady)
+			assert.NoError(t, err)
+		})
+	})
+
+	t.Run("multiple conditions", func(t *testing.T) {
+
+		t.Run("multiple - no ready condition", func(t *testing.T) {
+			conditions := []toolchainv1alpha1.Condition{conditionOtherType, conditionOtherType2}
+			err := ValidateComponentConditionReady(conditions...)
+			require.Error(t, err)
+			assert.EqualError(t, err, "a ready condition was not found")
+		})
+
+		t.Run("multiple - condition not ready", func(t *testing.T) {
+			conditions := []toolchainv1alpha1.Condition{conditionNotReady, conditionOtherType}
+			err := ValidateComponentConditionReady(conditions...)
+			require.Error(t, err)
+			assert.EqualError(t, err, "deployment has unready status conditions: Available")
+		})
+
+		t.Run("multiple - condition ready", func(t *testing.T) {
+			conditions := []toolchainv1alpha1.Condition{conditionReady, conditionOtherType}
+			err := ValidateComponentConditionReady(conditions...)
+			require.NoError(t, err)
+		})
+	})
+}

--- a/pkg/status/deployment.go
+++ b/pkg/status/deployment.go
@@ -23,7 +23,7 @@ const (
 )
 
 // GetDeploymentStatusConditions looks up a deployment with the given name within the given namespace and checks its status
-// and finally returns a condition summarizing the status and an error if there was an error or if any conditions are false
+// and finally returns a condition summarizing the status
 func GetDeploymentStatusConditions(client client.Client, name, namespace string) []toolchainv1alpha1.Condition {
 	deploymentName := types.NamespacedName{Namespace: namespace, Name: name}
 	deployment := &appsv1.Deployment{}
@@ -37,7 +37,7 @@ func GetDeploymentStatusConditions(client client.Client, name, namespace string)
 	// get and check conditions
 	for _, condition := range deployment.Status.Conditions {
 		if (condition.Type == appsv1.DeploymentAvailable || condition.Type == appsv1.DeploymentProgressing) && condition.Status != corev1.ConditionTrue {
-			// there is a condition that is not ready, return it along with the error
+			// there is a condition that is not ready, return it
 			err := fmt.Errorf("%s: %s", ErrMsgDeploymentConditionNotReady, condition.Type)
 			errCondition := NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusDeploymentNotReadyReason, err.Error())
 			return []toolchainv1alpha1.Condition{*errCondition}

--- a/pkg/status/deployment.go
+++ b/pkg/status/deployment.go
@@ -24,14 +24,14 @@ const (
 
 // GetDeploymentStatusConditions looks up a deployment with the given name within the given namespace and checks its status
 // and finally returns a condition summarizing the status and an error if there was an error or if any conditions are false
-func GetDeploymentStatusConditions(client client.Client, name, namespace string) ([]toolchainv1alpha1.Condition, error) {
+func GetDeploymentStatusConditions(client client.Client, name, namespace string) []toolchainv1alpha1.Condition {
 	deploymentName := types.NamespacedName{Namespace: namespace, Name: name}
 	deployment := &appsv1.Deployment{}
 	err := client.Get(context.TODO(), deploymentName, deployment)
 	if err != nil {
 		err = errs.Wrap(err, ErrMsgCannotGetDeployment)
 		errCondition := NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusDeploymentNotFoundReason, err.Error())
-		return []toolchainv1alpha1.Condition{*errCondition}, err
+		return []toolchainv1alpha1.Condition{*errCondition}
 	}
 
 	// get and check conditions
@@ -40,13 +40,13 @@ func GetDeploymentStatusConditions(client client.Client, name, namespace string)
 			// there is a condition that is not ready, return it along with the error
 			err := fmt.Errorf("%s: %s", ErrMsgDeploymentConditionNotReady, condition.Type)
 			errCondition := NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusDeploymentNotReadyReason, err.Error())
-			return []toolchainv1alpha1.Condition{*errCondition}, err
+			return []toolchainv1alpha1.Condition{*errCondition}
 		}
 	}
 
 	// no problems with the deployment, return a ready condition
 	deploymentReadyCondition := NewComponentReadyCondition(toolchainv1alpha1.ToolchainStatusDeploymentReadyReason)
-	return []toolchainv1alpha1.Condition{*deploymentReadyCondition}, nil
+	return []toolchainv1alpha1.Condition{*deploymentReadyCondition}
 }
 
 func DeploymentAvailableCondition() appsv1.DeploymentCondition {

--- a/pkg/status/kubefed.go
+++ b/pkg/status/kubefed.go
@@ -9,10 +9,8 @@ import (
 
 	errs "github.com/pkg/errors"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubefed_common "sigs.k8s.io/kubefed/pkg/apis/core/common"
-	kubefed_v1beta1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	kubefed_util "sigs.k8s.io/kubefed/pkg/controller/util"
 )
 
@@ -30,31 +28,23 @@ type KubefedAttributes struct {
 	Threshold      int64
 }
 
-// GetKubefedConditions uses the provided kubefed attributes to determine kubefed status
-func GetKubefedConditions(attrs KubefedAttributes) (*kubefed_v1beta1.KubeFedClusterStatus, error) {
+// GetKubefedCondition uses the provided kubefed attributes to determine kubefed status
+func GetKubefedCondition(attrs KubefedAttributes) toolchainv1alpha1.Condition {
 	// look up cluster connection status
 	fedCluster, ok := attrs.GetClusterFunc()
 	if !ok {
-		notFoundMsg := ErrMsgClusterConnectionNotFound
-		notFoundReason := toolchainv1alpha1.ToolchainStatusClusterConnectionNotFoundReason
-		badClusterStatus := kubefed_v1beta1.KubeFedClusterStatus{
-			Conditions: []kubefed_v1beta1.ClusterCondition{
-				{
-					Type:          kubefed_common.ClusterReady,
-					Status:        corev1.ConditionFalse,
-					Reason:        &notFoundReason,
-					Message:       &notFoundMsg,
-					LastProbeTime: metav1.Now(),
-				},
-			},
-		}
-		return &badClusterStatus, fmt.Errorf(notFoundMsg)
+		return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotFoundReason, ErrMsgClusterConnectionNotFound)
 	}
-	clusterStatus := *fedCluster.ClusterStatus.DeepCopy()
 
 	// check conditions of cluster connection
 	if !kubefed_util.IsClusterReady(fedCluster.ClusterStatus) {
-		return &clusterStatus, fmt.Errorf("the cluster connection is not ready")
+		for _, c := range fedCluster.ClusterStatus.Conditions {
+			if c.Type == "Ready" {
+				return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, *c.Message)
+			}
+		}
+		genericErrMsg := "the cluster connection is not ready"
+		return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, genericErrMsg)
 	}
 
 	var lastProbeTime metav1.Time
@@ -66,34 +56,24 @@ func GetKubefedConditions(attrs KubefedAttributes) (*kubefed_v1beta1.KubeFedClus
 		}
 	}
 	if !foundLastProbeTime {
-		return &clusterStatus, fmt.Errorf("the time of the last probe could not be determined")
+		lastProbeNotFoundMsg := "the time of the last probe could not be determined"
+		return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, lastProbeNotFoundMsg)
 	}
 
 	// check that the last probe time is within limits. It should be less than (period + timeout) * threshold
-
 	totalf := (attrs.Period.Seconds() + attrs.Timeout.Seconds()) * float64(attrs.Threshold)
 	maxDuration, err := time.ParseDuration(fmt.Sprintf("%fs", totalf))
 	if err != nil {
-		return &clusterStatus, errs.Wrap(err, "the maximum duration since the last probe could not be determined - check the configured values for the kubefed health check period, timeout and failure threshold")
+		invalidLastProbeMsg := "the maximum duration since the last probe could not be determined - check the configured values for the kubefed health check period, timeout and failure threshold"
+		wrappedErr := errs.Wrap(err, invalidLastProbeMsg)
+		return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, wrappedErr.Error())
 	}
 
 	lastProbedTimePlusMaxDuration := lastProbeTime.Add(maxDuration)
 	currentTime := time.Now()
 	if currentTime.After(lastProbedTimePlusMaxDuration) {
 		errMsg := fmt.Sprintf("%s: %s", ErrMsgClusterConnectionLastProbeTimeExceeded, maxDuration.String())
-		errReason := toolchainv1alpha1.ToolchainStatusClusterConnectionLastProbeTimeExceededReason
-		badProbeCondition := kubefed_v1beta1.KubeFedClusterStatus{
-			Conditions: []kubefed_v1beta1.ClusterCondition{
-				{
-					Type:          kubefed_common.ClusterReady,
-					Status:        corev1.ConditionFalse,
-					Reason:        &errReason,
-					Message:       &errMsg,
-					LastProbeTime: lastProbeTime,
-				},
-			},
-		}
-		return &badProbeCondition, fmt.Errorf(errMsg)
+		return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionLastProbeTimeExceededReason, errMsg)
 	}
-	return &clusterStatus, nil
+	return *NewComponentReadyCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionReadyReason)
 }

--- a/pkg/status/kubefed.go
+++ b/pkg/status/kubefed.go
@@ -39,7 +39,7 @@ func GetKubefedCondition(attrs KubefedAttributes) toolchainv1alpha1.Condition {
 	// check conditions of cluster connection
 	if !kubefed_util.IsClusterReady(fedCluster.ClusterStatus) {
 		for _, c := range fedCluster.ClusterStatus.Conditions {
-			if c.Type == "Ready" {
+			if c.Type == "Ready" && c.Message != nil {
 				return *NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, *c.Message)
 			}
 		}

--- a/pkg/status/kubefed_test.go
+++ b/pkg/status/kubefed_test.go
@@ -25,7 +25,7 @@ func TestGetKubefedConditions(t *testing.T) {
 				Timeout:        3 * time.Second,
 				Threshold:      3,
 			}
-			conditions := []toolchainv1alpha1.Condition{GetKubefedCondition(readyAttrs)}
+			conditions := GetKubefedConditions(readyAttrs)
 			err := ValidateComponentConditionReady(conditions...)
 			assert.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestGetKubefedConditions(t *testing.T) {
 				Timeout:        3 * time.Second,
 				Threshold:      3,
 			}
-			conditions := []toolchainv1alpha1.Condition{GetKubefedCondition(readyAttrs)}
+			conditions := GetKubefedConditions(readyAttrs)
 			err := ValidateComponentConditionReady(conditions...)
 			assert.Error(t, err)
 			assert.Equal(t, msg, err.Error())
@@ -70,7 +70,7 @@ func TestGetKubefedConditions(t *testing.T) {
 				Timeout:        3 * time.Second,
 				Threshold:      3,
 			}
-			conditions := []toolchainv1alpha1.Condition{GetKubefedCondition(readyAttrs)}
+			conditions := GetKubefedConditions(readyAttrs)
 			err := ValidateComponentConditionReady(conditions...)
 			assert.Error(t, err)
 			assert.Equal(t, msg, err.Error())
@@ -93,7 +93,7 @@ func TestGetKubefedConditions(t *testing.T) {
 				Timeout:        3 * time.Second,
 				Threshold:      3,
 			}
-			conditions := []toolchainv1alpha1.Condition{GetKubefedCondition(readyAttrs)}
+			conditions := GetKubefedConditions(readyAttrs)
 			err := ValidateComponentConditionReady(conditions...)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), msg)


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-729

Use toolchainv1alpha1.Condition type for kubefed conditions so that all toolchain components can report their status using the same condition types for a uniform implementation.

Errors do not need to be returned with the conditions because they are already included in the conditions.

Related PRs:
https://github.com/codeready-toolchain/member-operator/pull/181
https://github.com/codeready-toolchain/host-operator/pull/254