### PR TITLE
Add new labels and generation predicate

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -80,12 +80,6 @@ func (LabelsAndGenerationPredicate) Update(e event.UpdateEvent) bool {
 	}
 
 	// reconcile if the labels have changed
-	if !reflect.DeepEqual(e.MetaOld.GetLabels(), e.MetaNew.GetLabels()) {
-		return true
-	}
-
-	if e.MetaNew.GetGeneration() == e.MetaOld.GetGeneration() && e.MetaNew.GetGeneration() != 0 {
-		return false
-	}
-	return true
+	return !reflect.DeepEqual(e.MetaOld.GetLabels(), e.MetaNew.GetLabels()) ||
+		e.MetaNew.GetGeneration() != e.MetaOld.GetGeneration()
 }


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/CRT-941

Adds a new predicate to only reconcile update events if Generation or Labels have changed.