### PR TITLE
Use centos7 image from centos organization

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/centos:7 as build-tools
+FROM quay.io/centos/centos:7 as build-tools
 
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"


### PR DESCRIPTION
Use centos7 image from centos organization since the app-sre org's mirror isn't working anymore