### PR TITLE
Set UserSignup deactivated state to false when approved

### DIFF
--- a/pkg/states/state_manager.go
+++ b/pkg/states/state_manager.go
@@ -17,6 +17,8 @@ func SetApproved(userSignup *v1alpha1.UserSignup, val bool) {
 
 	if val {
 		setState(userSignup, v1alpha1.UserSignupStateVerificationRequired, false)
+		setState(userSignup, v1alpha1.UserSignupStateDeactivating, false)
+		setState(userSignup, v1alpha1.UserSignupStateDeactivated, false)
 	}
 }
 

--- a/pkg/states/state_manager_test.go
+++ b/pkg/states/state_manager_test.go
@@ -23,11 +23,23 @@ func TestStateManager(t *testing.T) {
 		require.Len(t, u.Spec.States, 0)
 		require.False(t, Approved(u))
 
+		SetDeactivated(u, true)
 		SetVerificationRequired(u, true)
 		SetApproved(u, true)
 
 		// Setting approved should remove verification required
 		require.False(t, VerificationRequired(u))
+
+		// Setting approved should remove deactivated
+		require.False(t, Deactivated(u))
+
+		SetApproved(u, false)
+
+		SetDeactivating(u, true)
+		SetApproved(u, true)
+
+		// Setting approved should remove deactivating
+		require.False(t, Deactivating(u))
 	})
 
 	t.Run("test verification required", func(t *testing.T) {
@@ -106,12 +118,13 @@ func TestStateManager(t *testing.T) {
 		// Reapprove
 		SetApproved(u, true)
 
-		SetVerificationRequired(u, false)
-		// Should still not be active
-		require.False(t, Active(u))
+		// Deactivated should now be false
+		require.False(t, Deactivated(u))
 
-		SetDeactivated(u, false)
-		// Should be active when verification not required and not deactivated
+		// Verification Required should now be false
+		require.False(t, VerificationRequired(u))
+
+		// Should be active
 		require.True(t, Active(u))
 
 		SetDeactivating(u, true)


### PR DESCRIPTION
Simple PR, which sets the `deactivated` and `deactivating` states to false when a user is approved.

Fixes https://issues.redhat.com/browse/CRT-1015