### PR TITLE
feat: introduce cluster Config and a way to list them

### DIFF
--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -68,7 +68,7 @@ func updateClusterStatuses(namespace string, cl client.Client) {
 			continue
 		}
 
-		clientSet, err := kubeclientset.NewForConfig(cachedCluster.Config.Config)
+		clientSet, err := kubeclientset.NewForConfig(cachedCluster.RestConfig)
 		if err != nil {
 			clusterLogger.Error(err, "cannot create ClientSet for a ToolchainCluster")
 			continue

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -68,7 +68,7 @@ func updateClusterStatuses(namespace string, cl client.Client) {
 			continue
 		}
 
-		clientSet, err := kubeclientset.NewForConfig(cachedCluster.Config)
+		clientSet, err := kubeclientset.NewForConfig(cachedCluster.Config.Config)
 		if err != nil {
 			clusterLogger.Error(err, "cannot create ClientSet for a ToolchainCluster")
 			continue

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -17,8 +17,8 @@ type toolchainClusterClients struct {
 }
 
 type Config struct {
-	// Config contains rest config data
-	Config *rest.Config
+	// RestConfig contains rest config data
+	RestConfig *rest.Config
 	// Name is the name of the cluster. Has to be unique - is used as a key in a map.
 	Name string
 	// APIEndpoint is the API endpoint of the corresponding ToolchainCluster. This can be a hostname,

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -16,10 +16,7 @@ type toolchainClusterClients struct {
 	refreshCache func()
 }
 
-// CachedToolchainCluster stores cluster client; cluster related info and previous health check probe results
-type CachedToolchainCluster struct {
-	// Client is the kube client for the cluster.
-	Client client.Client
+type Config struct {
 	// Config contains rest config data
 	Config *rest.Config
 	// Name is the name of the cluster. Has to be unique - is used as a key in a map.
@@ -31,13 +28,20 @@ type CachedToolchainCluster struct {
 	Type Type
 	// OperatorNamespace is a name of a namespace (in the cluster) the operator is running in
 	OperatorNamespace string
-	// ClusterStatus is the cluster result as of the last health check probe.
-	ClusterStatus *toolchainv1alpha1.ToolchainClusterStatus
 	// OwnerClusterName keeps the name of the cluster the ToolchainCluster resource is created in
 	// eg. if this ToolchainCluster identifies a Host cluster (and thus is created in Member)
 	// then the OwnerClusterName has a name of the member - it has to be same name as the name
 	// that is used for identifying the member in a Host cluster
 	OwnerClusterName string
+}
+
+// CachedToolchainCluster stores cluster client; cluster related info and previous health check probe results
+type CachedToolchainCluster struct {
+	*Config
+	// Client is the kube client for the cluster.
+	Client client.Client
+	// ClusterStatus is the cluster result as of the last health check probe.
+	ClusterStatus *toolchainv1alpha1.ToolchainClusterStatus
 }
 
 func (c *toolchainClusterClients) addCachedToolchainCluster(cluster *CachedToolchainCluster) {

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -477,11 +477,13 @@ var notReady clusterOption = func(c *CachedToolchainCluster) {
 func newTestCachedToolchainCluster(t *testing.T, name string, clusterType Type, options ...clusterOption) *CachedToolchainCluster {
 	cl := test.NewFakeClient(t)
 	cachedCluster := &CachedToolchainCluster{
-		Name:              name,
-		Client:            cl,
-		OperatorNamespace: name + "Namespace",
-		Type:              clusterType,
-		ClusterStatus:     &toolchainv1alpha1.ToolchainClusterStatus{},
+		Config: &Config{
+			Name:              name,
+			OperatorNamespace: name + "Namespace",
+			Type:              clusterType,
+		},
+		Client:        cl,
+		ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{},
 	}
 	for _, configure := range options {
 		configure(cachedCluster)

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -12,7 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -77,7 +76,7 @@ func (s *ToolchainClusterService) addToolchainCluster(log logr.Logger, toolchain
 	cachedToolchainCluster, exists := clusterCache.getCachedToolchainCluster(toolchainCluster.Name, false)
 	if !exists ||
 		cachedToolchainCluster.Client == nil ||
-		!reflect.DeepEqual(clusterConfig, cachedToolchainCluster.Config) {
+		!reflect.DeepEqual(clusterConfig.Config, cachedToolchainCluster.Config) {
 
 		log.Info("creating new client for the cached ToolchainCluster")
 		scheme := runtime.NewScheme()
@@ -87,7 +86,7 @@ func (s *ToolchainClusterService) addToolchainCluster(log logr.Logger, toolchain
 		if err := v1.AddToScheme(scheme); err != nil {
 			return err
 		}
-		cl, err = client.New(clusterConfig, client.Options{
+		cl, err = client.New(clusterConfig.Config, client.Options{
 			Scheme: scheme,
 		})
 		if err != nil {
@@ -99,14 +98,9 @@ func (s *ToolchainClusterService) addToolchainCluster(log logr.Logger, toolchain
 	}
 
 	cluster := &CachedToolchainCluster{
-		Name:              toolchainCluster.Name,
-		APIEndpoint:       toolchainCluster.Spec.APIEndpoint,
-		Client:            cl,
-		Config:            clusterConfig,
-		ClusterStatus:     &toolchainCluster.Status,
-		Type:              Type(toolchainCluster.Labels[labelType]),
-		OperatorNamespace: toolchainCluster.Labels[labelNamespace],
-		OwnerClusterName:  toolchainCluster.Labels[labelOwnerClusterName],
+		Config:        clusterConfig,
+		Client:        cl,
+		ClusterStatus: &toolchainCluster.Status,
 	}
 	if cluster.Type == "" {
 		cluster.Type = Member
@@ -148,8 +142,8 @@ func (s *ToolchainClusterService) enrichLogger(cluster *toolchainv1alpha1.Toolch
 		WithValues("Request.Namespace", cluster.Namespace, "Request.Name", cluster.Name)
 }
 
-// NewClusterConfig generate a new cluster config by fetching the necessary info the given ToolchainCluster's associated Secret
-func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.ToolchainCluster, timeout time.Duration) (*rest.Config, error) {
+// NewClusterConfig generate a new cluster config by fetching the necessary info the given ToolchainCluster's associated Secret and taking all data from ToolchainCluster CR
+func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.ToolchainCluster, timeout time.Duration) (*Config, error) {
 	clusterName := toolchainCluster.Name
 
 	apiEndpoint := toolchainCluster.Spec.APIEndpoint
@@ -191,7 +185,14 @@ func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.Tool
 	clusterConfig.Burst = toolchainAPIBurst
 	clusterConfig.Timeout = timeout
 
-	return clusterConfig, nil
+	return &Config{
+		Name:              toolchainCluster.Name,
+		APIEndpoint:       toolchainCluster.Spec.APIEndpoint,
+		Config:            clusterConfig,
+		Type:              Type(toolchainCluster.Labels[labelType]),
+		OperatorNamespace: toolchainCluster.Labels[labelNamespace],
+		OwnerClusterName:  toolchainCluster.Labels[labelOwnerClusterName],
+	}, nil
 }
 
 func IsReady(clusterStatus *toolchainv1alpha1.ToolchainClusterStatus) bool {
@@ -203,4 +204,20 @@ func IsReady(clusterStatus *toolchainv1alpha1.ToolchainClusterStatus) bool {
 		}
 	}
 	return false
+}
+
+func ListToolchainClusterConfigs(cl client.Client, namespace string, clusterType Type, timeout time.Duration) ([]*Config, error) {
+	toolchainClusters := &toolchainv1alpha1.ToolchainClusterList{}
+	if err := cl.List(context.TODO(), toolchainClusters, client.InNamespace(namespace), client.MatchingLabels{labelType: string(clusterType)}); err != nil {
+		return nil, err
+	}
+	var configs []*Config
+	for _, cluster := range toolchainClusters.Items {
+		clusterConfig, err := NewClusterConfig(cl, &cluster, timeout)
+		if err != nil {
+			return nil, err
+		}
+		configs = append(configs, clusterConfig)
+	}
+	return configs, nil
 }

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -1,12 +1,19 @@
 package cluster_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test/verify"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestAddToolchainClusterAsMember(t *testing.T) {
@@ -56,5 +63,97 @@ func TestDeleteToolchainClusterWhenDoesNotExist(t *testing.T) {
 		// when
 		service.DeleteToolchainCluster("east")
 		return nil
+	})
+}
+
+func TestListToolchainClusterConfigs(t *testing.T) {
+	// given
+	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	m1, sec1 := test.NewToolchainClusterWithEndpoint("east", "secret1", "http://m1.com", status, verify.Labels(cluster.Member, test.MemberOperatorNs, "m1ClusterName"))
+	m2, sec2 := test.NewToolchainClusterWithEndpoint("west", "secret2", "http://m2.com", status, verify.Labels(cluster.Member, test.MemberOperatorNs, "m2ClusterName"))
+	host, secHost := test.NewToolchainCluster("host", "secretHost", status, verify.Labels(cluster.Host, test.HostOperatorNs, "hostClusterName"))
+	noise, secNoise := test.NewToolchainCluster("noise", "secretNoise", status, verify.Labels(cluster.Type("e2e"), test.MemberOperatorNs, "noiseClusterName"))
+	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
+	cl := test.NewFakeClient(t, m1, m2, host, noise, sec1, sec2, secHost, secNoise)
+
+	t.Run("list members", func(t *testing.T) {
+		// when
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, cluster.Member, time.Second)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, clusterConfigs, 2)
+		verify.AssertClusterConfigThat(t, clusterConfigs[0]).
+			IsOfType(cluster.Member).
+			HasName("east").
+			HasOperatorNamespace("toolchain-member-operator").
+			HasOwnerClusterName("m1ClusterName").
+			HasAPIEndpoint("http://m1.com").
+			RestConfigHasHost("http://m1.com")
+		verify.AssertClusterConfigThat(t, clusterConfigs[1]).
+			IsOfType(cluster.Member).
+			HasName("west").
+			HasOperatorNamespace("toolchain-member-operator").
+			HasOwnerClusterName("m2ClusterName").
+			HasAPIEndpoint("http://m2.com").
+			RestConfigHasHost("http://m2.com")
+	})
+
+	t.Run("list host", func(t *testing.T) {
+		// when
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, cluster.Host, time.Second)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, clusterConfigs, 1)
+		verify.AssertClusterConfigThat(t, clusterConfigs[0]).
+			IsOfType(cluster.Host).
+			HasName("host").
+			HasOperatorNamespace("toolchain-host-operator").
+			HasOwnerClusterName("hostClusterName").
+			HasAPIEndpoint("http://cluster.com").
+			RestConfigHasHost("http://cluster.com")
+	})
+
+	t.Run("list members when there is none present", func(t *testing.T) {
+		// given
+		cl := test.NewFakeClient(t, host, noise, secNoise)
+
+		// when
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, cluster.Member, time.Second)
+
+		// then
+		require.NoError(t, err)
+		require.Len(t, clusterConfigs, 0)
+	})
+
+	t.Run("when list fails", func(t *testing.T) {
+		//given
+		cl := test.NewFakeClient(t, m1, m2, host, noise, sec1, sec2, secHost, secNoise)
+		cl.MockList = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, cluster.Member, time.Second)
+
+		// then
+		require.Error(t, err)
+		require.Len(t, clusterConfigs, 0)
+	})
+
+	t.Run("when get secret fails", func(t *testing.T) {
+		//given
+		cl := test.NewFakeClient(t, m1, m2, host, noise, sec1, sec2, secHost, secNoise)
+		cl.MockGet = func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+			return fmt.Errorf("some error")
+		}
+
+		// when
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, cluster.Member, time.Second)
+
+		// then
+		require.Error(t, err)
+		require.Len(t, clusterConfigs, 0)
 	})
 }

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -204,9 +204,11 @@ func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClu
 	}
 	return func() (*cluster.CachedToolchainCluster, bool) {
 		toolchainClusterValue := &cluster.CachedToolchainCluster{
-			Type:              cluster.Host,
-			OperatorNamespace: test.HostOperatorNs,
-			OwnerClusterName:  test.MemberClusterName,
+			Config: &cluster.Config{
+				Type:              cluster.Host,
+				OperatorNamespace: test.HostOperatorNs,
+				OwnerClusterName:  test.MemberClusterName,
+			},
 			ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
 				Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
 					Type:          conditionType,

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -238,7 +238,7 @@ func (a *ClusterConfigAssertion) HasAPIEndpoint(apiEndpoint string) *ClusterConf
 }
 
 func (a *ClusterConfigAssertion) RestConfigHasHost(host string) *ClusterConfigAssertion {
-	require.NotNil(a.t, a.clusterConfig.Config)
-	assert.Equal(a.t, host, a.clusterConfig.Config.Host)
+	require.NotNil(a.t, a.clusterConfig.RestConfig)
+	assert.Equal(a.t, host, a.clusterConfig.RestConfig.Host)
 	return a
 }

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -153,11 +153,14 @@ func UpdateToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 	require.NoError(t, err)
 	cachedToolchainCluster, ok := cluster.GetCachedToolchainCluster("east")
 	require.True(t, ok)
-	assert.Equal(t, cluster.Host, cachedToolchainCluster.Type)
-	assert.Equal(t, "toolchain-host-operator", cachedToolchainCluster.OperatorNamespace)
 	assert.Equal(t, statusFalse, *cachedToolchainCluster.ClusterStatus)
-	assert.Equal(t, test.NameMember, cachedToolchainCluster.OwnerClusterName)
-	assert.Equal(t, "http://cluster.com", cachedToolchainCluster.APIEndpoint)
+	AssertClusterConfigThat(t, cachedToolchainCluster.Config).
+		IsOfType(cluster.Host).
+		HasName("east").
+		HasOperatorNamespace("toolchain-host-operator").
+		HasOwnerClusterName(test.NameMember).
+		HasAPIEndpoint("http://cluster.com").
+		RestConfigHasHost("http://cluster.com")
 }
 
 func DeleteToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
@@ -195,4 +198,47 @@ func Labels(clType cluster.Type, ns, ownerClusterName string) map[string]string 
 
 func newToolchainClusterService(cl client.Client) cluster.ToolchainClusterService {
 	return cluster.NewToolchainClusterService(cl, logf.Log, "test-namespace", 3*time.Second)
+}
+
+type ClusterConfigAssertion struct {
+	t             *testing.T
+	clusterConfig *cluster.Config
+}
+
+func AssertClusterConfigThat(t *testing.T, clusterConfig *cluster.Config) *ClusterConfigAssertion {
+	return &ClusterConfigAssertion{
+		t:             t,
+		clusterConfig: clusterConfig,
+	}
+}
+
+func (a *ClusterConfigAssertion) IsOfType(clusterType cluster.Type) *ClusterConfigAssertion {
+	assert.Equal(a.t, clusterType, a.clusterConfig.Type)
+	return a
+}
+
+func (a *ClusterConfigAssertion) HasOperatorNamespace(namespace string) *ClusterConfigAssertion {
+	assert.Equal(a.t, namespace, a.clusterConfig.OperatorNamespace)
+	return a
+}
+
+func (a *ClusterConfigAssertion) HasName(name string) *ClusterConfigAssertion {
+	assert.Equal(a.t, name, a.clusterConfig.Name)
+	return a
+}
+
+func (a *ClusterConfigAssertion) HasOwnerClusterName(name string) *ClusterConfigAssertion {
+	assert.Equal(a.t, name, a.clusterConfig.OwnerClusterName)
+	return a
+}
+
+func (a *ClusterConfigAssertion) HasAPIEndpoint(apiEndpoint string) *ClusterConfigAssertion {
+	assert.Equal(a.t, apiEndpoint, a.clusterConfig.APIEndpoint)
+	return a
+}
+
+func (a *ClusterConfigAssertion) RestConfigHasHost(host string) *ClusterConfigAssertion {
+	require.NotNil(a.t, a.clusterConfig.Config)
+	assert.Equal(a.t, host, a.clusterConfig.Config.Host)
+	return a
 }


### PR DESCRIPTION
This PR introduces a `Config` type in cluster package - it more or less represents the configuration of ToolchainCluster. There is nothing new in there - just moving the params around.
The reason for that is that in host-operator we need to list all cluster configs for member clusters to be able to add it to Manager.

related PRs:
https://github.com/codeready-toolchain/host-operator/pull/542
https://github.com/codeready-toolchain/member-operator/pull/312
https://github.com/codeready-toolchain/toolchain-e2e/pull/412
https://github.com/codeready-toolchain/registration-service/pull/229