### PR TITLE
build: run GitHub Actions on Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   test-with-coverage:
     name: Test with Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Install Go
       uses: actions/setup-go@v2
@@ -36,7 +36,7 @@ jobs:
     
   golangci:
     name: GolangCI Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: Install Go
       uses: actions/setup-go@v2


### PR DESCRIPTION
using an LTS version instead of `lastest`

Fixes https://issues.redhat.com/browse/CRT-1033

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
