### PR TITLE
chore: pull centos7 image from quay.io/app-sre instead of hub.docker.com

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM centos:7 as build-tools
+FROM quay.io/app-sre/centos:7 as build-tools
 
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"


### PR DESCRIPTION
same as https://github.com/codeready-toolchain/host-operator/pull/346

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
