### PR TITLE
fix: compare rest.Config and not cluster.Config

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -76,7 +76,7 @@ func (s *ToolchainClusterService) addToolchainCluster(log logr.Logger, toolchain
 	cachedToolchainCluster, exists := clusterCache.getCachedToolchainCluster(toolchainCluster.Name, false)
 	if !exists ||
 		cachedToolchainCluster.Client == nil ||
-		!reflect.DeepEqual(clusterConfig.RestConfig, cachedToolchainCluster.Config) {
+		!reflect.DeepEqual(clusterConfig.RestConfig, cachedToolchainCluster.RestConfig) {
 
 		log.Info("creating new client for the cached ToolchainCluster")
 		scheme := runtime.NewScheme()


### PR DESCRIPTION
This is the real fix for the weird behavior that I saw in our logs. We should compare the `rest.Config` when checking if the new client should be created.

related PRs: 
https://github.com/codeready-toolchain/member-operator/pull/320
https://github.com/codeready-toolchain/host-operator/pull/561