### PR TITLE
Add ModifyMemberOperatorConfig for tests

### DIFF
--- a/pkg/test/config/memberoperatorconfig.go
+++ b/pkg/test/config/memberoperatorconfig.go
@@ -280,3 +280,10 @@ func NewMemberOperatorConfig(options ...MemberOperatorConfigOption) *toolchainv1
 	}
 	return memberOperatorConfig
 }
+
+func ModifyMemberOperatorConfig(memberOperatorConfig *toolchainv1alpha1.MemberOperatorConfig, options ...MemberOperatorConfigOption) *toolchainv1alpha1.MemberOperatorConfig {
+	for _, option := range options {
+		option.Apply(memberOperatorConfig)
+	}
+	return memberOperatorConfig
+}


### PR DESCRIPTION
Adds a function `ModifyMemberOperatorConfig` that allows to reuse the `MemberOperatorConfigOption` functions for modifying a `MemberOperatorConfig` resource.