### PR TITLE
fix: split role for toolchain-cluster SAs

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -36,14 +36,17 @@ create_service_account() {
 if [[ -n `oc get rolebinding ${SA_NAME} 2>/dev/null` ]]; then
     oc delete rolebinding ${SA_NAME} -n ${OPERATOR_NS} ${OC_ADDITIONAL_PARAMS}
 fi
+
 cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ${SA_NAME}
   namespace: ${OPERATOR_NS}
----
+EOF
+
+if [[ ${JOINING_CLUSTER_TYPE} == "host" ]]; then
+    cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -56,22 +59,40 @@ rules:
   - "bannedusers"
   - "changetierrequests"
   - "hostoperatorconfigs"
-  - "idlers"
   - "masteruserrecords"
-  - "memberstatuses"
   - "notifications"
-  - "nstemplatesets"
   - "nstemplatetiers"
   - "registrationservices"
   - "templateupdaterequests"
   - "tiertemplates"
   - "toolchainclusters"
   - "toolchainstatuses"
-  - "useraccounts"
   - "usersignups"
   verbs:
   - "*"
----
+EOF
+else
+    cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${SA_NAME}
+  namespace: ${OPERATOR_NS}
+rules:
+- apiGroups:
+  - toolchain.dev.openshift.com
+  resources:
+  - "idlers"
+  - "nstemplatesets"
+  - "memberstatuses"
+  - "toolchainclusters"
+  - "useraccounts"
+  verbs:
+  - "*"
+EOF
+fi
+
+cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:


### PR DESCRIPTION
We cannot create Role for non-existing resource kinds in member cluster in OSD. 
I'm referring to the new member cluster where we install only member operator and not the host one - that means that we don't have host CRDs available there