### PR TITLE
refactor: use `client.Object` instead of `meta.Accessor()`

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	templatev1 "github.com/openshift/api/template/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	authv1 "github.com/openshift/api/authorization/v1"
@@ -587,11 +586,9 @@ func TestProcessAndApply(t *testing.T) {
 		// given
 		cl := NewFakeClient(t)
 		cl.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
-			meta, err := meta.Accessor(obj)
-			require.NoError(t, err)
-			t.Logf("updating resource of kind %s with version %s\n", obj.GetObjectKind().GroupVersionKind().Kind, meta.GetResourceVersion())
-			if obj.GetObjectKind().GroupVersionKind().Kind == "RoleBinding" && meta.GetResourceVersion() != "1" {
-				return fmt.Errorf("invalid resource version: %q", meta.GetResourceVersion())
+			t.Logf("updating resource of kind %s with version %s\n", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetResourceVersion())
+			if obj.GetObjectKind().GroupVersionKind().Kind == "RoleBinding" && obj.GetResourceVersion() != "1" {
+				return fmt.Errorf("invalid resource version: %q", obj.GetResourceVersion())
 			}
 			return cl.Client.Update(ctx, obj, opts...)
 		}

--- a/pkg/client/toolchain_object.go
+++ b/pkg/client/toolchain_object.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -37,19 +35,14 @@ type toolchainObjectImpl struct {
 }
 
 // NewToolchainObject returns an instance of ToolchainObject for the given runtime.Object
-func NewToolchainObject(ob client.Object) (ToolchainObject, error) {
-	if ob == nil {
+func NewToolchainObject(obj client.Object) (ToolchainObject, error) {
+	if obj == nil {
 		return nil, fmt.Errorf("the provided object is nil, so the constructor cannot create an instance of ToolchainObject")
 	}
-	accessor, err := meta.Accessor(ob)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get accessor of object %v", ob)
-	}
-
 	return &toolchainObjectImpl{
-		Object:       accessor,
-		gvk:          ob.GetObjectKind().GroupVersionKind(),
-		clientObject: ob,
+		Object:       obj,
+		gvk:          obj.GetObjectKind().GroupVersionKind(),
+		clientObject: obj,
 	}, nil
 }
 

--- a/pkg/template/processor_test.go
+++ b/pkg/template/processor_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/template"
 	. "github.com/codeready-toolchain/toolchain-common/pkg/test"
 	templatev1 "github.com/openshift/api/template/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 
 	authv1 "github.com/openshift/api/authorization/v1"
 	"github.com/stretchr/testify/assert"
@@ -237,13 +236,11 @@ func getNameWithTimestamp(prefix string) string {
 func assertObject(t *testing.T, expectedObj expectedObj, actual client.ToolchainObject) {
 	expected, err := newObject(string(expectedObj.template), expectedObj.username, expectedObj.commit)
 	require.NoError(t, err, "failed to create object from template")
-	expMeta, err := meta.Accessor(expected)
-	require.NoError(t, err)
 
 	assert.Equal(t, expected, actual.GetClientObject())
 	assert.Equal(t, expected.GetObjectKind().GroupVersionKind(), actual.GetGvk())
-	assert.Equal(t, expMeta.GetName(), actual.GetName())
-	assert.Equal(t, expMeta.GetNamespace(), actual.GetNamespace())
+	assert.Equal(t, expected.GetName(), actual.GetName())
+	assert.Equal(t, expected.GetNamespace(), actual.GetNamespace())
 }
 
 type expectedObj struct {
@@ -252,7 +249,7 @@ type expectedObj struct {
 	commit   string
 }
 
-func newObject(template, username, commit string) (runtime.Unstructured, error) {
+func newObject(template, username, commit string) (*unstructured.Unstructured, error) {
 	tmpl := texttemplate.New("")
 	tmpl, err := tmpl.Parse(template)
 	if err != nil {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/CRT-1182

see also: https://github.com/codeready-toolchain/member-operator/pull/297, https://github.com/codeready-toolchain/toolchain-e2e/pull/384 and https://github.com/codeready-toolchain/registration-service/pull/215

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
