### PR TITLE
lint: configure GitHub Action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -22,18 +22,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     
-    - name: Cache dependencies
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles ('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.29
+        version: v1.39
+        skip-go-installation: true
         args: -E gofmt,golint,megacheck,misspell
 
 


### PR DESCRIPTION
upgrade underlying GolangCI action to 1.39
Do not use cache and avoid tons of errors such as:

```
Error: /usr/bin/tar: ... : Cannot open: File exists
```

Fixes https://issues.redhat.com/browse/CRT-1108

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
