### PR TITLE
Add modifier for mur labels

### DIFF
--- a/pkg/test/masteruserrecord/master_user_record.go
+++ b/pkg/test/masteruserrecord/master_user_record.go
@@ -381,3 +381,18 @@ func WithAnnotation(key, value string) MurModifier {
 		return nil
 	}
 }
+
+// WithLabel sets a label with the given key/value
+func WithLabel(key, value string) MurModifier {
+	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
+		if mur.Labels == nil {
+			mur.Labels = map[string]string{}
+		}
+		mur.Labels[key] = value
+		return nil
+	}
+}
+
+func WithOwnerLabel(owner string) MurModifier {
+	return WithLabel(toolchainv1alpha1.MasterUserRecordOwnerLabelKey, owner)
+}


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRT-1222

Adds a MasterUserRecord modifier test utility func to be used to add the owner label to MURs in changetierrequest_controller_test.go in the host operator.