### PR TITLE
script: hide CABundle when printing the ToolchainCluster CR

### DIFF
--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -309,8 +309,6 @@ spec:
 "
 
 echo "Creating ToolchainCluster representation of ${JOINING_CLUSTER_TYPE} in ${CLUSTER_JOIN_TO}:"
-echo ${TOOLCHAINCLUSTER_CRD} | yq '.spec.caBundle="***"'
-
 cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
 ${TOOLCHAINCLUSTER_CRD}
 EOF

--- a/scripts/add-cluster.sh
+++ b/scripts/add-cluster.sh
@@ -309,7 +309,7 @@ spec:
 "
 
 echo "Creating ToolchainCluster representation of ${JOINING_CLUSTER_TYPE} in ${CLUSTER_JOIN_TO}:"
-echo ${TOOLCHAINCLUSTER_CRD}
+echo ${TOOLCHAINCLUSTER_CRD} | yq '.spec.caBundle="***"'
 
 cat <<EOF | oc apply ${OC_ADDITIONAL_PARAMS} -f -
 ${TOOLCHAINCLUSTER_CRD}


### PR DESCRIPTION
it's verbose and probably useless if we need to debug the tests.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
