### PR TITLE
Create common toolchainconfig lib for host and reg service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/codeready-toolchain/toolchain-common
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20210708073330-362a8f80c8fc
+	github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/emicklei/go-restful v2.12.0+incompatible // indirect
 	github.com/go-logr/logr v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
-github.com/codeready-toolchain/api v0.0.0-20210708073330-362a8f80c8fc h1:0bNU7ob0afVVW7rYMeqnlTRINnYEafgBC/C1YP1DZTY=
-github.com/codeready-toolchain/api v0.0.0-20210708073330-362a8f80c8fc/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
+github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948 h1:xwO422mdiCvAcbrnnU6PCEcBQ6Q/rQCvcbC/NxOKxkQ=
+github.com/codeready-toolchain/api v0.0.0-20210721211719-002c2be44948/go.mod h1:+QWudsY8VJYCWui6oamNNJ0eo1kmqi3UsA9lY687O8c=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/pkg/configuration/toolchainconfig/cache.go
+++ b/pkg/configuration/toolchainconfig/cache.go
@@ -1,0 +1,91 @@
+package toolchainconfig
+
+import (
+	"context"
+	"sync"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
+	errs "github.com/pkg/errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var configCache = &cache{}
+
+var cacheLog = logf.Log.WithName("cache_toolchainconfig")
+
+type cache struct {
+	sync.RWMutex
+	config  *toolchainv1alpha1.ToolchainConfig
+	secrets map[string]map[string]string // map of secret key-value pairs indexed by secret name
+}
+
+func (c *cache) set(config *toolchainv1alpha1.ToolchainConfig, secrets map[string]map[string]string) {
+	c.Lock()
+	defer c.Unlock()
+	c.config = config.DeepCopy()
+	c.secrets = commonconfig.CopyOf(secrets)
+}
+
+func (c *cache) get() (*toolchainv1alpha1.ToolchainConfig, map[string]map[string]string) {
+	c.RLock()
+	defer c.RUnlock()
+	return c.config.DeepCopy(), commonconfig.CopyOf(c.secrets)
+}
+
+func updateConfig(config *toolchainv1alpha1.ToolchainConfig, secrets map[string]map[string]string) {
+	configCache.set(config, secrets)
+}
+
+func LoadLatest(cl client.Client) error {
+	namespace, err := commonconfig.GetWatchNamespace()
+	if err != nil {
+		return errs.Wrap(err, "Failed to get watch namespace")
+	}
+
+	config := &toolchainv1alpha1.ToolchainConfig{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: "config"}, config); err != nil {
+		if apierrors.IsNotFound(err) {
+			cacheLog.Info("ToolchainConfig resource with the name 'config' wasn't found, default configuration will be used", "namespace", namespace)
+			return nil
+		}
+		return err
+	}
+
+	allSecrets, err := commonconfig.LoadSecrets(cl, namespace)
+	if err != nil {
+		return err
+	}
+
+	configCache.set(config, allSecrets)
+	return nil
+}
+
+// GetConfig returns a cached host-operator config.
+// If no config is stored in the cache, then it retrieves it from the cluster and stores in the cache.
+// If the resource is not found, then returns the default config.
+// If any failure happens while getting the ToolchainConfig resource, then returns an error.
+func GetConfig(cl client.Client) (ToolchainConfig, error) {
+	config, secrets := configCache.get()
+	if config == nil {
+		if err := LoadLatest(cl); err != nil {
+			return ToolchainConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}, secrets: secrets}, err
+		}
+		config, secrets = configCache.get()
+	}
+	if config == nil {
+		return ToolchainConfig{cfg: &toolchainv1alpha1.ToolchainConfigSpec{}, secrets: secrets}, nil
+	}
+	return ToolchainConfig{cfg: &config.Spec, secrets: secrets}, nil
+}
+
+// Reset resets the cache.
+// Should be used only in tests, but since it has to be used in other packages,
+// then the function has to be exported and placed here.
+func Reset() {
+	configCache = &cache{}
+}

--- a/pkg/configuration/toolchainconfig/cache_test.go
+++ b/pkg/configuration/toolchainconfig/cache_test.go
@@ -1,0 +1,277 @@
+package toolchainconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCache(t *testing.T) {
+	// given
+	os.Setenv("WATCH_NAMESPACE", test.HostOperatorNs)
+	cl := test.NewFakeClient(t)
+
+	// when
+	defaultConfig, err := GetConfig(cl)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, 1000, defaultConfig.AutomaticApproval().MaxNumberOfUsersOverall())
+	assert.Empty(t, defaultConfig.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+
+	t.Run("return config that is stored in cache", func(t *testing.T) {
+		// given
+		config := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(123, testconfig.PerMemberCluster("member1", 321)))
+		cl := test.NewFakeClient(t, config)
+
+		// when
+		actual, err := GetConfig(cl)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 123, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+		assert.Equal(t, config.Spec.Host.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster, actual.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+
+		t.Run("returns the same when the cache hasn't been updated", func(t *testing.T) {
+			// given
+			newConfig := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(666))
+			cl := test.NewFakeClient(t, newConfig)
+
+			// when
+			actual, err := GetConfig(cl)
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, 123, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+			assert.Equal(t, config.Spec.Host.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster, actual.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+		})
+
+		t.Run("returns the new config when the cache was updated", func(t *testing.T) {
+			// given
+			newConfig := NewToolchainConfigWithReset(t,
+				testconfig.AutomaticApproval().MaxNumberOfUsers(666),
+				testconfig.Deactivation().DeactivatingNotificationDays(5),
+				testconfig.Notifications().Secret().
+					Ref("notification-secret").
+					MailgunAPIKey("mailgunAPIKey"),
+			)
+			cl := test.NewFakeClient(t)
+			secretData := map[string]map[string]string{
+				"notification-secret": {
+					"mailgunAPIKey": "abc123",
+				},
+			}
+
+			// when
+			updateConfig(newConfig, secretData)
+
+			// then
+			actual, err := GetConfig(cl)
+			require.NoError(t, err)
+			assert.Equal(t, 666, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+			assert.Empty(t, actual.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+			assert.Equal(t, 5, actual.Deactivation().DeactivatingNotificationDays())
+			assert.Equal(t, "abc123", actual.Notifications().MailgunAPIKey()) // secret value
+		})
+	})
+}
+
+func TestGetConfigFailed(t *testing.T) {
+	// given
+	t.Run("config not found", func(t *testing.T) {
+		config := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(123, testconfig.PerMemberCluster("member1", 321)))
+		cl := test.NewFakeClient(t, config)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return apierrors.NewNotFound(schema.GroupResource{}, "config")
+		}
+
+		// when
+		defaultConfig, err := GetConfig(cl)
+
+		// then
+		require.NoError(t, err)
+		assert.Equal(t, 1000, defaultConfig.AutomaticApproval().MaxNumberOfUsersOverall())
+		assert.Empty(t, defaultConfig.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+
+	})
+
+	t.Run("error getting config", func(t *testing.T) {
+		config := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(123, testconfig.PerMemberCluster("member1", 321)))
+		cl := test.NewFakeClient(t, config)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		defaultConfig, err := GetConfig(cl)
+
+		// then
+		require.Error(t, err)
+		assert.Equal(t, 1000, defaultConfig.AutomaticApproval().MaxNumberOfUsersOverall())
+		assert.Empty(t, defaultConfig.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+	})
+
+	t.Run("load secrets error", func(t *testing.T) {
+		config := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(123, testconfig.PerMemberCluster("member1", 321)))
+		// given
+		cl := test.NewFakeClient(t, config)
+		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			return fmt.Errorf("list error")
+		}
+
+		// when
+		err := LoadLatest(cl)
+
+		// then
+		require.EqualError(t, err, "list error")
+	})
+}
+
+func TestLoadLatest(t *testing.T) {
+	t.Run("config found", func(t *testing.T) {
+		initconfig := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(1100))
+		// given
+		cl := test.NewFakeClient(t, initconfig)
+
+		// when
+		err := LoadLatest(cl)
+
+		// then
+		require.NoError(t, err)
+		actual, err := GetConfig(cl)
+		require.NoError(t, err)
+		assert.Equal(t, 1100, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+
+		t.Run("returns the same when the config hasn't been updated", func(t *testing.T) {
+			// when
+			err := LoadLatest(cl)
+
+			// then
+			require.NoError(t, err)
+			actual, err = GetConfig(cl)
+			require.NoError(t, err)
+			assert.Equal(t, 1100, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+		})
+
+		t.Run("returns the new value when the config has been updated", func(t *testing.T) {
+			// get
+			changedConfig := UpdateToolchainConfigWithReset(t, cl, testconfig.AutomaticApproval().MaxNumberOfUsers(2000))
+			err := cl.Update(context.TODO(), changedConfig)
+			require.NoError(t, err)
+
+			// when
+			err = LoadLatest(cl)
+
+			// then
+			require.NoError(t, err)
+			actual, err = GetConfig(cl)
+			require.NoError(t, err)
+			assert.Equal(t, 2000, actual.AutomaticApproval().MaxNumberOfUsersOverall())
+		})
+	})
+
+	t.Run("config not found", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t)
+
+		// when
+		err := LoadLatest(cl)
+
+		// then
+		require.NoError(t, err)
+	})
+
+	t.Run("get config error", func(t *testing.T) {
+		initconfig := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(100))
+		// given
+		cl := test.NewFakeClient(t, initconfig)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return fmt.Errorf("get error")
+		}
+
+		// when
+		err := LoadLatest(cl)
+
+		// then
+		require.EqualError(t, err, "get error")
+	})
+
+	t.Run("load secrets error", func(t *testing.T) {
+		initconfig := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(100))
+		// given
+		cl := test.NewFakeClient(t, initconfig)
+		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			return fmt.Errorf("list error")
+		}
+
+		// when
+		err := LoadLatest(cl)
+
+		// then
+		require.EqualError(t, err, "list error")
+	})
+}
+
+func TestMultipleExecutionsInParallel(t *testing.T) {
+	// given
+	var latch sync.WaitGroup
+	latch.Add(1)
+	var waitForFinished sync.WaitGroup
+	initconfig := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(1, testconfig.PerMemberCluster("member", 1)))
+	cl := test.NewFakeClient(t, initconfig)
+
+	for i := 0; i < 1000; i++ {
+		waitForFinished.Add(2)
+		go func() {
+			defer waitForFinished.Done()
+			latch.Wait()
+
+			// when
+			config, err := GetConfig(cl)
+
+			// then
+			require.NoError(t, err)
+			assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersOverall())
+			assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+		}()
+		go func(i int) {
+			defer waitForFinished.Done()
+			latch.Wait()
+			config := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().MaxNumberOfUsers(i+1, testconfig.PerMemberCluster(fmt.Sprintf("member%d", i), i)))
+			updateConfig(config, map[string]map[string]string{})
+		}(i)
+	}
+
+	// when
+	latch.Done()
+	waitForFinished.Wait()
+	config, err := GetConfig(test.NewFakeClient(t))
+
+	// then
+	require.NoError(t, err)
+	assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersOverall())
+	assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+}
+
+func newSecret(name string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: test.HostOperatorNs,
+		},
+		Data: data,
+	}
+}

--- a/pkg/configuration/toolchainconfig/cache_test.go
+++ b/pkg/configuration/toolchainconfig/cache_test.go
@@ -12,9 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -264,14 +262,4 @@ func TestMultipleExecutionsInParallel(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersOverall())
 	assert.NotEmpty(t, config.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
-}
-
-func newSecret(name string, data map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: test.HostOperatorNs,
-		},
-		Data: data,
-	}
 }

--- a/pkg/configuration/toolchainconfig/configuration.go
+++ b/pkg/configuration/toolchainconfig/configuration.go
@@ -1,0 +1,373 @@
+package toolchainconfig
+
+import (
+	"strings"
+	"time"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	ToolchainStatusName = "toolchain-status"
+
+	// NotificationDeliveryServiceMailgun is the notification delivery service to use during production
+	NotificationDeliveryServiceMailgun = "mailgun"
+)
+
+var logger = logf.Log.WithName("configuration")
+
+type ToolchainConfig struct {
+	cfg     *toolchainv1alpha1.ToolchainConfigSpec
+	secrets map[string]map[string]string
+}
+
+func NewToolchainConfig(cfg *toolchainv1alpha1.ToolchainConfigSpec, secrets map[string]map[string]string) ToolchainConfig {
+	return ToolchainConfig{
+		cfg:     cfg,
+		secrets: secrets,
+	}
+}
+
+func (c *ToolchainConfig) Print() {
+	logger.Info("Toolchain configuration variables", "ToolchainConfigSpec", c.cfg)
+}
+
+func (c *ToolchainConfig) Environment() string {
+	return getString(c.cfg.Host.Environment, "prod")
+}
+
+func (c *ToolchainConfig) AutomaticApproval() AutoApprovalConfig {
+	return AutoApprovalConfig{c.cfg.Host.AutomaticApproval}
+}
+
+func (c *ToolchainConfig) Deactivation() DeactivationConfig {
+	return DeactivationConfig{c.cfg.Host.Deactivation}
+}
+
+func (c *ToolchainConfig) Metrics() MetricsConfig {
+	return MetricsConfig{c.cfg.Host.Metrics}
+}
+
+func (c *ToolchainConfig) Notifications() NotificationsConfig {
+	return NotificationsConfig{
+		c:       c.cfg.Host.Notifications,
+		secrets: c.secrets,
+	}
+}
+
+func (c *ToolchainConfig) RegistrationService() RegistrationServiceConfig {
+	return RegistrationServiceConfig{
+		c:       c.cfg.Host.RegistrationService,
+		secrets: c.secrets,
+	}
+}
+
+func (c *ToolchainConfig) Tiers() TiersConfig {
+	return TiersConfig{c.cfg.Host.Tiers}
+}
+
+func (c *ToolchainConfig) ToolchainStatus() ToolchainStatusConfig {
+	return ToolchainStatusConfig{c.cfg.Host.ToolchainStatus}
+}
+
+func (c *ToolchainConfig) Users() UsersConfig {
+	return UsersConfig{c.cfg.Host.Users}
+}
+
+type AutoApprovalConfig struct {
+	approval toolchainv1alpha1.AutomaticApprovalConfig
+}
+
+func (a AutoApprovalConfig) IsEnabled() bool {
+	return getBool(a.approval.Enabled, false)
+}
+
+func (a AutoApprovalConfig) ResourceCapacityThresholdDefault() int {
+	return getInt(a.approval.ResourceCapacityThreshold.DefaultThreshold, 80)
+}
+
+func (a AutoApprovalConfig) ResourceCapacityThresholdSpecificPerMemberCluster() map[string]int {
+	return a.approval.ResourceCapacityThreshold.SpecificPerMemberCluster
+}
+
+func (a AutoApprovalConfig) MaxNumberOfUsersOverall() int {
+	return getInt(a.approval.MaxNumberOfUsers.Overall, 1000)
+}
+
+func (a AutoApprovalConfig) MaxNumberOfUsersSpecificPerMemberCluster() map[string]int {
+	return a.approval.MaxNumberOfUsers.SpecificPerMemberCluster
+}
+
+type DeactivationConfig struct {
+	dctv toolchainv1alpha1.DeactivationConfig
+}
+
+func (d DeactivationConfig) DeactivatingNotificationDays() int {
+	return getInt(d.dctv.DeactivatingNotificationDays, 3)
+}
+
+func (d DeactivationConfig) DeactivationDomainsExcluded() []string {
+	excluded := getString(d.dctv.DeactivationDomainsExcluded, "")
+	v := strings.FieldsFunc(excluded, func(c rune) bool {
+		return c == ','
+	})
+	return v
+}
+
+func (d DeactivationConfig) UserSignupDeactivatedRetentionDays() int {
+	return getInt(d.dctv.UserSignupDeactivatedRetentionDays, 365)
+}
+
+func (d DeactivationConfig) UserSignupUnverifiedRetentionDays() int {
+	return getInt(d.dctv.UserSignupUnverifiedRetentionDays, 7)
+}
+
+type MetricsConfig struct {
+	metrics toolchainv1alpha1.MetricsConfig
+}
+
+func (d MetricsConfig) ForceSynchronization() bool {
+	return getBool(d.metrics.ForceSynchronization, false)
+}
+
+type NotificationsConfig struct {
+	c       toolchainv1alpha1.NotificationsConfig
+	secrets map[string]map[string]string
+}
+
+func (n NotificationsConfig) notificationSecret(secretKey string) string {
+	secret := getString(n.c.Secret.Ref, "")
+	return n.secrets[secret][secretKey]
+}
+
+func (n NotificationsConfig) NotificationDeliveryService() string {
+	return getString(n.c.NotificationDeliveryService, "mailgun")
+}
+
+func (n NotificationsConfig) DurationBeforeNotificationDeletion() time.Duration {
+	v := getString(n.c.DurationBeforeNotificationDeletion, "24h")
+	duration, err := time.ParseDuration(v)
+	if err != nil {
+		duration = 24 * time.Hour
+	}
+	return duration
+}
+
+func (n NotificationsConfig) AdminEmail() string {
+	return getString(n.c.AdminEmail, "")
+}
+
+func (n NotificationsConfig) MailgunDomain() string {
+	key := getString(n.c.Secret.MailgunDomain, "")
+	return n.notificationSecret(key)
+}
+
+func (n NotificationsConfig) MailgunAPIKey() string {
+	key := getString(n.c.Secret.MailgunAPIKey, "")
+	return n.notificationSecret(key)
+}
+
+func (n NotificationsConfig) MailgunSenderEmail() string {
+	key := getString(n.c.Secret.MailgunSenderEmail, "")
+	return n.notificationSecret(key)
+}
+
+func (n NotificationsConfig) MailgunReplyToEmail() string {
+	key := getString(n.c.Secret.MailgunReplyToEmail, "")
+	return n.notificationSecret(key)
+}
+
+type RegistrationServiceConfig struct {
+	c       toolchainv1alpha1.RegistrationServiceConfig
+	secrets map[string]map[string]string
+}
+
+func (r RegistrationServiceConfig) Analytics() RegistrationServiceAnalyticsConfig {
+	return RegistrationServiceAnalyticsConfig{r.c.Analytics}
+}
+
+func (r RegistrationServiceConfig) Auth() RegistrationServiceAuthConfig {
+	return RegistrationServiceAuthConfig{r.c.Auth}
+}
+
+func (r RegistrationServiceConfig) Environment() string {
+	return getString(r.c.Environment, "prod")
+}
+
+func (r RegistrationServiceConfig) LogLevel() string {
+	return getString(r.c.LogLevel, "info")
+}
+
+func (r RegistrationServiceConfig) Namespace() string {
+	return getString(r.c.Namespace, "toolchain-host-operator")
+}
+
+func (r RegistrationServiceConfig) RegistrationServiceURL() string {
+	return getString(r.c.RegistrationServiceURL, "https://registration.crt-placeholder.com")
+}
+
+func (r RegistrationServiceConfig) Verification() RegistrationServiceVerificationConfig {
+	return RegistrationServiceVerificationConfig{c: r.c.Verification, secrets: r.secrets}
+}
+
+type RegistrationServiceAnalyticsConfig struct {
+	c toolchainv1alpha1.RegistrationServiceAnalyticsConfig
+}
+
+func (r RegistrationServiceAnalyticsConfig) WoopraDomain() string {
+	return getString(r.c.WoopraDomain, "")
+}
+
+func (r RegistrationServiceAnalyticsConfig) SegmentWriteKey() string {
+	return getString(r.c.SegmentWriteKey, "")
+}
+
+type RegistrationServiceAuthConfig struct {
+	c toolchainv1alpha1.RegistrationServiceAuthConfig
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientLibraryURL() string {
+	return getString(r.c.AuthClientLibraryURL, "https://sso.prod-preview.openshift.io/auth/js/keycloak.js")
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientConfigContentType() string {
+	return getString(r.c.AuthClientConfigContentType, "application/json; charset=utf-8")
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientConfigRaw() string {
+	return getString(r.c.AuthClientConfigRaw, `{"realm": "toolchain-public","auth-server-url": "https://sso.prod-preview.openshift.io/auth","ssl-required": "none","resource": "crt","clientId": "crt","public-client": true}`)
+}
+
+func (r RegistrationServiceAuthConfig) AuthClientPublicKeysURL() string {
+	return getString(r.c.AuthClientPublicKeysURL, "https://sso.prod-preview.openshift.io/auth/realms/toolchain-public/protocol/openid-connect/certs")
+}
+
+type RegistrationServiceVerificationConfig struct {
+	c       toolchainv1alpha1.RegistrationServiceVerificationConfig
+	secrets map[string]map[string]string
+}
+
+func (r RegistrationServiceVerificationConfig) registrationServiceSecret(secretKey string) string {
+	secret := getString(r.c.Secret.Ref, "")
+	return r.secrets[secret][secretKey]
+}
+
+func (r RegistrationServiceVerificationConfig) Enabled() bool {
+	return getBool(r.c.Enabled, false)
+}
+
+func (r RegistrationServiceVerificationConfig) DailyLimit() int {
+	return getInt(r.c.DailyLimit, 5)
+}
+
+func (r RegistrationServiceVerificationConfig) AttemptsAllowed() int {
+	return getInt(r.c.AttemptsAllowed, 3)
+}
+
+func (r RegistrationServiceVerificationConfig) MessageTemplate() string {
+	return getString(r.c.MessageTemplate, "Developer Sandbox for Red Hat OpenShift: Your verification code is %s")
+}
+
+func (r RegistrationServiceVerificationConfig) ExcludedEmailDomains() string {
+	return getString(r.c.ExcludedEmailDomains, "")
+}
+
+func (r RegistrationServiceVerificationConfig) CodeExpiresInMin() int {
+	return getInt(r.c.CodeExpiresInMin, 5)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioAccountSID() string {
+	key := getString(r.c.Secret.TwilioAccountSID, "")
+	return r.registrationServiceSecret(key)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioAuthToken() string {
+	key := getString(r.c.Secret.TwilioAuthToken, "")
+	return r.registrationServiceSecret(key)
+}
+
+func (r RegistrationServiceVerificationConfig) TwilioFromNumber() string {
+	key := getString(r.c.Secret.TwilioFromNumber, "")
+	return r.registrationServiceSecret(key)
+}
+
+type TiersConfig struct {
+	tiers toolchainv1alpha1.TiersConfig
+}
+
+func (d TiersConfig) DefaultTier() string {
+	return getString(d.tiers.DefaultTier, "base")
+}
+
+func (d TiersConfig) DurationBeforeChangeTierRequestDeletion() time.Duration {
+	v := getString(d.tiers.DurationBeforeChangeTierRequestDeletion, "24h")
+	duration, err := time.ParseDuration(v)
+	if err != nil {
+		duration = 24 * time.Hour
+	}
+	return duration
+}
+
+func (d TiersConfig) TemplateUpdateRequestMaxPoolSize() int {
+	return getInt(d.tiers.TemplateUpdateRequestMaxPoolSize, 5)
+}
+
+type ToolchainStatusConfig struct {
+	t toolchainv1alpha1.ToolchainStatusConfig
+}
+
+func (d ToolchainStatusConfig) ToolchainStatusRefreshTime() time.Duration {
+	v := getString(d.t.ToolchainStatusRefreshTime, "5s")
+	duration, err := time.ParseDuration(v)
+	if err != nil {
+		duration = 5 * time.Second
+	}
+	return duration
+}
+
+type UsersConfig struct {
+	c toolchainv1alpha1.UsersConfig
+}
+
+func (d UsersConfig) MasterUserRecordUpdateFailureThreshold() int {
+	return getInt(d.c.MasterUserRecordUpdateFailureThreshold, 2) // default: allow 1 failure, try again and then give up if failed again
+}
+
+func (d UsersConfig) ForbiddenUsernamePrefixes() []string {
+	prefixes := getString(d.c.ForbiddenUsernamePrefixes, "openshift,kube,default,redhat,sandbox")
+	v := strings.FieldsFunc(prefixes, func(c rune) bool {
+		return c == ','
+	})
+	return v
+}
+
+func (d UsersConfig) ForbiddenUsernameSuffixes() []string {
+	suffixes := getString(d.c.ForbiddenUsernameSuffixes, "admin")
+	v := strings.FieldsFunc(suffixes, func(c rune) bool {
+		return c == ','
+	})
+	return v
+}
+
+func getBool(value *bool, defaultValue bool) bool {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}
+
+func getInt(value *int, defaultValue int) int {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}
+
+func getString(value *string, defaultValue string) string {
+	if value != nil {
+		return *value
+	}
+	return defaultValue
+}

--- a/pkg/configuration/toolchainconfig/configuration_test.go
+++ b/pkg/configuration/toolchainconfig/configuration_test.go
@@ -1,0 +1,263 @@
+package toolchainconfig
+
+import (
+	"testing"
+	"time"
+
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAutomaticApprovalConfig(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.False(t, toolchainCfg.AutomaticApproval().IsEnabled())
+		assert.Equal(t, 1000, toolchainCfg.AutomaticApproval().MaxNumberOfUsersOverall())
+		assert.Empty(t, toolchainCfg.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+		assert.Equal(t, 80, toolchainCfg.AutomaticApproval().ResourceCapacityThresholdDefault())
+		assert.Empty(t, toolchainCfg.AutomaticApproval().ResourceCapacityThresholdSpecificPerMemberCluster())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.AutomaticApproval().Enabled(true).MaxNumberOfUsers(123, testconfig.PerMemberCluster("member1", 321)).ResourceCapacityThreshold(456, testconfig.PerMemberCluster("member1", 654)))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.True(t, toolchainCfg.AutomaticApproval().IsEnabled())
+		assert.Equal(t, 123, toolchainCfg.AutomaticApproval().MaxNumberOfUsersOverall())
+		assert.Equal(t, cfg.Spec.Host.AutomaticApproval.MaxNumberOfUsers.SpecificPerMemberCluster, toolchainCfg.AutomaticApproval().MaxNumberOfUsersSpecificPerMemberCluster())
+		assert.Equal(t, 456, toolchainCfg.AutomaticApproval().ResourceCapacityThresholdDefault())
+		assert.Equal(t, cfg.Spec.Host.AutomaticApproval.ResourceCapacityThreshold.SpecificPerMemberCluster, toolchainCfg.AutomaticApproval().ResourceCapacityThresholdSpecificPerMemberCluster())
+	})
+}
+
+func TestDeactivationConfig(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 3, toolchainCfg.Deactivation().DeactivatingNotificationDays())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Deactivation().DeactivatingNotificationDays(5))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 5, toolchainCfg.Deactivation().DeactivatingNotificationDays())
+	})
+}
+
+func TestEnvironment(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, "prod", toolchainCfg.Environment())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Environment(testconfig.E2E))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, "e2e-tests", toolchainCfg.Environment())
+	})
+}
+
+func TestMetrics(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.False(t, toolchainCfg.Metrics().ForceSynchronization())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Metrics().ForceSynchronization(true))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.True(t, toolchainCfg.Metrics().ForceSynchronization())
+	})
+}
+
+func TestNotifications(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Empty(t, toolchainCfg.Notifications().AdminEmail())
+		assert.Empty(t, toolchainCfg.Notifications().MailgunDomain())
+		assert.Empty(t, toolchainCfg.Notifications().MailgunAPIKey())
+		assert.Empty(t, toolchainCfg.Notifications().MailgunSenderEmail())
+		assert.Empty(t, toolchainCfg.Notifications().MailgunReplyToEmail())
+		assert.Equal(t, "mailgun", toolchainCfg.Notifications().NotificationDeliveryService())
+		assert.Equal(t, 24*time.Hour, toolchainCfg.Notifications().DurationBeforeNotificationDeletion())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t,
+			testconfig.Notifications().
+				AdminEmail("joe.schmoe@redhat.com").
+				DurationBeforeNotificationDeletion("48h").
+				NotificationDeliveryService("mailknife").
+				Secret().
+				Ref("notifications").
+				MailgunAPIKey("mailgunAPIKey").
+				MailgunDomain("mailgunDomain").
+				MailgunReplyToEmail("replyTo").
+				MailgunSenderEmail("sender"))
+		notificationSecretValues := make(map[string]string)
+		notificationSecretValues["mailgunAPIKey"] = "abc123"
+		notificationSecretValues["mailgunDomain"] = "domain.abc"
+		notificationSecretValues["replyTo"] = "devsandbox_rulez@redhat.com"
+		notificationSecretValues["sender"] = "devsandbox@redhat.com"
+		secrets := make(map[string]map[string]string)
+		secrets["notifications"] = notificationSecretValues
+
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, secrets)
+
+		assert.Equal(t, "joe.schmoe@redhat.com", toolchainCfg.Notifications().AdminEmail())
+		assert.Equal(t, "abc123", toolchainCfg.Notifications().MailgunAPIKey())
+		assert.Equal(t, "domain.abc", toolchainCfg.Notifications().MailgunDomain())
+		assert.Equal(t, "devsandbox_rulez@redhat.com", toolchainCfg.Notifications().MailgunReplyToEmail())
+		assert.Equal(t, "devsandbox@redhat.com", toolchainCfg.Notifications().MailgunSenderEmail())
+		assert.Equal(t, "mailknife", toolchainCfg.Notifications().NotificationDeliveryService())
+		assert.Equal(t, 48*time.Hour, toolchainCfg.Notifications().DurationBeforeNotificationDeletion())
+	})
+}
+
+func TestRegistrationService(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, "prod", toolchainCfg.RegistrationService().Environment())
+		assert.Equal(t, "info", toolchainCfg.RegistrationService().LogLevel())
+		assert.Equal(t, "toolchain-host-operator", toolchainCfg.RegistrationService().Namespace())
+		assert.Equal(t, "https://registration.crt-placeholder.com", toolchainCfg.RegistrationService().RegistrationServiceURL())
+		assert.Empty(t, toolchainCfg.RegistrationService().Analytics().SegmentWriteKey())
+		assert.Empty(t, toolchainCfg.RegistrationService().Analytics().WoopraDomain())
+		assert.Equal(t, "https://sso.prod-preview.openshift.io/auth/js/keycloak.js", toolchainCfg.RegistrationService().Auth().AuthClientLibraryURL())
+		assert.Equal(t, "application/json; charset=utf-8", toolchainCfg.RegistrationService().Auth().AuthClientConfigContentType())
+		assert.Equal(t, `{"realm": "toolchain-public","auth-server-url": "https://sso.prod-preview.openshift.io/auth","ssl-required": "none","resource": "crt","clientId": "crt","public-client": true}`,
+			toolchainCfg.RegistrationService().Auth().AuthClientConfigRaw())
+		assert.Equal(t, "https://sso.prod-preview.openshift.io/auth/realms/toolchain-public/protocol/openid-connect/certs", toolchainCfg.RegistrationService().Auth().AuthClientPublicKeysURL())
+		assert.False(t, toolchainCfg.RegistrationService().Verification().Enabled())
+		assert.Equal(t, 5, toolchainCfg.RegistrationService().Verification().DailyLimit())
+		assert.Equal(t, 3, toolchainCfg.RegistrationService().Verification().AttemptsAllowed())
+		assert.Equal(t, "Developer Sandbox for Red Hat OpenShift: Your verification code is %s", toolchainCfg.RegistrationService().Verification().MessageTemplate())
+		assert.Empty(t, toolchainCfg.RegistrationService().Verification().ExcludedEmailDomains())
+		assert.Equal(t, 5, toolchainCfg.RegistrationService().Verification().CodeExpiresInMin())
+		assert.Empty(t, toolchainCfg.RegistrationService().Verification().TwilioAccountSID())
+		assert.Empty(t, toolchainCfg.RegistrationService().Verification().TwilioAuthToken())
+		assert.Empty(t, toolchainCfg.RegistrationService().Verification().TwilioFromNumber())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.RegistrationService().
+			Environment("e2e-tests").
+			LogLevel("debug").
+			Namespace("another-namespace").
+			RegistrationServiceURL("www.crtregservice.com").
+			Analytics().SegmentWriteKey("keyabc").
+			Analytics().WoopraDomain("woopra.com").
+			Auth().AuthClientLibraryURL("https://sso.openshift.com/auth/js/keycloak.js").
+			Auth().AuthClientConfigContentType("application/xml").
+			Auth().AuthClientConfigRaw(`{"realm": "toolchain-private"}`).
+			Auth().AuthClientPublicKeysURL("https://sso.openshift.com/certs").
+			Verification().Enabled(true).
+			Verification().DailyLimit(15).
+			Verification().AttemptsAllowed(13).
+			Verification().MessageTemplate("Developer Sandbox verification code: %s").
+			Verification().ExcludedEmailDomains("redhat.com,ibm.com").
+			Verification().CodeExpiresInMin(151).
+			Verification().Secret().Ref("verification-secrets").TwilioAccountSID("twiolio.sid").TwilioAuthToken("twiolio.token").TwilioFromNumber("twiolio.fromnumber"))
+
+		verificationSecretValues := make(map[string]string)
+		verificationSecretValues["twiolio.sid"] = "def"
+		verificationSecretValues["twiolio.token"] = "ghi"
+		verificationSecretValues["twiolio.fromnumber"] = "jkl"
+		secrets := make(map[string]map[string]string)
+		secrets["verification-secrets"] = verificationSecretValues
+
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, secrets)
+
+		assert.Equal(t, "e2e-tests", toolchainCfg.RegistrationService().Environment())
+		assert.Equal(t, "debug", toolchainCfg.RegistrationService().LogLevel())
+		assert.Equal(t, "another-namespace", toolchainCfg.RegistrationService().Namespace())
+		assert.Equal(t, "www.crtregservice.com", toolchainCfg.RegistrationService().RegistrationServiceURL())
+		assert.Equal(t, "keyabc", toolchainCfg.RegistrationService().Analytics().SegmentWriteKey())
+		assert.Equal(t, "woopra.com", toolchainCfg.RegistrationService().Analytics().WoopraDomain())
+		assert.Equal(t, "https://sso.openshift.com/auth/js/keycloak.js", toolchainCfg.RegistrationService().Auth().AuthClientLibraryURL())
+		assert.Equal(t, "application/xml", toolchainCfg.RegistrationService().Auth().AuthClientConfigContentType())
+		assert.Equal(t, `{"realm": "toolchain-private"}`, toolchainCfg.RegistrationService().Auth().AuthClientConfigRaw())
+		assert.Equal(t, "https://sso.openshift.com/certs", toolchainCfg.RegistrationService().Auth().AuthClientPublicKeysURL())
+
+		assert.True(t, toolchainCfg.RegistrationService().Verification().Enabled())
+		assert.Equal(t, 15, toolchainCfg.RegistrationService().Verification().DailyLimit())
+		assert.Equal(t, 13, toolchainCfg.RegistrationService().Verification().AttemptsAllowed())
+		assert.Equal(t, "Developer Sandbox verification code: %s", toolchainCfg.RegistrationService().Verification().MessageTemplate())
+		assert.Equal(t, "redhat.com,ibm.com", toolchainCfg.RegistrationService().Verification().ExcludedEmailDomains())
+		assert.Equal(t, 151, toolchainCfg.RegistrationService().Verification().CodeExpiresInMin())
+		assert.Equal(t, "def", toolchainCfg.RegistrationService().Verification().TwilioAccountSID())
+		assert.Equal(t, "ghi", toolchainCfg.RegistrationService().Verification().TwilioAuthToken())
+		assert.Equal(t, "jkl", toolchainCfg.RegistrationService().Verification().TwilioFromNumber())
+	})
+}
+
+func TestTiers(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, "base", toolchainCfg.Tiers().DefaultTier())
+		assert.Equal(t, 24*time.Hour, toolchainCfg.Tiers().DurationBeforeChangeTierRequestDeletion())
+		assert.Equal(t, 5, toolchainCfg.Tiers().TemplateUpdateRequestMaxPoolSize())
+	})
+	t.Run("invalid", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Tiers().DurationBeforeChangeTierRequestDeletion("rapid"))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 24*time.Hour, toolchainCfg.Tiers().DurationBeforeChangeTierRequestDeletion())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Tiers().
+			DefaultTier("advanced").
+			DurationBeforeChangeTierRequestDeletion("48h").
+			TemplateUpdateRequestMaxPoolSize(40))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, "advanced", toolchainCfg.Tiers().DefaultTier())
+		assert.Equal(t, 48*time.Hour, toolchainCfg.Tiers().DurationBeforeChangeTierRequestDeletion())
+		assert.Equal(t, 40, toolchainCfg.Tiers().TemplateUpdateRequestMaxPoolSize())
+	})
+}
+
+func TestToolchainStatus(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 5*time.Second, toolchainCfg.ToolchainStatus().ToolchainStatusRefreshTime())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.ToolchainStatus().ToolchainStatusRefreshTime("10s"))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 10*time.Second, toolchainCfg.ToolchainStatus().ToolchainStatusRefreshTime())
+	})
+}
+
+func TestUsers(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t)
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 2, toolchainCfg.Users().MasterUserRecordUpdateFailureThreshold())
+		assert.Equal(t, []string{"openshift", "kube", "default", "redhat", "sandbox"}, toolchainCfg.Users().ForbiddenUsernamePrefixes())
+		assert.Equal(t, []string{"admin"}, toolchainCfg.Users().ForbiddenUsernameSuffixes())
+	})
+	t.Run("non-default", func(t *testing.T) {
+		cfg := NewToolchainConfigWithReset(t, testconfig.Users().MasterUserRecordUpdateFailureThreshold(10).ForbiddenUsernamePrefixes("bread,butter").ForbiddenUsernameSuffixes("sugar,cream"))
+		toolchainCfg := NewToolchainConfig(&cfg.Spec, map[string]map[string]string{})
+
+		assert.Equal(t, 10, toolchainCfg.Users().MasterUserRecordUpdateFailureThreshold())
+		assert.Equal(t, []string{"bread", "butter"}, toolchainCfg.Users().ForbiddenUsernamePrefixes())
+		assert.Equal(t, []string{"sugar", "cream"}, toolchainCfg.Users().ForbiddenUsernameSuffixes())
+	})
+}

--- a/pkg/configuration/toolchainconfig/test.go
+++ b/pkg/configuration/toolchainconfig/test.go
@@ -1,0 +1,28 @@
+package toolchainconfig
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewToolchainConfigWithReset(t *testing.T, options ...testconfig.ToolchainConfigOption) *toolchainv1alpha1.ToolchainConfig {
+	t.Cleanup(Reset)
+	return testconfig.NewToolchainConfig(options...)
+}
+
+func UpdateToolchainConfigWithReset(t *testing.T, cl client.Client, options ...testconfig.ToolchainConfigOption) *toolchainv1alpha1.ToolchainConfig {
+	currentConfig := &toolchainv1alpha1.ToolchainConfig{}
+	err := cl.Get(context.TODO(), types.NamespacedName{Namespace: test.HostOperatorNs, Name: "config"}, currentConfig)
+	require.NoError(t, err)
+	t.Cleanup(Reset)
+	return testconfig.ModifyToolchainConfig(currentConfig, options...)
+}

--- a/pkg/test/config/toolchainconfig.go
+++ b/pkg/test/config/toolchainconfig.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type EnvName string
@@ -259,11 +261,194 @@ func RegistrationService() *RegistrationServiceOption {
 	return o
 }
 
+func (o RegistrationServiceOption) Environment(value string) RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Environment = &value
+	})
+	return o
+}
+
+func (o RegistrationServiceOption) LogLevel(value string) RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.LogLevel = &value
+	})
+	return o
+}
+
+func (o RegistrationServiceOption) Namespace(value string) RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Namespace = &value
+	})
+	return o
+}
+
 func (o RegistrationServiceOption) RegistrationServiceURL(value string) RegistrationServiceOption {
 	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
 		config.Spec.Host.RegistrationService.RegistrationServiceURL = &value
 	})
 	return o
+}
+
+func (o RegistrationServiceOption) Analytics() *RegistrationServiceAnalyticsOption {
+	c := &RegistrationServiceAnalyticsOption{
+		ToolchainConfigOptionImpl: o.ToolchainConfigOptionImpl,
+		parent:                    o,
+	}
+	return c
+}
+
+func (o RegistrationServiceOption) Auth() *RegistrationServiceAuthOption {
+	c := &RegistrationServiceAuthOption{
+		ToolchainConfigOptionImpl: o.ToolchainConfigOptionImpl,
+		parent:                    o,
+	}
+	return c
+}
+
+func (o RegistrationServiceOption) Verification() *RegistrationServiceVerificationOption {
+	c := &RegistrationServiceVerificationOption{
+		ToolchainConfigOptionImpl: o.ToolchainConfigOptionImpl,
+		parent:                    o,
+	}
+	return c
+}
+
+type RegistrationServiceAnalyticsOption struct {
+	*ToolchainConfigOptionImpl
+	parent RegistrationServiceOption
+}
+
+func (o RegistrationServiceAnalyticsOption) SegmentWriteKey(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Analytics.SegmentWriteKey = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceAnalyticsOption) WoopraDomain(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Analytics.WoopraDomain = &value
+	})
+	return &o.parent
+}
+
+type RegistrationServiceAuthOption struct {
+	*ToolchainConfigOptionImpl
+	parent RegistrationServiceOption
+}
+
+func (o RegistrationServiceAuthOption) AuthClientConfigContentType(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Auth.AuthClientConfigContentType = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceAuthOption) AuthClientLibraryURL(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Auth.AuthClientLibraryURL = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceAuthOption) AuthClientConfigRaw(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Auth.AuthClientConfigRaw = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceAuthOption) AuthClientPublicKeysURL(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Auth.AuthClientPublicKeysURL = &value
+	})
+	return &o.parent
+}
+
+type RegistrationServiceVerificationOption struct {
+	*ToolchainConfigOptionImpl
+	parent RegistrationServiceOption
+}
+
+func (o RegistrationServiceVerificationOption) Enabled(value bool) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.Enabled = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) DailyLimit(value int) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.DailyLimit = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) AttemptsAllowed(value int) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.AttemptsAllowed = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) MessageTemplate(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.MessageTemplate = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) ExcludedEmailDomains(value string) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.ExcludedEmailDomains = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) CodeExpiresInMin(value int) *RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.CodeExpiresInMin = &value
+	})
+	return &o.parent
+}
+
+func (o RegistrationServiceVerificationOption) Secret() *RegistrationVerificationSecretOption {
+	c := &RegistrationVerificationSecretOption{
+		ToolchainConfigOptionImpl: o.ToolchainConfigOptionImpl,
+	}
+	return c
+}
+
+type RegistrationVerificationSecretOption struct {
+	*ToolchainConfigOptionImpl
+}
+
+func (o RegistrationVerificationSecretOption) Ref(value string) RegistrationVerificationSecretOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.Secret.Ref = &value
+	})
+	return o
+}
+
+func (o RegistrationVerificationSecretOption) TwilioAccountSID(value string) *RegistrationVerificationSecretOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.Secret.TwilioAccountSID = &value
+	})
+	return &o
+}
+
+func (o RegistrationVerificationSecretOption) TwilioAuthToken(value string) *RegistrationVerificationSecretOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.Secret.TwilioAuthToken = &value
+	})
+	return &o
+}
+
+func (o RegistrationVerificationSecretOption) TwilioFromNumber(value string) *RegistrationVerificationSecretOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.Verification.Secret.TwilioFromNumber = &value
+	})
+	return &o
 }
 
 type TiersOption struct {
@@ -276,6 +461,13 @@ func Tiers() *TiersOption {
 	}
 	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
 		config.Spec.Host.Tiers = toolchainv1alpha1.TiersConfig{}
+	})
+	return o
+}
+
+func (o TiersOption) DefaultTier(value string) TiersOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.Tiers.DefaultTier = &value
 	})
 	return o
 }
@@ -382,3 +574,23 @@ func (o MembersOption) SpecificPerMemberCluster(clusterName string, memberConfig
 }
 
 //---End of Member Configurations---//
+
+func NewToolchainConfig(options ...ToolchainConfigOption) *toolchainv1alpha1.ToolchainConfig {
+	toolchainConfig := &toolchainv1alpha1.ToolchainConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: test.HostOperatorNs,
+			Name:      "config",
+		},
+	}
+	for _, option := range options {
+		option.Apply(toolchainConfig)
+	}
+	return toolchainConfig
+}
+
+func ModifyToolchainConfig(toolchainConfig *toolchainv1alpha1.ToolchainConfig, options ...ToolchainConfigOption) *toolchainv1alpha1.ToolchainConfig {
+	for _, option := range options {
+		option.Apply(toolchainConfig)
+	}
+	return toolchainConfig
+}


### PR DESCRIPTION
Both the host operator and registration service will use the ToolchainConfig resource for configuration. The cache and configuration functions will all be part of toolchain-common and will be imported for use by both.

Summary of changes:
- Added cache for ToolchainConfig, similar to MemberOperatorConfig in member-operator repo
- Added the remaining configuration functions for all ToolchainConfig fields
- Added test helper functions for creating ToolchainConfig resources in unit and e2e tests