### PR TITLE
refactor: use options to create or update object

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -84,6 +84,16 @@ func SaveConfiguration(saveConfiguration bool) ApplyObjectOption {
 // The return boolean says if the object was either created or updated (`true`). If nothing changed (ie, the generation was not
 // incremented by the server), then it returns `false`.
 func (p ApplyClient) ApplyObject(obj runtime.Object, options ...ApplyObjectOption) (bool, error) {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	createdOrUpdated, err := p.applyObject(obj, options...)
+	if err != nil {
+		return createdOrUpdated, errors.Wrapf(err, "unable to create resource of kind: %s, version: %s", gvk.Kind, gvk.Version)
+	}
+	return createdOrUpdated, nil
+}
+
+func (p ApplyClient) applyObject(obj runtime.Object, options ...ApplyObjectOption) (bool, error) {
+	// gets the meta accessor to the new resource
 	// gets the meta accessor to the new resource
 	metaNew, err := meta.Accessor(obj)
 	if err != nil {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -79,12 +79,12 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					_, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					createdOrChanged, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -97,12 +97,12 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					_, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 					obj.Spec.ClusterIP = "" // modify for version to update
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					createdOrChanged, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -116,14 +116,14 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					_, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the modified obj
 					modifiedObj := modifiedService.DeepCopy()
 					modifiedObj.Spec.ClusterIP = ""
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
+					createdOrChanged, err := cl.ApplyObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -137,14 +137,14 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					_, err := cl.ApplyObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the modified obj
 					modifiedObj := modifiedService.DeepCopy()
 					modifiedObj.Spec.ClusterIP = ""
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
+					createdOrChanged, err := cl.ApplyObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestApplySingle(t *testing.T) {
 					cl, cli := newClient(t, s)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.ForceUpdate(true), client.SetOwner(&appsv1.Deployment{}))
+					createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject(), client.ForceUpdate(true), client.SetOwner(&appsv1.Deployment{}))
 
 					// then
 					require.NoError(t, err)
@@ -178,11 +178,11 @@ func TestApplySingle(t *testing.T) {
 				t.Run("it should update when spec is different", func(t *testing.T) {
 					// given
 					cl, cli := newClient(t, s)
-					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
+					_, err := cl.ApplyObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
 					require.NoError(t, err)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject())
+					createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject())
 
 					// then
 					require.NoError(t, err)
@@ -196,11 +196,11 @@ func TestApplySingle(t *testing.T) {
 				t.Run("it should not update when using same object", func(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
-					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
+					_, err := cl.ApplyObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
 					require.NoError(t, err)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject())
+					createdOrChanged, err := cl.ApplyObject(defaultService.DeepCopyObject())
 
 					// then
 					require.NoError(t, err)
@@ -212,7 +212,7 @@ func TestApplySingle(t *testing.T) {
 					cl, cli := newClient(t, s)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SetOwner(&appsv1.Deployment{}))
+					createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject(), client.SetOwner(&appsv1.Deployment{}))
 
 					// then
 					require.NoError(t, err)
@@ -232,7 +232,7 @@ func TestApplySingle(t *testing.T) {
 					cl, cli := newClient(t, s)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
+					createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
 
 					// then
 					require.NoError(t, err)
@@ -247,11 +247,11 @@ func TestApplySingle(t *testing.T) {
 				t.Run("it should update when spec is different", func(t *testing.T) {
 					// given
 					cl, cli := newClient(t, s)
-					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.SaveConfiguration(false))
+					_, err := cl.ApplyObject(defaultService.DeepCopyObject(), client.SaveConfiguration(false))
 					require.NoError(t, err)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
+					createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
 
 					// then
 					require.NoError(t, err)
@@ -272,7 +272,7 @@ func TestApplySingle(t *testing.T) {
 				}
 
 				// when
-				createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject())
+				createdOrChanged, err := cl.ApplyObject(modifiedService.DeepCopyObject())
 
 				// then
 				require.Error(t, err)
@@ -295,14 +295,14 @@ func TestApplySingle(t *testing.T) {
 					obj, err := toUnstructured(defaultService.DeepCopy())
 
 					require.NoError(t, err)
-					_, err = cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
+					_, err = cl.ApplyObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					modifiedObj := obj.DeepCopy()
 					err = unstructured.SetNestedField(modifiedObj.Object, "", "spec", "clusterIP") // modify for version to update
 					require.NoError(t, err)
 
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
+					createdOrChanged, err := cl.ApplyObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -322,11 +322,11 @@ func TestApplySingle(t *testing.T) {
 		t.Run("it should update ConfigMap when data field is different and forceUpdate=false", func(t *testing.T) {
 			// given
 			cl, cli := newClient(t, s)
-			_, err := cl.CreateOrUpdateObject(defaultCm.DeepCopyObject(), client.ForceUpdate(true))
+			_, err := cl.ApplyObject(defaultCm.DeepCopyObject(), client.ForceUpdate(true))
 			require.NoError(t, err)
 
 			// when
-			createdOrChanged, err := cl.CreateOrUpdateObject(modifiedCm.DeepCopyObject())
+			createdOrChanged, err := cl.ApplyObject(modifiedCm.DeepCopyObject())
 
 			// then
 			require.NoError(t, err)
@@ -533,7 +533,7 @@ func TestProcessAndApply(t *testing.T) {
 		labels := newLabels("", "john", "")
 
 		// when
-		createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 
 		// then
 		require.NoError(t, err)
@@ -553,7 +553,7 @@ func TestProcessAndApply(t *testing.T) {
 		labels := newLabels("basic", "john", "dev")
 
 		// when
-		createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 
 		// then
 		require.NoError(t, err)
@@ -573,7 +573,7 @@ func TestProcessAndApply(t *testing.T) {
 		labels := newLabels("", "john", "dev")
 
 		// when
-		createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 
 		// then
 		require.NoError(t, err)
@@ -602,7 +602,7 @@ func TestProcessAndApply(t *testing.T) {
 		require.NoError(t, err)
 		witoutType := newLabels("basic", "john", "")
 
-		createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, witoutType)
+		createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, witoutType)
 		require.NoError(t, err)
 		assert.True(t, createdOrUpdated)
 		assertRoleBindingExists(t, cl, user, witoutType)
@@ -614,7 +614,7 @@ func TestProcessAndApply(t *testing.T) {
 		objs, err = p.Process(tmpl, values)
 		require.NoError(t, err)
 		complete := newLabels("advanced", "john", "dev")
-		createdOrUpdated, err = client.NewApplyClient(cl, s).Apply(objs, complete)
+		createdOrUpdated, err = client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, complete)
 
 		// then
 		require.NoError(t, err)
@@ -637,14 +637,14 @@ func TestProcessAndApply(t *testing.T) {
 		objs, err := p.Process(tmpl, values)
 		require.NoError(t, err)
 		labels := newLabels("basic", "john", "dev")
-		created, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		created, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 		require.NoError(t, err)
 		assert.True(t, created)
 		assertNamespaceExists(t, cl, user, labels, commit)
 		assertRoleBindingExists(t, cl, user, labels)
 
 		// when apply the same template again
-		updated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		updated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 
 		// then
 		require.NoError(t, err)
@@ -667,7 +667,7 @@ func TestProcessAndApply(t *testing.T) {
 			// when
 			objs, err := p.Process(tmpl, values)
 			require.NoError(t, err)
-			createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, newLabels("", "", ""))
+			createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, newLabels("", "", ""))
 
 			// then
 			require.Error(t, err)
@@ -687,7 +687,7 @@ func TestProcessAndApply(t *testing.T) {
 			objs, err := p.Process(tmpl, values)
 			require.NoError(t, err)
 			labels := newLabels("", "", "")
-			createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+			createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 			require.NoError(t, err)
 			assert.True(t, createdOrUpdated)
 
@@ -697,7 +697,7 @@ func TestProcessAndApply(t *testing.T) {
 			require.NoError(t, err)
 			objs, err = p.Process(tmpl, values)
 			require.NoError(t, err)
-			createdOrUpdated, err = client.NewApplyClient(cl, s).Apply(objs, newLabels("advanced", "john", "dev"))
+			createdOrUpdated, err = client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, newLabels("advanced", "john", "dev"))
 
 			// then
 			assert.Error(t, err)
@@ -729,7 +729,7 @@ func TestProcessAndApply(t *testing.T) {
 			},
 		})
 		labels := newLabels("basic", "john", "dev")
-		createdOrUpdated, err := client.NewApplyClient(cl, s).Apply(objs, labels)
+		createdOrUpdated, err := client.NewApplyClient(cl, s).ApplyToolchainObjects(objs, labels)
 
 		// then
 		require.NoError(t, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -79,12 +79,12 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, true, nil)
+					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(obj, true, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -97,12 +97,12 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, true, nil)
+					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 					obj.Spec.ClusterIP = "" // modify for version to update
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(obj, true, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -116,34 +116,35 @@ func TestApplySingle(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, true, nil)
+					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the modified obj
 					modifiedObj := modifiedService.DeepCopy()
 					modifiedObj.Spec.ClusterIP = ""
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, true, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
 					assert.True(t, createdOrChanged) // resource was updated on the server, so returned value if `true`
 					updateGeneration := modifiedObj.GetGeneration()
 					assert.Equal(t, originalGeneration+1, updateGeneration)
+					assert.NotEmpty(t, modifiedObj.Annotations[client.LastAppliedConfigurationAnnotationKey])
 				})
 
 				t.Run("it should update when specs are different including ClusterIP", func(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
 					obj := defaultService.DeepCopy()
-					_, err := cl.CreateOrUpdateObject(obj, true, nil)
+					_, err := cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					originalGeneration := obj.GetGeneration()
 
 					// when updating with the modified obj
 					modifiedObj := modifiedService.DeepCopy()
 					modifiedObj.Spec.ClusterIP = ""
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, true, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -158,7 +159,7 @@ func TestApplySingle(t *testing.T) {
 					cl, cli := newClient(t, s)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), true, &appsv1.Deployment{})
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.ForceUpdate(true), client.SetOwner(&appsv1.Deployment{}))
 
 					// then
 					require.NoError(t, err)
@@ -168,6 +169,7 @@ func TestApplySingle(t *testing.T) {
 					require.NoError(t, err)
 					assert.Equal(t, "all-services", service.Spec.Selector["run"])
 					assert.NotEmpty(t, service.OwnerReferences)
+					assert.NotEmpty(t, service.Annotations[client.LastAppliedConfigurationAnnotationKey])
 				})
 			})
 
@@ -176,11 +178,11 @@ func TestApplySingle(t *testing.T) {
 				t.Run("it should update when spec is different", func(t *testing.T) {
 					// given
 					cl, cli := newClient(t, s)
-					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), true, nil)
+					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
 					require.NoError(t, err)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), false, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject())
 
 					// then
 					require.NoError(t, err)
@@ -194,11 +196,11 @@ func TestApplySingle(t *testing.T) {
 				t.Run("it should not update when using same object", func(t *testing.T) {
 					// given
 					cl, _ := newClient(t, s)
-					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), true, nil)
+					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.ForceUpdate(true))
 					require.NoError(t, err)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), false, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject())
 
 					// then
 					require.NoError(t, err)
@@ -210,7 +212,7 @@ func TestApplySingle(t *testing.T) {
 					cl, cli := newClient(t, s)
 
 					// when
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), false, &appsv1.Deployment{})
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SetOwner(&appsv1.Deployment{}))
 
 					// then
 					require.NoError(t, err)
@@ -223,6 +225,45 @@ func TestApplySingle(t *testing.T) {
 				})
 			})
 
+			t.Run("when not saving the configuration", func(t *testing.T) {
+
+				t.Run("when object is missing, it should create it", func(t *testing.T) {
+					// given
+					cl, cli := newClient(t, s)
+
+					// when
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
+
+					// then
+					require.NoError(t, err)
+					assert.True(t, createdOrChanged)
+					service := &corev1.Service{}
+					err = cli.Get(context.TODO(), namespacedName, service)
+					require.NoError(t, err)
+					assert.Equal(t, "all-services", service.Spec.Selector["run"])
+					assert.Empty(t, service.Annotations[client.LastAppliedConfigurationAnnotationKey])
+				})
+
+				t.Run("it should update when spec is different", func(t *testing.T) {
+					// given
+					cl, cli := newClient(t, s)
+					_, err := cl.CreateOrUpdateObject(defaultService.DeepCopyObject(), client.SaveConfiguration(false))
+					require.NoError(t, err)
+
+					// when
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), client.SaveConfiguration(false))
+
+					// then
+					require.NoError(t, err)
+					assert.True(t, createdOrChanged)
+					service := &corev1.Service{}
+					err = cli.Get(context.TODO(), namespacedName, service)
+					require.NoError(t, err)
+					assert.Equal(t, "all-services", service.Spec.Selector["run"])
+					assert.Empty(t, service.Annotations[client.LastAppliedConfigurationAnnotationKey])
+				})
+			})
+
 			t.Run("when object cannot be retrieved because of any error, then it should fail", func(t *testing.T) {
 				// given
 				cl, cli := newClient(t, s)
@@ -231,7 +272,7 @@ func TestApplySingle(t *testing.T) {
 				}
 
 				// when
-				createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject(), false, nil)
+				createdOrChanged, err := cl.CreateOrUpdateObject(modifiedService.DeepCopyObject())
 
 				// then
 				require.Error(t, err)
@@ -254,14 +295,14 @@ func TestApplySingle(t *testing.T) {
 					obj, err := toUnstructured(defaultService.DeepCopy())
 
 					require.NoError(t, err)
-					_, err = cl.CreateOrUpdateObject(obj, true, nil)
+					_, err = cl.CreateOrUpdateObject(obj, client.ForceUpdate(true))
 					require.NoError(t, err)
 					modifiedObj := obj.DeepCopy()
 					err = unstructured.SetNestedField(modifiedObj.Object, "", "spec", "clusterIP") // modify for version to update
 					require.NoError(t, err)
 
 					// when updating with the same obj again
-					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, true, nil)
+					createdOrChanged, err := cl.CreateOrUpdateObject(modifiedObj, client.ForceUpdate(true))
 
 					// then
 					require.NoError(t, err)
@@ -281,11 +322,11 @@ func TestApplySingle(t *testing.T) {
 		t.Run("it should update ConfigMap when data field is different and forceUpdate=false", func(t *testing.T) {
 			// given
 			cl, cli := newClient(t, s)
-			_, err := cl.CreateOrUpdateObject(defaultCm.DeepCopyObject(), true, nil)
+			_, err := cl.CreateOrUpdateObject(defaultCm.DeepCopyObject(), client.ForceUpdate(true))
 			require.NoError(t, err)
 
 			// when
-			createdOrChanged, err := cl.CreateOrUpdateObject(modifiedCm.DeepCopyObject(), false, nil)
+			createdOrChanged, err := cl.CreateOrUpdateObject(modifiedCm.DeepCopyObject())
 
 			// then
 			require.NoError(t, err)


### PR DESCRIPTION
move the `owner` and `forceUpdate` parameters as options,
add add an option to avoid saving the configuration
(which causes troubles when the resource is too big, for example,
a ConfigMap with large JSON files)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
