### PR TITLE
chore: drop capacity exhausted flag and extract cluster filter logic

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -38,9 +38,6 @@ type CachedToolchainCluster struct {
 	// then the OwnerClusterName has a name of the member - it has to be same name as the name
 	// that is used for identifying the member in a Host cluster
 	OwnerClusterName string
-	// CapacityExhausted a flag to indicate that the cluster capacity has exhausted
-	// and it cannot be used to provision new user accounts.
-	CapacityExhausted bool
 }
 
 func (c *toolchainClusterClients) addCachedToolchainCluster(cluster *CachedToolchainCluster) {
@@ -74,11 +71,6 @@ type Condition func(cluster *CachedToolchainCluster) bool
 // Ready checks that the cluster is in a 'Ready' status condition
 var Ready Condition = func(cluster *CachedToolchainCluster) bool {
 	return IsReady(cluster.ClusterStatus)
-}
-
-// CapacityNotExhausted checks that the cluster capacity has not exhausted
-var CapacityNotExhausted Condition = func(cluster *CachedToolchainCluster) bool {
-	return !cluster.CapacityExhausted
 }
 
 func (c *toolchainClusterClients) getCachedToolchainClustersByType(clusterType Type, conditions ...Condition) []*CachedToolchainCluster {

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -84,19 +84,22 @@ var CapacityNotExhausted Condition = func(cluster *CachedToolchainCluster) bool 
 func (c *toolchainClusterClients) getCachedToolchainClustersByType(clusterType Type, conditions ...Condition) []*CachedToolchainCluster {
 	c.RLock()
 	defer c.RUnlock()
-	clusters := make([]*CachedToolchainCluster, 0, len(c.clusters))
+	return Filter(clusterType, c.clusters, conditions...)
+}
+func Filter(clusterType Type, clusters map[string]*CachedToolchainCluster, conditions ...Condition) []*CachedToolchainCluster {
+	filteredClusters := make([]*CachedToolchainCluster, 0, len(clusters))
 clusters:
-	for _, cluster := range c.clusters {
+	for _, cluster := range clusters {
 		if cluster.Type == clusterType {
 			for _, match := range conditions {
 				if !match(cluster) {
 					continue clusters
 				}
 			}
-			clusters = append(clusters, cluster)
+			filteredClusters = append(filteredClusters, cluster)
 		}
 	}
-	return clusters
+	return filteredClusters
 }
 
 // GetCachedToolchainCluster returns a kube client for the cluster (with the given name) and info if the client exists

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -208,34 +208,10 @@ func TestGetClustersByType(t *testing.T) {
 		clusterCache.addCachedToolchainCluster(member2)
 		member3 := newTestCachedToolchainCluster(t, "cluster-3", Member, notReady)
 		clusterCache.addCachedToolchainCluster(member3)
-		member4 := newTestCachedToolchainCluster(t, "cluster-4", Member, ready, capacityExhausted)
-		clusterCache.addCachedToolchainCluster(member4)
 
 		t.Run("get only ready member clusters", func(t *testing.T) {
 			//when
 			clusters := GetMemberClusters(Ready)
-
-			//then
-			assert.Len(t, clusters, 3)
-			assert.Contains(t, clusters, member1)
-			assert.Contains(t, clusters, member2)
-			assert.Contains(t, clusters, member4)
-		})
-
-		t.Run("get only member clusters with free capacity", func(t *testing.T) {
-			//when
-			clusters := GetMemberClusters(CapacityNotExhausted)
-
-			//then
-			assert.Len(t, clusters, 3)
-			assert.Contains(t, clusters, member1)
-			assert.Contains(t, clusters, member2)
-			assert.Contains(t, clusters, member3)
-		})
-
-		t.Run("get only ready member clusters that have free capacity", func(t *testing.T) {
-			//when
-			clusters := GetMemberClusters(Ready, CapacityNotExhausted)
 
 			//then
 			assert.Len(t, clusters, 2)
@@ -461,11 +437,6 @@ var notReady clusterOption = func(c *CachedToolchainCluster) {
 	})
 }
 
-// capacityExhausted an option to state that the cluster capacity has exhausted
-var capacityExhausted clusterOption = func(c *CachedToolchainCluster) {
-	c.CapacityExhausted = true
-}
-
 func newTestCachedToolchainCluster(t *testing.T, name string, clusterType Type, options ...clusterOption) *CachedToolchainCluster {
 	cl := test.NewFakeClient(t)
 	cachedCluster := &CachedToolchainCluster{
@@ -473,7 +444,6 @@ func newTestCachedToolchainCluster(t *testing.T, name string, clusterType Type, 
 		Client:            cl,
 		OperatorNamespace: name + "Namespace",
 		Type:              clusterType,
-		CapacityExhausted: false,
 		ClusterStatus:     &v1alpha1.ToolchainClusterStatus{},
 	}
 	for _, configure := range options {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"encoding/base64"
-	"strconv"
 	"time"
 
 	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
@@ -17,10 +16,9 @@ import (
 )
 
 const (
-	labelType              = "type"
-	labelNamespace         = "namespace"
-	labelOwnerClusterName  = "ownerClusterName"
-	labelCapacityExhausted = "toolchain.dev.openshift.com/capacity-exhausted"
+	labelType             = "type"
+	labelNamespace        = "namespace"
+	labelOwnerClusterName = "ownerClusterName"
 
 	defaultHostOperatorNamespace   = "toolchain-host-operator"
 	defaultMemberOperatorNamespace = "toolchain-member-operator"
@@ -75,13 +73,6 @@ func (s *ToolchainClusterService) addToolchainCluster(toolchainCluster *v1alpha1
 		return errors.Wrap(err, "cannot create ToolchainCluster client")
 	}
 
-	capacityExhausted := false
-	if c, exists := toolchainCluster.Labels[labelCapacityExhausted]; exists {
-		capacityExhausted, err = strconv.ParseBool(c)
-		if err != nil {
-			return errors.Wrap(err, "cannot create ToolchainCluster client")
-		}
-	}
 	cluster := &CachedToolchainCluster{
 		Name:              toolchainCluster.Name,
 		APIEndpoint:       toolchainCluster.Spec.APIEndpoint,
@@ -91,7 +82,6 @@ func (s *ToolchainClusterService) addToolchainCluster(toolchainCluster *v1alpha1
 		Type:              Type(toolchainCluster.Labels[labelType]),
 		OperatorNamespace: toolchainCluster.Labels[labelNamespace],
 		OwnerClusterName:  toolchainCluster.Labels[labelOwnerClusterName],
-		CapacityExhausted: capacityExhausted,
 	}
 	if cluster.Type == "" {
 		cluster.Type = Member

--- a/pkg/test/hostoperatorconfig.go
+++ b/pkg/test/hostoperatorconfig.go
@@ -1,0 +1,97 @@
+package test
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type HostOperatorConfigOptionFunc func(config *toolchainv1alpha1.HostOperatorConfig)
+
+type HostOperatorConfigOption interface {
+	Apply(config *toolchainv1alpha1.HostOperatorConfig)
+}
+
+type HostOperatorConfigOptionImpl struct {
+	toApply []HostOperatorConfigOptionFunc
+}
+
+func (option *HostOperatorConfigOptionImpl) Apply(config *toolchainv1alpha1.HostOperatorConfig) {
+	for _, apply := range option.toApply {
+		apply(config)
+	}
+}
+
+func (option *HostOperatorConfigOptionImpl) addFunction(funcToAdd HostOperatorConfigOptionFunc) {
+	option.toApply = append(option.toApply, funcToAdd)
+}
+
+type AutomaticApprovalOption struct {
+	*HostOperatorConfigOptionImpl
+}
+
+func AutomaticApproval() *AutomaticApprovalOption {
+	o := &AutomaticApprovalOption{
+		HostOperatorConfigOptionImpl: &HostOperatorConfigOptionImpl{},
+	}
+	o.addFunction(func(config *toolchainv1alpha1.HostOperatorConfig) {
+		config.Spec.AutomaticApproval = toolchainv1alpha1.AutomaticApproval{}
+	})
+	return o
+}
+
+func (o AutomaticApprovalOption) Enabled() AutomaticApprovalOption {
+	o.addFunction(func(config *toolchainv1alpha1.HostOperatorConfig) {
+		config.Spec.AutomaticApproval.Enabled = true
+	})
+	return o
+}
+
+func (o AutomaticApprovalOption) Disabled() AutomaticApprovalOption {
+	o.addFunction(func(config *toolchainv1alpha1.HostOperatorConfig) {
+		config.Spec.AutomaticApproval.Enabled = false
+	})
+	return o
+}
+
+type PerMemberClusterOption func(map[string]int)
+
+func PerMemberCluster(name string, value int) PerMemberClusterOption {
+	return func(clusters map[string]int) {
+		clusters[name] = value
+	}
+}
+
+func (o AutomaticApprovalOption) ResourceCapThreshold(defaultThreshold int, perMember ...PerMemberClusterOption) AutomaticApprovalOption {
+	o.addFunction(func(config *toolchainv1alpha1.HostOperatorConfig) {
+		config.Spec.AutomaticApproval.ResourceCapacityThreshold.DefaultThreshold = defaultThreshold
+		config.Spec.AutomaticApproval.ResourceCapacityThreshold.SpecificPerMemberCluster = map[string]int{}
+		for _, add := range perMember {
+			add(config.Spec.AutomaticApproval.ResourceCapacityThreshold.SpecificPerMemberCluster)
+		}
+	})
+	return o
+}
+
+func (o AutomaticApprovalOption) MaxUsersNumber(overall int, perMember ...PerMemberClusterOption) AutomaticApprovalOption {
+	o.addFunction(func(config *toolchainv1alpha1.HostOperatorConfig) {
+		config.Spec.AutomaticApproval.MaxNumberOfUsers.Overall = overall
+		config.Spec.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster = map[string]int{}
+		for _, add := range perMember {
+			add(config.Spec.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster)
+		}
+	})
+	return o
+}
+
+func NewHostOperatorConfig(options ...HostOperatorConfigOption) *toolchainv1alpha1.HostOperatorConfig {
+	hostOperatorConfig := &toolchainv1alpha1.HostOperatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: HostOperatorNs,
+			Name:      "config",
+		},
+	}
+	for _, option := range options {
+		option.Apply(hostOperatorConfig)
+	}
+	return hostOperatorConfig
+}


### PR DESCRIPTION
Drop the capacity exhausted flag from the `ToolchainCluster` - this is replaced by setting the capacity thresholds in `HostOperatorConfig`
It also extracts the cluster filter logic to an exported function so it can be used outside of this project/package