### PR TITLE
fix: create client only when ToolchainCluster config changed

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -52,11 +52,11 @@ func (c *toolchainClusterClients) deleteCachedToolchainCluster(name string) {
 	delete(c.clusters, name)
 }
 
-func (c *toolchainClusterClients) getCachedToolchainCluster(name string) (*CachedToolchainCluster, bool) {
+func (c *toolchainClusterClients) getCachedToolchainCluster(name string, canRefreshCache bool) (*CachedToolchainCluster, bool) {
 	c.RLock()
 	defer c.RUnlock()
 	_, ok := c.clusters[name]
-	if !ok && c.refreshCache != nil {
+	if !ok && canRefreshCache && c.refreshCache != nil {
 		c.RUnlock()
 		c.refreshCache()
 		c.RLock()
@@ -96,7 +96,7 @@ clusters:
 
 // GetCachedToolchainCluster returns a kube client for the cluster (with the given name) and info if the client exists
 func GetCachedToolchainCluster(name string) (*CachedToolchainCluster, bool) {
-	return clusterCache.getCachedToolchainCluster(name)
+	return clusterCache.getCachedToolchainCluster(name, true)
 }
 
 // GetHostClusterFunc a func that returns the Host cluster from the cache,

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -60,7 +60,7 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	timeSinceLastProbe := time.Since(lastProbeTime.Time)
 	if timeSinceLastProbe > maxDuration {
 		err := fmt.Errorf("%s: %s", ErrMsgClusterConnectionLastProbeTimeExceeded, maxDuration.String())
-		logger.Error(err, fmt.Sprintf("the last probe happened before: %s, see: %+v", timeSinceLastProbe.String(), toolchainCluster.ClusterStatus))
+		logger.Error(err, fmt.Sprintf("the last probe for %s happened before: %s, see: %+v", toolchainCluster.Name, timeSinceLastProbe.String(), toolchainCluster.ClusterStatus))
 		return []toolchainv1alpha1.Condition{*NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionLastProbeTimeExceededReason, err.Error())}
 	}
 	return []toolchainv1alpha1.Condition{*NewComponentReadyCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionReadyReason)}


### PR DESCRIPTION
while working on e2e tests I faced several times this kind of error in the member operator log:
```
2021-07-01T15:57:14.261Z        ERROR   controller-runtime.manager.controller.memberstatus      the last probe happened before: 9.261310055s, see: &{Conditions:[{Type:Ready Status:True LastProbeTime:2021-07-01 15:57:05 +0000 UTC LastTransitionTime:2021-07-01 15:51:53 +0000 UTC Reason:ClusterReady Message:/healthz responded with ok}]} {"reconciler group": "toolchain.dev.openshift.com", "reconciler kind": "MemberStatus", "name": "toolchain-member-status", "namespace": "toolchain-member-01154907", "error": "exceeded the maximum duration since the last probe: 8s"}
```
It also happened that my e2e tests failed a few times because of that.
I checked the logs in production and the same error occurs there as well.

After digging deeper I figured out that the creation of the client may take several seconds. This causes that the cache is updated with a delay and with a combination of bad timing it can result in the error that is pasted above.

To avoid that, the code checks if there is any change in the `rest.Config` - if there is, then it creates a new client. If not - which is the most frequent case - it reuses the cached client.

PRs with updated dependency to verify that it works fine:
https://github.com/codeready-toolchain/member-operator/pull/276
https://github.com/codeready-toolchain/host-operator/pull/481