### PR TITLE
Add kube core api group to member client

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -84,6 +84,9 @@ func (s *ToolchainClusterService) addToolchainCluster(log logr.Logger, toolchain
 		if err := toolchainv1alpha1.AddToScheme(scheme); err != nil {
 			return err
 		}
+		if err := v1.AddToScheme(scheme); err != nil {
+			return err
+		}
 		cl, err = client.New(clusterConfig, client.Options{
 			Scheme: scheme,
 		})


### PR DESCRIPTION
So the member cluster client (used by host) can get Secrets and Service Accounts. It's required for the proxy.