### PR TITLE
Use gofrs uuid in other places as well

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/operator-framework/operator-sdk v0.19.2
 	github.com/pkg/errors v0.9.1
 	github.com/redhat-cop/operator-utils v0.0.0-20190827162636-51e6b0c32776
-	github.com/satori/go.uuid v1.2.0
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/h2non/gock.v1 v1.0.14
 	gopkg.in/square/go-jose.v2 v2.3.0

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -6,13 +6,13 @@ import (
 	"errors"
 	"testing"
 
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/gofrs/uuid"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	errs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -60,7 +60,7 @@ func TestNewClient(t *testing.T) {
 		})
 
 		t.Run("update object with data", func(t *testing.T) {
-			key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+			key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.Must(uuid.NewV4()).String()}
 			data := make(map[string][]byte)
 			data["key"] = []byte("value")
 			created := &v1.Secret{
@@ -247,7 +247,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func createAndGetSecret(t *testing.T, fclient *FakeClient) (*v1.Secret, *v1.Secret) {
-	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.Must(uuid.NewV4()).String()}
 	data := make(map[string]string)
 	data["key"] = "value"
 	created := &v1.Secret{
@@ -275,7 +275,7 @@ func createAndGetSecret(t *testing.T, fclient *FakeClient) (*v1.Secret, *v1.Secr
 }
 
 func createAndGetDeployment(t *testing.T, fclient *FakeClient) (*appsv1.Deployment, *appsv1.Deployment) {
-	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.NewV4().String()}
+	key := types.NamespacedName{Namespace: "somenamespace", Name: "somename" + uuid.Must(uuid.NewV4()).String()}
 	replicas := int32(1)
 	created := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/test/masteruserrecord/master_user_record.go
+++ b/pkg/test/masteruserrecord/master_user_record.go
@@ -13,8 +13,8 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	uuid "github.com/gofrs/uuid"
 	"github.com/redhat-cop/operator-utils/pkg/util"
-	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,7 +81,7 @@ func NewMasterUserRecords(t *testing.T, size int, nameFmt string, modifiers ...M
 }
 
 func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier) *toolchainv1alpha1.MasterUserRecord {
-	userID := uuid.NewV4().String()
+	userID := uuid.Must(uuid.NewV4()).String()
 	hash, err := computeTemplateRefsHash(DefaultNSTemplateTier) // we can assume the JSON marshalling will always work
 	require.NoError(t, err)
 	mur := &toolchainv1alpha1.MasterUserRecord{


### PR DESCRIPTION
This is a follow up to https://github.com/codeready-toolchain/toolchain-common/pull/184. There were a few other places that needed to be updated to use gofrs uuid