### PR TITLE
chore: update api with new format & kubebuilder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/codeready-toolchain/api v0.0.0-20210512064851-b871cbf562fd
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v0.4.0
 	github.com/go-openapi/spec v0.19.7 // indirect
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
@@ -30,10 +30,14 @@ require (
 	sigs.k8s.io/controller-runtime v0.6.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043
+
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM
+	github.com/go-logr/logr => github.com/go-logr/logr v0.1.0
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20200821140346-b94c46af3f2b // Using 'github.com/openshift/api@release-4.5'
 	k8s.io/client-go => k8s.io/client-go v0.18.3 // Required by prometheus-operator
+	k8s.io/klog/v2 => k8s.io/klog/v2 v2.0.0
 	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6 // avoids case-insensitive import collision: "github.com/googleapis/gnostic/openapiv2" and "github.com/googleapis/gnostic/OpenAPIv2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-common
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210520133910-ab0d90c32c0b
+	github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-logr/logr v0.4.0
@@ -29,8 +29,6 @@ require (
 	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66 // indirect
 	sigs.k8s.io/controller-runtime v0.6.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v13.3.2+incompatible // Required by OLM

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126 h1:ctRxZ3qcUNtaYoZqc3PUAedQChPpl0iZvyJXF5M6ySE=
+github.com/codeready-toolchain/api v0.0.0-20210525072732-81a688cbd126/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -557,8 +559,6 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
-github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff h1:YfHt1MpDDqdovcvxgXZh/FglkRwX10BwFlARE7wyTro=
-github.com/matousjobanek/api v0.0.0-20210521080009-872e73020eff/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1290,6 +1290,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac h1:sAvhNk5RRuc6FNYGqe7Ygz3PSo/2wGWbulskmzRX8Vs=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1328,6 +1329,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1 h1:VkuV0MxlRPmRu5iTgBZU4UxUX2LiR99n3sdQGRxZF4w=
 sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,6 @@ github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMe
 github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1:XGLbWH/ujMcbPbhZq52Nv6UrCghb1yGn//133kEsvDk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/codeready-toolchain/api v0.0.0-20210512064851-b871cbf562fd h1:f4Fan/pVzKab7arIkPJVuboAel5+Vqveq+qi++cLSuM=
-github.com/codeready-toolchain/api v0.0.0-20210512064851-b871cbf562fd/go.mod h1:tVouC34ewr4KABqqsVgsUmrg+eDeKsPIBD7VLOeZPEQ=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.2.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
@@ -559,6 +557,8 @@ github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzferVeWqbgNs=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043 h1:FrCL5fGboLnw/8pzb+2tl5rOGmocaQnlVw+ZVbXirgY=
+github.com/matousjobanek/api v0.0.0-20210520100306-bffff6b38043/go.mod h1:Tk3X/k80o6hKIVlhaBoTRWpECEnZYWZcJdYMGV1pZvE=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -1113,6 +1113,7 @@ golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200115044656-831fdb1e1868/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200403190813-44a64ad78b9b/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0 h1:SQvH+DjrwqD1hyyQU+K7JegHz1KEZgEwt17p9d6R2eg=
 golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -1289,6 +1290,7 @@ k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120 h1:RPscN6KhmG54S33L+lr3GS+oD1jmchIU0ll519K6FA4=
 k8s.io/gengo v0.0.0-20200114144118-36b2048a9120/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
+k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
@@ -1326,6 +1328,7 @@ sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.4.1/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/kubebuilder v1.0.9-0.20200618125005-36aa113dbe99/go.mod h1:FGPx0hvP73+bapzWoy5ePuhAJYgJjrFbPxgvWyortM0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -811,7 +811,7 @@ func addToScheme(t *testing.T) *runtime.Scheme {
 	s := scheme.Scheme
 	err := authv1.Install(s)
 	require.NoError(t, err)
-	err = v1alpha1.AddToScheme(s)
+	err = toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -811,7 +811,7 @@ func addToScheme(t *testing.T) *runtime.Scheme {
 	s := scheme.Scheme
 	err := authv1.Install(s)
 	require.NoError(t, err)
-	err = apis.AddToScheme(s)
+	err = v1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"sync"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,7 +32,7 @@ type CachedToolchainCluster struct {
 	// OperatorNamespace is a name of a namespace (in the cluster) the operator is running in
 	OperatorNamespace string
 	// ClusterStatus is the cluster result as of the last health check probe.
-	ClusterStatus *v1alpha1.ToolchainClusterStatus
+	ClusterStatus *toolchainv1alpha1.ToolchainClusterStatus
 	// OwnerClusterName keeps the name of the cluster the ToolchainCluster resource is created in
 	// eg. if this ToolchainCluster identifies a Host cluster (and thus is created in Member)
 	// then the OwnerClusterName has a name of the member - it has to be same name as the name

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"sync"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -423,16 +423,16 @@ type clusterOption func(*CachedToolchainCluster)
 
 // Ready an option to state the cluster as "ready"
 var ready clusterOption = func(c *CachedToolchainCluster) {
-	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, v1alpha1.ToolchainClusterCondition{
-		Type:   v1alpha1.ToolchainClusterReady,
+	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.ToolchainClusterCondition{
+		Type:   toolchainv1alpha1.ToolchainClusterReady,
 		Status: v1.ConditionTrue,
 	})
 }
 
 // clusterNotReady an option to state the cluster as "not ready"
 var notReady clusterOption = func(c *CachedToolchainCluster) {
-	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, v1alpha1.ToolchainClusterCondition{
-		Type:   v1alpha1.ToolchainClusterReady,
+	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.ToolchainClusterCondition{
+		Type:   toolchainv1alpha1.ToolchainClusterReady,
 		Status: v1.ConditionFalse,
 	})
 }
@@ -444,7 +444,7 @@ func newTestCachedToolchainCluster(t *testing.T, name string, clusterType Type, 
 		Client:            cl,
 		OperatorNamespace: name + "Namespace",
 		Type:              clusterType,
-		ClusterStatus:     &v1alpha1.ToolchainClusterStatus{},
+		ClusterStatus:     &toolchainv1alpha1.ToolchainClusterStatus{},
 	}
 	for _, configure := range options {
 		configure(cachedCluster)

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -51,7 +51,7 @@ func NewToolchainClusterService(client client.Client, log logr.Logger, namespace
 
 // AddOrUpdateToolchainCluster takes the ToolchainCluster CR object,
 // creates CachedToolchainCluster with a kube client and stores it in a cache
-func (s *ToolchainClusterService) AddOrUpdateToolchainCluster(cluster *v1alpha1.ToolchainCluster) error {
+func (s *ToolchainClusterService) AddOrUpdateToolchainCluster(cluster *toolchainv1alpha1.ToolchainCluster) error {
 	log := s.enrichLogger(cluster)
 	log.Info("observed a cluster")
 
@@ -62,7 +62,7 @@ func (s *ToolchainClusterService) AddOrUpdateToolchainCluster(cluster *v1alpha1.
 	return nil
 }
 
-func (s *ToolchainClusterService) addToolchainCluster(toolchainCluster *v1alpha1.ToolchainCluster) error {
+func (s *ToolchainClusterService) addToolchainCluster(toolchainCluster *toolchainv1alpha1.ToolchainCluster) error {
 	// create the restclient of toolchainCluster
 	clusterConfig, err := NewClusterConfig(s.client, toolchainCluster, s.timeout)
 	if err != nil {
@@ -106,7 +106,7 @@ func (s *ToolchainClusterService) DeleteToolchainCluster(name string) {
 }
 
 func (s *ToolchainClusterService) refreshCache() {
-	toolchainClusters := &v1alpha1.ToolchainClusterList{}
+	toolchainClusters := &toolchainv1alpha1.ToolchainClusterList{}
 	if err := s.client.List(context.TODO(), toolchainClusters, &client.ListOptions{Namespace: s.namespace}); err != nil {
 		s.log.Error(err, "the cluster cache was not refreshed")
 	}
@@ -119,13 +119,13 @@ func (s *ToolchainClusterService) refreshCache() {
 	}
 }
 
-func (s *ToolchainClusterService) enrichLogger(cluster *v1alpha1.ToolchainCluster) logr.Logger {
+func (s *ToolchainClusterService) enrichLogger(cluster *toolchainv1alpha1.ToolchainCluster) logr.Logger {
 	return s.log.
 		WithValues("Request.Namespace", cluster.Namespace, "Request.Name", cluster.Name)
 }
 
 // NewClusterConfig generate a new cluster config by fetching the necessary info the given ToolchainCluster's associated Secret
-func NewClusterConfig(cl client.Client, toolchainCluster *v1alpha1.ToolchainCluster, timeout time.Duration) (*rest.Config, error) {
+func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.ToolchainCluster, timeout time.Duration) (*rest.Config, error) {
 	clusterName := toolchainCluster.Name
 
 	apiEndpoint := toolchainCluster.Spec.APIEndpoint
@@ -170,9 +170,9 @@ func NewClusterConfig(cl client.Client, toolchainCluster *v1alpha1.ToolchainClus
 	return clusterConfig, nil
 }
 
-func IsReady(clusterStatus *v1alpha1.ToolchainClusterStatus) bool {
+func IsReady(clusterStatus *toolchainv1alpha1.ToolchainClusterStatus) bool {
 	for _, condition := range clusterStatus.Conditions {
-		if condition.Type == v1alpha1.ToolchainClusterReady {
+		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
 			if condition.Status == v1.ConditionTrue {
 				return true
 			}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -3,7 +3,7 @@ package cluster_test
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/verify"

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -3,7 +3,7 @@ package cluster_test
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/verify"
@@ -11,7 +11,7 @@ import (
 
 func TestAddToolchainClusterAsMember(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterAsMember(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterAsMember(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		return service.AddOrUpdateToolchainCluster(toolchainCluster)
 	})
@@ -20,7 +20,7 @@ func TestAddToolchainClusterAsMember(t *testing.T) {
 
 func TestAddToolchainClusterAsHost(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterAsHost(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterAsHost(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		return service.AddOrUpdateToolchainCluster(toolchainCluster)
 	})
@@ -28,7 +28,7 @@ func TestAddToolchainClusterAsHost(t *testing.T) {
 
 func TestAddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterFailsBecauseOfMissingSecret(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterFailsBecauseOfMissingSecret(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		return service.AddOrUpdateToolchainCluster(toolchainCluster)
 	})
@@ -36,7 +36,7 @@ func TestAddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T) {
 
 func TestAddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterFailsBecauseOfEmptySecret(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterFailsBecauseOfEmptySecret(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		return service.AddOrUpdateToolchainCluster(toolchainCluster)
 	})
@@ -44,7 +44,7 @@ func TestAddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T) {
 
 func TestUpdateToolchainCluster(t *testing.T) {
 	// given & then
-	verify.UpdateToolchainCluster(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.UpdateToolchainCluster(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		return service.AddOrUpdateToolchainCluster(toolchainCluster)
 	})
@@ -52,7 +52,7 @@ func TestUpdateToolchainCluster(t *testing.T) {
 
 func TestDeleteToolchainClusterWhenDoesNotExist(t *testing.T) {
 	// given & then
-	verify.DeleteToolchainCluster(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.DeleteToolchainCluster(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// when
 		service.DeleteToolchainCluster("east")
 		return nil

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -16,10 +16,10 @@ import (
 func TestRefreshCacheInService(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster, sec := test.NewToolchainCluster("east", "secret", status, map[string]string{"ownerClusterName": test.NameMember})
 	s := scheme.Scheme
-	err := v1alpha1.AddToScheme(s)
+	err := toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	cl := test.NewFakeClient(t, toolchainCluster, sec)
 	service := NewToolchainClusterService(cl, logf.Log, "test-namespace", 0)
@@ -68,7 +68,7 @@ func TestRefreshCacheInService(t *testing.T) {
 	})
 }
 
-func assertMemberCluster(t *testing.T, cachedCluster *CachedToolchainCluster, status v1alpha1.ToolchainClusterStatus) {
+func assertMemberCluster(t *testing.T, cachedCluster *CachedToolchainCluster, status toolchainv1alpha1.ToolchainClusterStatus) {
 	assert.Equal(t, Member, cachedCluster.Type)
 	assert.Equal(t, status, *cachedCluster.ClusterStatus)
 	assert.Equal(t, test.NameMember, cachedCluster.OwnerClusterName)

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -3,8 +3,7 @@ package cluster
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,7 +19,7 @@ func TestRefreshCacheInService(t *testing.T) {
 	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster, sec := test.NewToolchainCluster("east", "secret", status, map[string]string{"ownerClusterName": test.NameMember})
 	s := scheme.Scheme
-	err := apis.AddToScheme(s)
+	err := v1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	cl := test.NewFakeClient(t, toolchainCluster, sec)
 	service := NewToolchainClusterService(cl, logf.Log, "test-namespace", 0)

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -1,7 +1,7 @@
 package condition
 
 import (
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/condition/condition_blackbox_test.go
+++ b/pkg/condition/condition_blackbox_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 

--- a/pkg/controller/toolchaincluster/healthchecker.go
+++ b/pkg/controller/toolchaincluster/healthchecker.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -44,7 +44,7 @@ type HealthChecker struct {
 
 // updateClusterStatuses checks cluster health and updates status of all ToolchainClusters
 func updateClusterStatuses(namespace string, cl client.Client) {
-	clusters := &v1alpha1.ToolchainClusterList{}
+	clusters := &toolchainv1alpha1.ToolchainClusterList{}
 	err := cl.List(context.TODO(), clusters, client.InNamespace(namespace))
 	if err != nil {
 		logger.Error(err, "unable to list existing ToolchainClusters")
@@ -61,7 +61,7 @@ func updateClusterStatuses(namespace string, cl client.Client) {
 		cachedCluster, ok := cluster.GetCachedToolchainCluster(clusterObj.Name)
 		if !ok {
 			clusterLogger.Error(fmt.Errorf("cluster %s not found in cache", clusterObj.Name), "failed to retrieve stored data for cluster")
-			clusterObj.Status.Conditions = []v1alpha1.ToolchainClusterCondition{clusterOfflineCondition()}
+			clusterObj.Status.Conditions = []toolchainv1alpha1.ToolchainClusterCondition{clusterOfflineCondition()}
 			if err := cl.Status().Update(context.TODO(), clusterObj); err != nil {
 				clusterLogger.Error(err, "failed to update the status of ToolchainCluster")
 			}
@@ -87,7 +87,7 @@ func updateClusterStatuses(namespace string, cl client.Client) {
 	}
 }
 
-func (hc *HealthChecker) updateIndividualClusterStatus(toolchainCluster *v1alpha1.ToolchainCluster) error {
+func (hc *HealthChecker) updateIndividualClusterStatus(toolchainCluster *toolchainv1alpha1.ToolchainCluster) error {
 
 	currentClusterStatus := hc.getClusterHealthStatus()
 
@@ -107,8 +107,8 @@ func (hc *HealthChecker) updateIndividualClusterStatus(toolchainCluster *v1alpha
 }
 
 // getClusterHealthStatus gets the kubernetes cluster health status by requesting "/healthz"
-func (hc *HealthChecker) getClusterHealthStatus() *v1alpha1.ToolchainClusterStatus {
-	clusterStatus := v1alpha1.ToolchainClusterStatus{}
+func (hc *HealthChecker) getClusterHealthStatus() *toolchainv1alpha1.ToolchainClusterStatus {
+	clusterStatus := toolchainv1alpha1.ToolchainClusterStatus{}
 	body, err := hc.remoteClusterClientset.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).Raw()
 	if err != nil {
 		hc.logger.Error(err, "Failed to do cluster health check for a ToolchainCluster")
@@ -124,48 +124,48 @@ func (hc *HealthChecker) getClusterHealthStatus() *v1alpha1.ToolchainClusterStat
 	return &clusterStatus
 }
 
-func clusterReadyCondition() v1alpha1.ToolchainClusterCondition {
+func clusterReadyCondition() toolchainv1alpha1.ToolchainClusterCondition {
 	currentTime := metav1.Now()
-	return v1alpha1.ToolchainClusterCondition{
-		Type:               v1alpha1.ToolchainClusterReady,
+	return toolchainv1alpha1.ToolchainClusterCondition{
+		Type:               toolchainv1alpha1.ToolchainClusterReady,
 		Status:             corev1.ConditionTrue,
-		Reason:             v1alpha1.ToolchainClusterClusterReadyReason,
+		Reason:             toolchainv1alpha1.ToolchainClusterClusterReadyReason,
 		Message:            healthzOk,
 		LastProbeTime:      currentTime,
 		LastTransitionTime: &currentTime,
 	}
 }
 
-func clusterNotReadyCondition() v1alpha1.ToolchainClusterCondition {
+func clusterNotReadyCondition() toolchainv1alpha1.ToolchainClusterCondition {
 	currentTime := metav1.Now()
-	return v1alpha1.ToolchainClusterCondition{
-		Type:               v1alpha1.ToolchainClusterReady,
+	return toolchainv1alpha1.ToolchainClusterCondition{
+		Type:               toolchainv1alpha1.ToolchainClusterReady,
 		Status:             corev1.ConditionFalse,
-		Reason:             v1alpha1.ToolchainClusterClusterNotReadyReason,
+		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReadyReason,
 		Message:            healthzNotOk,
 		LastProbeTime:      currentTime,
 		LastTransitionTime: &currentTime,
 	}
 }
 
-func clusterOfflineCondition() v1alpha1.ToolchainClusterCondition {
+func clusterOfflineCondition() toolchainv1alpha1.ToolchainClusterCondition {
 	currentTime := metav1.Now()
-	return v1alpha1.ToolchainClusterCondition{
-		Type:               v1alpha1.ToolchainClusterOffline,
+	return toolchainv1alpha1.ToolchainClusterCondition{
+		Type:               toolchainv1alpha1.ToolchainClusterOffline,
 		Status:             corev1.ConditionTrue,
-		Reason:             v1alpha1.ToolchainClusterClusterNotReachableReason,
+		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReachableReason,
 		Message:            clusterNotReachableMsg,
 		LastProbeTime:      currentTime,
 		LastTransitionTime: &currentTime,
 	}
 }
 
-func clusterNotOfflineCondition() v1alpha1.ToolchainClusterCondition {
+func clusterNotOfflineCondition() toolchainv1alpha1.ToolchainClusterCondition {
 	currentTime := metav1.Now()
-	return v1alpha1.ToolchainClusterCondition{
-		Type:               v1alpha1.ToolchainClusterOffline,
+	return toolchainv1alpha1.ToolchainClusterCondition{
+		Type:               toolchainv1alpha1.ToolchainClusterOffline,
 		Status:             corev1.ConditionFalse,
-		Reason:             v1alpha1.ToolchainClusterClusterReachableReason,
+		Reason:             toolchainv1alpha1.ToolchainClusterClusterReachableReason,
 		Message:            clusterReachableMsg,
 		LastProbeTime:      currentTime,
 		LastTransitionTime: &currentTime,

--- a/pkg/controller/toolchaincluster/healthchecker.go
+++ b/pkg/controller/toolchaincluster/healthchecker.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"

--- a/pkg/controller/toolchaincluster/healthchecker_test.go
+++ b/pkg/controller/toolchaincluster/healthchecker_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"

--- a/pkg/controller/toolchaincluster/healthchecker_test.go
+++ b/pkg/controller/toolchaincluster/healthchecker_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -34,9 +34,9 @@ func TestClusterHealthChecks(t *testing.T) {
 		Reply(404)
 
 	t.Run("ToolchainCluster.status doesn't contain any conditions", func(t *testing.T) {
-		unstable, sec := newToolchainCluster("unstable", "http://unstable.com", v1alpha1.ToolchainClusterStatus{})
-		notFound, _ := newToolchainCluster("not-found", "http://not-found.com", v1alpha1.ToolchainClusterStatus{})
-		stable, _ := newToolchainCluster("stable", "http://cluster.com", v1alpha1.ToolchainClusterStatus{})
+		unstable, sec := newToolchainCluster("unstable", "http://unstable.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		notFound, _ := newToolchainCluster("not-found", "http://not-found.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, _ := newToolchainCluster("stable", "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
 
 		cl := test.NewFakeClient(t, unstable, notFound, stable, sec)
 		reset := setupCachedClusters(t, cl, unstable, notFound, stable)
@@ -84,7 +84,7 @@ func TestClusterHealthChecks(t *testing.T) {
 	})
 
 	t.Run("if the connection cannot be established at beginning, then it should be offline", func(t *testing.T) {
-		stable, sec := newToolchainCluster("failing", "http://failing.com", v1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster("failing", "http://failing.com", toolchainv1alpha1.ToolchainClusterStatus{})
 
 		cl := test.NewFakeClient(t, stable, sec)
 
@@ -96,7 +96,7 @@ func TestClusterHealthChecks(t *testing.T) {
 	})
 }
 
-func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*v1alpha1.ToolchainCluster) func() {
+func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolchainv1alpha1.ToolchainCluster) func() {
 	service := cluster.NewToolchainClusterService(cl, logf.Log, "test-namespace", 0)
 	for _, clustr := range clusters {
 		err := service.AddOrUpdateToolchainCluster(clustr)
@@ -112,19 +112,19 @@ func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*v1alpha
 	}
 }
 
-func withStatus(conditions ...v1alpha1.ToolchainClusterCondition) v1alpha1.ToolchainClusterStatus {
-	return v1alpha1.ToolchainClusterStatus{
+func withStatus(conditions ...toolchainv1alpha1.ToolchainClusterCondition) toolchainv1alpha1.ToolchainClusterStatus {
+	return toolchainv1alpha1.ToolchainClusterStatus{
 		Conditions: conditions,
 	}
 }
 
-func newToolchainCluster(name, apiEndpoint string, status v1alpha1.ToolchainClusterStatus) (*v1alpha1.ToolchainCluster, *corev1.Secret) {
+func newToolchainCluster(name, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
 	toolchainCluster, secret := test.NewToolchainClusterWithEndpoint(name, "secret", apiEndpoint, status, map[string]string{})
 	return toolchainCluster, secret
 }
 
-func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...v1alpha1.ToolchainClusterCondition) {
-	tc := &v1alpha1.ToolchainCluster{}
+func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...toolchainv1alpha1.ToolchainClusterCondition) {
+	tc := &toolchainv1alpha1.ToolchainCluster{}
 	err := cl.Get(context.TODO(), test.NamespacedName("test-namespace", clusterName), tc)
 	require.NoError(t, err)
 	assert.Len(t, tc.Status.Conditions, len(clusterConds))
@@ -142,30 +142,30 @@ ExpConditions:
 	}
 }
 
-func healthy() v1alpha1.ToolchainClusterCondition {
-	return v1alpha1.ToolchainClusterCondition{
-		Type:    v1alpha1.ToolchainClusterReady,
+func healthy() toolchainv1alpha1.ToolchainClusterCondition {
+	return toolchainv1alpha1.ToolchainClusterCondition{
+		Type:    toolchainv1alpha1.ToolchainClusterReady,
 		Status:  corev1.ConditionTrue,
 		Reason:  "ClusterReady",
 		Message: "/healthz responded with ok",
 	}
 }
-func unhealthy() v1alpha1.ToolchainClusterCondition {
-	return v1alpha1.ToolchainClusterCondition{Type: v1alpha1.ToolchainClusterReady,
+func unhealthy() toolchainv1alpha1.ToolchainClusterCondition {
+	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  "ClusterNotReady",
 		Message: "/healthz responded without ok",
 	}
 }
-func offline() v1alpha1.ToolchainClusterCondition {
-	return v1alpha1.ToolchainClusterCondition{Type: v1alpha1.ToolchainClusterOffline,
+func offline() toolchainv1alpha1.ToolchainClusterCondition {
+	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterOffline,
 		Status:  corev1.ConditionTrue,
 		Reason:  "ClusterNotReachable",
 		Message: "cluster is not reachable",
 	}
 }
-func notOffline() v1alpha1.ToolchainClusterCondition {
-	return v1alpha1.ToolchainClusterCondition{Type: v1alpha1.ToolchainClusterOffline,
+func notOffline() toolchainv1alpha1.ToolchainClusterCondition {
+	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterOffline,
 		Status:  corev1.ConditionFalse,
 		Reason:  "ClusterReachable",
 		Message: "cluster is reachable",

--- a/pkg/controller/toolchaincluster/toolchaincluster_controller.go
+++ b/pkg/controller/toolchaincluster/toolchaincluster_controller.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/toolchaincluster/toolchaincluster_controller_test.go
+++ b/pkg/controller/toolchaincluster/toolchaincluster_controller_test.go
@@ -3,7 +3,7 @@ package toolchaincluster
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/verify"

--- a/pkg/controller/toolchaincluster/toolchaincluster_controller_test.go
+++ b/pkg/controller/toolchaincluster/toolchaincluster_controller_test.go
@@ -3,7 +3,7 @@ package toolchaincluster
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/verify"
@@ -14,7 +14,7 @@ import (
 
 func TestAddToolchainClusterAsMember(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterAsMember(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterAsMember(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -27,7 +27,7 @@ func TestAddToolchainClusterAsMember(t *testing.T) {
 
 func TestAddToolchainClusterAsHost(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterAsHost(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterAsHost(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -39,7 +39,7 @@ func TestAddToolchainClusterAsHost(t *testing.T) {
 
 func TestAddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterFailsBecauseOfMissingSecret(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterFailsBecauseOfMissingSecret(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -51,7 +51,7 @@ func TestAddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T) {
 
 func TestAddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T) {
 	// given & then
-	verify.AddToolchainClusterFailsBecauseOfEmptySecret(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.AddToolchainClusterFailsBecauseOfEmptySecret(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -63,7 +63,7 @@ func TestAddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T) {
 
 func TestUpdateToolchainCluster(t *testing.T) {
 	// given & then
-	verify.UpdateToolchainCluster(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.UpdateToolchainCluster(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -75,7 +75,7 @@ func TestUpdateToolchainCluster(t *testing.T) {
 
 func TestDeleteToolchainCluster(t *testing.T) {
 	// given & then
-	verify.DeleteToolchainCluster(t, func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
+	verify.DeleteToolchainCluster(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
@@ -85,7 +85,7 @@ func TestDeleteToolchainCluster(t *testing.T) {
 	})
 }
 
-func prepareReconcile(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) (Reconciler, reconcile.Request) {
+func prepareReconcile(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) (Reconciler, reconcile.Request) {
 	controller := Reconciler{
 		client:              cl,
 		scheme:              scheme.Scheme,

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -12,13 +12,13 @@ import (
 var missingDataEvents = []event.UpdateEvent{
 	{},
 	{MetaNew: &metav1.ObjectMeta{}, MetaOld: &metav1.ObjectMeta{},
-		ObjectNew: &v1alpha1.UserAccount{}},
+		ObjectNew: &toolchainv1alpha1.UserAccount{}},
 	{MetaNew: &metav1.ObjectMeta{}, MetaOld: &metav1.ObjectMeta{},
-		ObjectOld: &v1alpha1.UserAccount{}},
-	{MetaNew: &metav1.ObjectMeta{}, ObjectOld: &v1alpha1.UserAccount{},
-		ObjectNew: &v1alpha1.UserAccount{}},
-	{ObjectNew: &v1alpha1.UserAccount{}, MetaOld: &metav1.ObjectMeta{},
-		ObjectOld: &v1alpha1.UserAccount{}}}
+		ObjectOld: &toolchainv1alpha1.UserAccount{}},
+	{MetaNew: &metav1.ObjectMeta{}, ObjectOld: &toolchainv1alpha1.UserAccount{},
+		ObjectNew: &toolchainv1alpha1.UserAccount{}},
+	{ObjectNew: &toolchainv1alpha1.UserAccount{}, MetaOld: &metav1.ObjectMeta{},
+		ObjectOld: &toolchainv1alpha1.UserAccount{}}}
 
 func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 	var noGenChangedPred = OnlyUpdateWhenGenerationNotChanged{}
@@ -41,7 +41,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 			updateEvent := event.UpdateEvent{
 				MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789)},
 				MetaOld:   &metav1.ObjectMeta{Generation: int64(987654321)},
-				ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+				ObjectNew: &toolchainv1alpha1.UserAccount{}, ObjectOld: &toolchainv1alpha1.UserAccount{}}
 
 			// when
 			ok := noGenChangedPred.Update(updateEvent)
@@ -55,7 +55,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 			updateEvent := event.UpdateEvent{
 				MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789)},
 				MetaOld:   &metav1.ObjectMeta{Generation: int64(123456789)},
-				ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+				ObjectNew: &toolchainv1alpha1.UserAccount{}, ObjectOld: &toolchainv1alpha1.UserAccount{}}
 
 			// when
 			ok := noGenChangedPred.Update(updateEvent)
@@ -70,7 +70,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 		// given
 		createEvent := event.CreateEvent{
 			Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
-			Object: &v1alpha1.UserAccount{}}
+			Object: &toolchainv1alpha1.UserAccount{}}
 
 		// when
 		ok := noGenChangedPred.Create(createEvent)
@@ -83,7 +83,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 		// given
 		deleteEvent := event.DeleteEvent{
 			Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
-			Object: &v1alpha1.UserAccount{}}
+			Object: &toolchainv1alpha1.UserAccount{}}
 
 		// when
 		ok := noGenChangedPred.Delete(deleteEvent)
@@ -96,7 +96,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 		// given
 		genericEvent := event.GenericEvent{
 			Meta:   &metav1.ObjectMeta{Generation: int64(123456789)},
-			Object: &v1alpha1.UserAccount{}}
+			Object: &toolchainv1alpha1.UserAccount{}}
 
 		// when
 		ok := noGenChangedPred.Generic(genericEvent)
@@ -127,7 +127,7 @@ func TestLabelsAndGenerationPredicate(t *testing.T) {
 			updateEvent := event.UpdateEvent{
 				MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789), Labels: map[string]string{"test": "label"}},
 				MetaOld:   &metav1.ObjectMeta{Generation: int64(123456789), Labels: map[string]string{"test": "label"}},
-				ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+				ObjectNew: &toolchainv1alpha1.UserAccount{}, ObjectOld: &toolchainv1alpha1.UserAccount{}}
 
 			// when
 			ok := labelsAndGenPred.Update(updateEvent)
@@ -141,7 +141,7 @@ func TestLabelsAndGenerationPredicate(t *testing.T) {
 			updateEvent := event.UpdateEvent{
 				MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789), Labels: map[string]string{"test": "label"}},
 				MetaOld:   &metav1.ObjectMeta{Generation: int64(987654321), Labels: map[string]string{"test": "label"}},
-				ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+				ObjectNew: &toolchainv1alpha1.UserAccount{}, ObjectOld: &toolchainv1alpha1.UserAccount{}}
 
 			// when
 			ok := labelsAndGenPred.Update(updateEvent)
@@ -155,7 +155,7 @@ func TestLabelsAndGenerationPredicate(t *testing.T) {
 			updateEvent := event.UpdateEvent{
 				MetaNew:   &metav1.ObjectMeta{Generation: int64(123456789), Labels: map[string]string{"test": "label"}},
 				MetaOld:   &metav1.ObjectMeta{Generation: int64(123456789), Labels: map[string]string{"test": "label", "another": "newlabel"}},
-				ObjectNew: &v1alpha1.UserAccount{}, ObjectOld: &v1alpha1.UserAccount{}}
+				ObjectNew: &toolchainv1alpha1.UserAccount{}, ObjectOld: &toolchainv1alpha1.UserAccount{}}
 
 			// when
 			ok := labelsAndGenPred.Update(updateEvent)

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -3,7 +3,7 @@ package predicate
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/event"

--- a/pkg/states/state_manager.go
+++ b/pkg/states/state_manager.go
@@ -1,61 +1,61 @@
 package states
 
-import "github.com/codeready-toolchain/api/api/v1alpha1"
+import toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
-func Active(userSignup *v1alpha1.UserSignup) bool {
+func Active(userSignup *toolchainv1alpha1.UserSignup) bool {
 	return Approved(userSignup) &&
 		!VerificationRequired(userSignup) &&
 		!Deactivated(userSignup)
 }
 
-func Approved(userSignup *v1alpha1.UserSignup) bool {
-	return contains(userSignup.Spec.States, v1alpha1.UserSignupStateApproved)
+func Approved(userSignup *toolchainv1alpha1.UserSignup) bool {
+	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateApproved)
 }
 
-func SetApproved(userSignup *v1alpha1.UserSignup, val bool) {
-	setState(userSignup, v1alpha1.UserSignupStateApproved, val)
+func SetApproved(userSignup *toolchainv1alpha1.UserSignup, val bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, val)
 
 	if val {
-		setState(userSignup, v1alpha1.UserSignupStateVerificationRequired, false)
-		setState(userSignup, v1alpha1.UserSignupStateDeactivating, false)
-		setState(userSignup, v1alpha1.UserSignupStateDeactivated, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateVerificationRequired, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, false)
 	}
 }
 
-func VerificationRequired(userSignup *v1alpha1.UserSignup) bool {
-	return contains(userSignup.Spec.States, v1alpha1.UserSignupStateVerificationRequired)
+func VerificationRequired(userSignup *toolchainv1alpha1.UserSignup) bool {
+	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateVerificationRequired)
 }
 
-func SetVerificationRequired(userSignup *v1alpha1.UserSignup, val bool) {
-	setState(userSignup, v1alpha1.UserSignupStateVerificationRequired, val)
+func SetVerificationRequired(userSignup *toolchainv1alpha1.UserSignup, val bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateVerificationRequired, val)
 }
 
-func Deactivating(userSignup *v1alpha1.UserSignup) bool {
-	return contains(userSignup.Spec.States, v1alpha1.UserSignupStateDeactivating)
+func Deactivating(userSignup *toolchainv1alpha1.UserSignup) bool {
+	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateDeactivating)
 }
 
-func SetDeactivating(userSignup *v1alpha1.UserSignup, val bool) {
-	setState(userSignup, v1alpha1.UserSignupStateDeactivating, val)
+func SetDeactivating(userSignup *toolchainv1alpha1.UserSignup, val bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, val)
 
 	if val {
-		setState(userSignup, v1alpha1.UserSignupStateDeactivated, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, false)
 	}
 }
 
-func Deactivated(userSignup *v1alpha1.UserSignup) bool {
-	return contains(userSignup.Spec.States, v1alpha1.UserSignupStateDeactivated)
+func Deactivated(userSignup *toolchainv1alpha1.UserSignup) bool {
+	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateDeactivated)
 }
 
-func SetDeactivated(userSignup *v1alpha1.UserSignup, val bool) {
-	setState(userSignup, v1alpha1.UserSignupStateDeactivated, val)
+func SetDeactivated(userSignup *toolchainv1alpha1.UserSignup, val bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, val)
 
 	if val {
-		setState(userSignup, v1alpha1.UserSignupStateApproved, false)
-		setState(userSignup, v1alpha1.UserSignupStateDeactivating, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, false)
+		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, false)
 	}
 }
 
-func setState(userSignup *v1alpha1.UserSignup, state v1alpha1.UserSignupState, val bool) {
+func setState(userSignup *toolchainv1alpha1.UserSignup, state toolchainv1alpha1.UserSignupState, val bool) {
 	if val && !contains(userSignup.Spec.States, state) {
 		userSignup.Spec.States = append(userSignup.Spec.States, state)
 	}
@@ -65,7 +65,7 @@ func setState(userSignup *v1alpha1.UserSignup, state v1alpha1.UserSignupState, v
 	}
 }
 
-func contains(s []v1alpha1.UserSignupState, state v1alpha1.UserSignupState) bool {
+func contains(s []toolchainv1alpha1.UserSignupState, state toolchainv1alpha1.UserSignupState) bool {
 	for _, a := range s {
 		if a == state {
 			return true
@@ -74,7 +74,7 @@ func contains(s []v1alpha1.UserSignupState, state v1alpha1.UserSignupState) bool
 	return false
 }
 
-func remove(s []v1alpha1.UserSignupState, state v1alpha1.UserSignupState) []v1alpha1.UserSignupState {
+func remove(s []toolchainv1alpha1.UserSignupState, state toolchainv1alpha1.UserSignupState) []toolchainv1alpha1.UserSignupState {
 	for i, v := range s {
 		if v == state {
 			return append(s[:i], s[i+1:]...)

--- a/pkg/states/state_manager.go
+++ b/pkg/states/state_manager.go
@@ -1,6 +1,6 @@
 package states
 
-import "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+import "github.com/codeready-toolchain/api/api/v1alpha1"
 
 func Active(userSignup *v1alpha1.UserSignup) bool {
 	return Approved(userSignup) &&

--- a/pkg/states/state_manager_test.go
+++ b/pkg/states/state_manager_test.go
@@ -1,14 +1,14 @@
 package states
 
 import (
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
 
 func TestStateManager(t *testing.T) {
 
-	u := &v1alpha1.UserSignup{}
+	u := &toolchainv1alpha1.UserSignup{}
 
 	t.Run("test approved", func(t *testing.T) {
 
@@ -16,7 +16,7 @@ func TestStateManager(t *testing.T) {
 
 		require.True(t, Approved(u))
 		require.Len(t, u.Spec.States, 1)
-		require.Equal(t, v1alpha1.UserSignupStateApproved, u.Spec.States[0])
+		require.Equal(t, toolchainv1alpha1.UserSignupStateApproved, u.Spec.States[0])
 
 		SetApproved(u, false)
 
@@ -49,7 +49,7 @@ func TestStateManager(t *testing.T) {
 		require.True(t, VerificationRequired(u))
 
 		require.Len(t, u.Spec.States, 1)
-		require.Equal(t, v1alpha1.UserSignupStateVerificationRequired, u.Spec.States[0])
+		require.Equal(t, toolchainv1alpha1.UserSignupStateVerificationRequired, u.Spec.States[0])
 
 		SetVerificationRequired(u, false)
 
@@ -64,7 +64,7 @@ func TestStateManager(t *testing.T) {
 
 		require.False(t, Deactivated(u))
 		require.Len(t, u.Spec.States, 1)
-		require.Equal(t, v1alpha1.UserSignupStateDeactivating, u.Spec.States[0])
+		require.Equal(t, toolchainv1alpha1.UserSignupStateDeactivating, u.Spec.States[0])
 
 		SetDeactivating(u, false)
 
@@ -83,7 +83,7 @@ func TestStateManager(t *testing.T) {
 
 		require.True(t, Deactivated(u))
 		require.Len(t, u.Spec.States, 1)
-		require.Equal(t, v1alpha1.UserSignupStateDeactivated, u.Spec.States[0])
+		require.Equal(t, toolchainv1alpha1.UserSignupStateDeactivated, u.Spec.States[0])
 
 		SetDeactivated(u, false)
 		require.Len(t, u.Spec.States, 0)
@@ -98,7 +98,7 @@ func TestStateManager(t *testing.T) {
 	})
 
 	t.Run("test active", func(t *testing.T) {
-		u = &v1alpha1.UserSignup{}
+		u = &toolchainv1alpha1.UserSignup{}
 		// Should not be active by default
 		require.False(t, Active(u))
 

--- a/pkg/states/state_manager_test.go
+++ b/pkg/states/state_manager_test.go
@@ -1,7 +1,7 @@
 package states
 
 import (
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"testing"
 )

--- a/pkg/status/componentconditions.go
+++ b/pkg/status/componentconditions.go
@@ -3,7 +3,7 @@ package status
 import (
 	"fmt"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/status/componentconditions_test.go
+++ b/pkg/status/componentconditions_test.go
@@ -3,7 +3,7 @@ package status
 import (
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/status/deployment.go
+++ b/pkg/status/deployment.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	errs "github.com/pkg/errors"
 

--- a/pkg/status/deployment_test.go
+++ b/pkg/status/deployment_test.go
@@ -3,7 +3,7 @@ package status
 import (
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/require"

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/go-logr/logr"
 

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -7,7 +7,7 @@ import (
 	texttemplate "text/template"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -222,7 +222,7 @@ func addToScheme(t *testing.T) *runtime.Scheme {
 	s := scheme.Scheme
 	err := authv1.Install(s)
 	require.NoError(t, err)
-	err = apis.AddToScheme(s)
+	err = v1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -7,7 +7,7 @@ import (
 	texttemplate "text/template"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/client"
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
@@ -222,7 +222,7 @@ func addToScheme(t *testing.T) *runtime.Scheme {
 	s := scheme.Scheme
 	err := authv1.Install(s)
 	require.NoError(t, err)
-	err = v1alpha1.AddToScheme(s)
+	err = toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	return s
 }

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,7 +18,7 @@ import (
 // NewFakeClient creates a fake K8s client with ability to override specific Get/List/Create/Update/StatusUpdate/Delete functions
 func NewFakeClient(t T, initObjs ...runtime.Object) *FakeClient {
 	s := scheme.Scheme
-	err := apis.AddToScheme(s)
+	err := v1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	cl := fake.NewFakeClientWithScheme(s, initObjs...)
 	return &FakeClient{Client: cl, T: t}

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,7 +18,7 @@ import (
 // NewFakeClient creates a fake K8s client with ability to override specific Get/List/Create/Update/StatusUpdate/Delete functions
 func NewFakeClient(t T, initObjs ...runtime.Object) *FakeClient {
 	s := scheme.Scheme
-	err := v1alpha1.AddToScheme(s)
+	err := toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 	cl := fake.NewFakeClientWithScheme(s, initObjs...)
 	return &FakeClient{Client: cl, T: t}

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
@@ -14,11 +14,11 @@ const (
 	NameMember = "east"
 )
 
-func NewToolchainCluster(name, secName string, status v1alpha1.ToolchainClusterStatus, labels map[string]string) (*v1alpha1.ToolchainCluster, *corev1.Secret) {
+func NewToolchainCluster(name, secName string, status toolchainv1alpha1.ToolchainClusterStatus, labels map[string]string) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
 	return NewToolchainClusterWithEndpoint(name, secName, "http://cluster.com", status, labels)
 }
 
-func NewToolchainClusterWithEndpoint(name, secName, apiEndpoint string, status v1alpha1.ToolchainClusterStatus, labels map[string]string) (*v1alpha1.ToolchainCluster, *corev1.Secret) {
+func NewToolchainClusterWithEndpoint(name, secName, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus, labels map[string]string) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
 	logf.SetLogger(zap.Logger())
 	gock.New(apiEndpoint).
 		Get("api").
@@ -36,9 +36,9 @@ func NewToolchainClusterWithEndpoint(name, secName, apiEndpoint string, status v
 		},
 	}
 
-	return &v1alpha1.ToolchainCluster{
-		Spec: v1alpha1.ToolchainClusterSpec{
-			SecretRef: v1alpha1.LocalSecretReference{
+	return &toolchainv1alpha1.ToolchainCluster{
+		Spec: toolchainv1alpha1.ToolchainClusterSpec{
+			SecretRef: toolchainv1alpha1.LocalSecretReference{
 				Name: secName,
 			},
 			APIEndpoint: apiEndpoint,
@@ -53,9 +53,9 @@ func NewToolchainClusterWithEndpoint(name, secName, apiEndpoint string, status v
 	}, secret
 }
 
-func NewClusterStatus(conType v1alpha1.ToolchainClusterConditionType, conStatus corev1.ConditionStatus) v1alpha1.ToolchainClusterStatus {
-	return v1alpha1.ToolchainClusterStatus{
-		Conditions: []v1alpha1.ToolchainClusterCondition{{
+func NewClusterStatus(conType toolchainv1alpha1.ToolchainClusterConditionType, conStatus corev1.ConditionStatus) toolchainv1alpha1.ToolchainClusterStatus {
+	return toolchainv1alpha1.ToolchainClusterStatus{
+		Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
 			Type:   conType,
 			Status: conStatus,
 		}},

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/log/zap"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/test/condition.go
+++ b/pkg/test/condition.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/test/condition_test.go
+++ b/pkg/test/condition_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"

--- a/pkg/test/hostoperatorconfig.go
+++ b/pkg/test/hostoperatorconfig.go
@@ -1,7 +1,7 @@
 package test
 
 import (
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/test/masteruserrecord/assertion.go
+++ b/pkg/test/masteruserrecord/assertion.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/test/masteruserrecord/master_user_record.go
+++ b/pkg/test/masteruserrecord/master_user_record.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/redhat-cop/operator-utils/pkg/util"

--- a/pkg/test/masteruserrecord/master_user_record_test.go
+++ b/pkg/test/masteruserrecord/master_user_record_test.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/codeready-toolchain/api/pkg/apis"
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 
@@ -21,7 +20,7 @@ import (
 func TestMasterUserRecordAssertion(t *testing.T) {
 
 	s := scheme.Scheme
-	err := apis.AddToScheme(s)
+	err := toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 
 	t.Run("HasNSTemplateSet assertion", func(t *testing.T) {

--- a/pkg/test/status.go
+++ b/pkg/test/status.go
@@ -3,7 +3,7 @@ package test
 import (
 	"fmt"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/test/useraccount/assertion.go
+++ b/pkg/test/useraccount/assertion.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/test/useraccount/user_account.go
+++ b/pkg/test/useraccount/user_account.go
@@ -1,7 +1,7 @@
 package useraccount
 
 import (
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/pkg/apis/toolchain/v1alpha1"
+	"github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/codeready-toolchain/api/api/v1alpha1"
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -16,12 +16,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type FunctionToVerify func(toolchainCluster *v1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error
+type FunctionToVerify func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error
 
 func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	memberLabels := []map[string]string{
 		Labels("", "", test.NameHost),
 		Labels(cluster.Member, "", test.NameHost),
@@ -57,7 +57,7 @@ func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify
 func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
 	memberLabels := []map[string]string{
 		Labels(cluster.Host, "", test.NameMember),
 		Labels(cluster.Host, "host-ns", test.NameMember)}
@@ -92,7 +92,7 @@ func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) 
 func AddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster, _ := test.NewToolchainCluster("east", "secret", status, Labels("", "", test.NameHost))
 	cl := test.NewFakeClient(t, toolchainCluster)
 	service := newToolchainClusterService(cl)
@@ -110,7 +110,7 @@ func AddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T, functionToVeri
 func AddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster, _ := test.NewToolchainCluster("east", "secret", status,
 		Labels("", "", test.NameHost))
 	secret := &corev1.Secret{
@@ -134,10 +134,10 @@ func AddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T, functionToVerify
 func UpdateToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	statusTrue := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster1, sec1 := test.NewToolchainCluster("east", "secret1", statusTrue,
 		Labels("", "", test.NameMember))
-	statusFalse := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
+	statusFalse := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
 	toolchainCluster2, sec2 := test.NewToolchainCluster("east", "secret2", statusFalse,
 		Labels(cluster.Host, "", test.NameMember))
 	cl := test.NewFakeClient(t, toolchainCluster2, sec1, sec2)
@@ -163,7 +163,7 @@ func UpdateToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 func DeleteToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(v1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
 	toolchainCluster, sec := test.NewToolchainCluster("east", "sec", status,
 		Labels("", "", test.NameHost))
 	cl := test.NewFakeClient(t, sec)


### PR DESCRIPTION
result of codeready-toolchain/api#237
 * small changes in go.mod so we can use the new controller-tools 0.4.1 together with client-go 0.18.3
 * update all imports to api repo/types