### PR TITLE
Adding to check ApiEndpoint in MemberStatus for host-operator unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-common
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0
+	github.com/codeready-toolchain/api v0.0.0-20210318181858-c1ce5306dc21
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-common
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101
+	github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-logr/logr v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101 h1:oKHlw3jQXcMX8AbAlCdzn8ZS58jnGtjT7ItG5oaistM=
-github.com/codeready-toolchain/api v0.0.0-20210203025716-45f19e752101/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0 h1:V09dogUp3PogMrf0PWndjU4QLLI1tf9btDiTfb9eMDc=
+github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0 h1:V09dogUp3PogMrf0PWndjU4QLLI1tf9btDiTfb9eMDc=
-github.com/codeready-toolchain/api v0.0.0-20210313003646-9a89a8e824b0/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
+github.com/codeready-toolchain/api v0.0.0-20210318181858-c1ce5306dc21 h1:1LBWYGO8gm82epmqhu6u7x+sHlAJ8s3aBPPsGVfut1s=
+github.com/codeready-toolchain/api v0.0.0-20210318181858-c1ce5306dc21/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/test/condition.go
+++ b/pkg/test/condition.go
@@ -17,7 +17,7 @@ import (
 // because the LastTransitionTime of the actual conditions can be modified but the conditions
 // still should be treated as matched
 func AssertConditionsMatch(t T, actual []toolchainv1alpha1.Condition, expected ...toolchainv1alpha1.Condition) {
-	t.Logf("actual vs expected conditions: '%v' / '%v'", actual, expected)
+	//t.Logf("actual vs expected conditions: '%v' / '%v'", actual, expected)
 	require.Equal(t, len(expected), len(actual))
 	for _, c := range expected {
 		AssertContainsCondition(t, actual, c)

--- a/pkg/test/condition.go
+++ b/pkg/test/condition.go
@@ -17,7 +17,7 @@ import (
 // because the LastTransitionTime of the actual conditions can be modified but the conditions
 // still should be treated as matched
 func AssertConditionsMatch(t T, actual []toolchainv1alpha1.Condition, expected ...toolchainv1alpha1.Condition) {
-	//t.Logf("actual vs expected conditions: '%v' / '%v'", actual, expected)
+	t.Logf("actual vs expected conditions: '%v' / '%v'", actual, expected)
 	require.Equal(t, len(expected), len(actual))
 	for _, c := range expected {
 		AssertContainsCondition(t, actual, c)

--- a/pkg/test/status.go
+++ b/pkg/test/status.go
@@ -38,6 +38,7 @@ func AssertContainsMember(t T, members []toolchainv1alpha1.Member, contains tool
 		if c.ClusterName == contains.ClusterName {
 			t.Logf("checking '%s'", c.ClusterName)
 			AssertConditionsMatch(t, c.MemberStatus.Conditions, contains.MemberStatus.Conditions...)
+			assert.Equal(t, contains.MemberStatus.ApiEndpoint, c.MemberStatus.ApiEndpoint)
 			assert.Equal(t, contains.MemberStatus.ResourceUsage, c.MemberStatus.ResourceUsage)
 			assert.Equal(t, contains.UserAccountCount, c.UserAccountCount)
 			return

--- a/pkg/test/status.go
+++ b/pkg/test/status.go
@@ -38,7 +38,7 @@ func AssertContainsMember(t T, members []toolchainv1alpha1.Member, contains tool
 		if c.ClusterName == contains.ClusterName {
 			t.Logf("checking '%s'", c.ClusterName)
 			AssertConditionsMatch(t, c.MemberStatus.Conditions, contains.MemberStatus.Conditions...)
-			assert.Equal(t, contains.MemberStatus.ApiEndpoint, c.MemberStatus.ApiEndpoint)
+			assert.Equal(t, contains.ApiEndpoint, c.ApiEndpoint)
 			assert.Equal(t, contains.MemberStatus.ResourceUsage, c.MemberStatus.ResourceUsage)
 			assert.Equal(t, contains.UserAccountCount, c.UserAccountCount)
 			return


### PR DESCRIPTION
Adding ApiEndpoint compare check in AssertContainsMember - for toolchain status unit tests.

fix related to: https://issues.redhat.com/browse/CRT-971
related PR: https://github.com/codeready-toolchain/host-operator/pull/394