### PR TITLE
feat: change OnlyUpdateWhenGenerationNotChanged to EitherUpdateWhenGenerationNotChangedOrDelete

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -10,15 +10,13 @@ import (
 
 var log = logf.Log.WithName("generation_not_changed_predicate").WithName("eventFilters")
 
-// OnlyUpdateWhenGenerationNotChanged implements a default update predicate function on no generation change
-// (adapted from sigs.k8s.io/controller-runtime/pkg/predicate/predicate.ResourceVersionChangedPredicate)
-// other predicate functions return false for all cases
-// Copied and slightly modified from github.com/operator-framework/operator-sdk/pkg/predicate/predicate.go
-type OnlyUpdateWhenGenerationNotChanged struct {
+// EitherUpdateWhenGenerationNotChangedOrDelete implements a predicate that triggers
+// reconciles either for updates when generation was not changed or for deletion
+type EitherUpdateWhenGenerationNotChangedOrDelete struct {
 }
 
 // Update implements default UpdateEvent filter for validating no generation change
-func (OnlyUpdateWhenGenerationNotChanged) Update(e event.UpdateEvent) bool {
+func (EitherUpdateWhenGenerationNotChangedOrDelete) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
 		log.Error(nil, "Update event has no old runtime object to update", "event", e)
 		return false
@@ -31,17 +29,17 @@ func (OnlyUpdateWhenGenerationNotChanged) Update(e event.UpdateEvent) bool {
 }
 
 // Create implements Predicate
-func (OnlyUpdateWhenGenerationNotChanged) Create(e event.CreateEvent) bool {
+func (EitherUpdateWhenGenerationNotChangedOrDelete) Create(e event.CreateEvent) bool {
 	return false
 }
 
 // Delete implements Predicate
-func (OnlyUpdateWhenGenerationNotChanged) Delete(e event.DeleteEvent) bool {
-	return false
+func (EitherUpdateWhenGenerationNotChangedOrDelete) Delete(e event.DeleteEvent) bool {
+	return true
 }
 
 // Generic implements Predicate
-func (OnlyUpdateWhenGenerationNotChanged) Generic(e event.GenericEvent) bool {
+func (EitherUpdateWhenGenerationNotChangedOrDelete) Generic(e event.GenericEvent) bool {
 	return false
 }
 

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -15,7 +15,7 @@ var missingDataEvents = []event.UpdateEvent{
 	{ObjectOld: &toolchainv1alpha1.UserAccount{}}}
 
 func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
-	var noGenChangedPred = OnlyUpdateWhenGenerationNotChanged{}
+	var noGenChangedPred = EitherUpdateWhenGenerationNotChangedOrDelete{}
 
 	t.Run("update event", func(t *testing.T) {
 
@@ -70,7 +70,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	t.Run("delete event returns false", func(t *testing.T) {
+	t.Run("delete event returns true", func(t *testing.T) {
 		// given
 		deleteEvent := event.DeleteEvent{
 			Object: &toolchainv1alpha1.UserAccount{ObjectMeta: metav1.ObjectMeta{Generation: int64(123456789)}}}
@@ -79,7 +79,7 @@ func TestOnlyUpdateWhenGenerationNotChangedPredicate(t *testing.T) {
 		ok := noGenChangedPred.Delete(deleteEvent)
 
 		// then
-		assert.False(t, ok)
+		assert.True(t, ok)
 	})
 
 	t.Run("generic event returns false", func(t *testing.T) {


### PR DESCRIPTION
so we can trigger UserAccount & MUR synchronization when the UserAccount is deleted https://github.com/codeready-toolchain/member-operator/pull/262/files#diff-c89c801eedf1fb2ec513266c0db32b8bed526c51bc2e8d81fc09758f302a718cR46-R63