### PR TITLE
chore: Move predicate from member repo to toolchain-common

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -1,0 +1,51 @@
+package predicate
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var log = logf.Log.WithName("generation_not_changed_predicate").WithName("eventFilters")
+
+// OnlyUpdateWhenGenerationNotChanged implements a default update predicate function on no generation change
+// (adapted from sigs.k8s.io/controller-runtime/pkg/predicate/predicate.ResourceVersionChangedPredicate)
+// other predicate functions return false for all cases
+// Copied and slightly modified from github.com/operator-framework/operator-sdk/pkg/predicate/predicate.go
+type OnlyUpdateWhenGenerationNotChanged struct {
+}
+
+// Update implements default UpdateEvent filter for validating no generation change
+func (OnlyUpdateWhenGenerationNotChanged) Update(e event.UpdateEvent) bool {
+	if e.MetaOld == nil {
+		log.Error(nil, "Update event has no old metadata", "event", e)
+		return false
+	}
+	if e.ObjectOld == nil {
+		log.Error(nil, "Update event has no old runtime object to update", "event", e)
+		return false
+	}
+	if e.ObjectNew == nil {
+		log.Error(nil, "Update event has no new runtime object for update", "event", e)
+		return false
+	}
+	if e.MetaNew == nil {
+		log.Error(nil, "Update event has no new metadata", "event", e)
+		return false
+	}
+	return e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration()
+}
+
+// Create implements Predicate
+func (OnlyUpdateWhenGenerationNotChanged) Create(e event.CreateEvent) bool {
+	return false
+}
+
+// Delete implements Predicate
+func (OnlyUpdateWhenGenerationNotChanged) Delete(e event.DeleteEvent) bool {
+	return false
+}
+
+// Generic implements Predicate
+func (OnlyUpdateWhenGenerationNotChanged) Generic(e event.GenericEvent) bool {
+	return false
+}

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -1,0 +1,101 @@
+package predicate
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var predicate = OnlyUpdateWhenGenerationNotChanged{}
+
+func TestPredicateUpdateShouldReturnFalseBecauseOfMissingData(t *testing.T) {
+	// given
+	updateEvents := []event.UpdateEvent{
+		{},
+		{MetaNew: &metav1.ObjectMeta{}, MetaOld: &metav1.ObjectMeta{},
+			ObjectNew: &v1alpha1.UserAccount{}},
+		{MetaNew: &metav1.ObjectMeta{}, MetaOld: &metav1.ObjectMeta{},
+			ObjectOld: &v1alpha1.UserAccount{}},
+		{MetaNew: &metav1.ObjectMeta{}, ObjectOld: &v1alpha1.UserAccount{},
+			ObjectNew: &v1alpha1.UserAccount{}},
+		{ObjectNew: &v1alpha1.UserAccount{}, MetaOld: &metav1.ObjectMeta{},
+			ObjectOld: &v1alpha1.UserAccount{}}}
+
+	for _, event := range updateEvents {
+		// when
+		ok := predicate.Update(event)
+
+		// then
+		assert.False(t, ok)
+	}
+}
+
+func TestPredicateUpdateShouldReturnFalseAsGenerationChanged(t *testing.T) {
+	// given
+	updateEvent := event.UpdateEvent{
+		MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		MetaOld:   &metav1.ObjectMeta{Generation: int64(987654321)},
+		ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+
+	// when
+	ok := predicate.Update(updateEvent)
+
+	// then
+	assert.False(t, ok)
+}
+
+func TestPredicateUpdateShouldReturnTrueAsGenerationNotChanged(t *testing.T) {
+	// given
+	updateEvent := event.UpdateEvent{
+		MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		MetaOld:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+
+	// when
+	ok := predicate.Update(updateEvent)
+
+	// then
+	assert.True(t, ok)
+}
+
+func TestPredicateCreateShouldReturnFalse(t *testing.T) {
+	// given
+	createEvent := event.CreateEvent{
+		Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		Object: &v1alpha1.UserAccount{}}
+
+	// when
+	ok := predicate.Create(createEvent)
+
+	// then
+	assert.False(t, ok)
+}
+
+func TestPredicateDeleteShouldReturnFalse(t *testing.T) {
+	// given
+	deleteEvent := event.DeleteEvent{
+		Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		Object: &v1alpha1.UserAccount{}}
+
+	// when
+	ok := predicate.Delete(deleteEvent)
+
+	// then
+	assert.False(t, ok)
+}
+
+func TestPredicateGenericShouldReturnFalse(t *testing.T) {
+	// given
+	genericEvent := event.GenericEvent{
+		Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
+		Object: &v1alpha1.UserAccount{}}
+
+	// when
+	ok := predicate.Generic(genericEvent)
+
+	// then
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Move predicate package from member repo to toolchain-common so that it can be used by the host operator controllers as well.