### PR TITLE
fix: delete role binding before creating

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -23,6 +23,9 @@ login_to_cluster() {
 }
 
 create_service_account() {
+# we need to delete the bindings since we cannot change the roleRef of the existing bindings
+oc delete rolebinding ${SA_NAME} -n ${OPERATOR_NS}
+oc delete clusterrolebinding ${SA_NAME}
 cat <<EOF | oc apply -f -
 ---
 apiVersion: v1


### PR DESCRIPTION
We need to delete the bindings since we cannot change the `roleRef` of the existing bindings - running the script twice fails with: 
```
for: "STDIN": RoleBinding.rbac.authorization.k8s.io "toolchaincluster-host-operator" is invalid: roleRef: Invalid value: rbac.RoleRef{APIGroup:"rbac.authorization.k8s.io", Kind:"Role", Name:"toolchaincluster-host-operator"}: cannot change roleRef
```