### PR TITLE
test: modifier to set spec.tiername in MasterUserRecord

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/go-openapi/swag v0.19.9 // indirect
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang-jwt/jwt v3.2.2+incompatible
-	github.com/google/go-cmp v0.5.2
 	github.com/lestrrat-go/jwx v0.9.0
 	github.com/magiconair/properties v1.8.1
 	github.com/mailru/easyjson v0.7.1 // indirect

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -267,6 +267,13 @@ func AdditionalAccounts(clusters ...string) MurModifier {
 	}
 }
 
+func TierName(tierName string) MurModifier {
+	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
+		mur.Spec.TierName = tierName
+		return nil
+	}
+}
+
 func NsLimit(limit string) UaInMurModifier {
 	return func(targetCluster string, mur *toolchainv1alpha1.MasterUserRecord) {
 		for i, ua := range mur.Spec.UserAccounts {
@@ -278,7 +285,7 @@ func NsLimit(limit string) UaInMurModifier {
 	}
 }
 
-func TierName(tierName string) UaInMurModifier {
+func UserAccountTierName(tierName string) UaInMurModifier {
 	return func(targetCluster string, mur *toolchainv1alpha1.MasterUserRecord) {
 		for i, ua := range mur.Spec.UserAccounts {
 			if ua.TargetCluster == targetCluster {

--- a/pkg/test/masteruserrecord/masteruserrecord_test.go
+++ b/pkg/test/masteruserrecord/masteruserrecord_test.go
@@ -328,7 +328,7 @@ func TestTierNameModifier(t *testing.T) {
 		mur2 := murtest.NewMasterUserRecord(t, "jack", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
 
 		// when
-		murtest.ModifyUaInMur(mur1, test.MemberClusterName, murtest.TierName("admin"))
+		murtest.ModifyUaInMur(mur1, test.MemberClusterName, murtest.UserAccountTierName("admin"))
 
 		// then
 		assert.Equal(t, "admin", mur1.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName) // modified

--- a/pkg/test/useraccount/useraccount_test.go
+++ b/pkg/test/useraccount/useraccount_test.go
@@ -17,7 +17,7 @@ func TestUserAccountFromMur(t *testing.T) {
 		userAcc := uatest.NewUserAccountFromMur(mur)
 
 		// when
-		murtest.ModifyUaInMur(mur, test.MemberClusterName, murtest.TierName("admin"))
+		murtest.ModifyUaInMur(mur, test.MemberClusterName, murtest.UserAccountTierName("admin"))
 
 		// then
 		assert.Equal(t, "admin", mur.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName) // modified


### PR DESCRIPTION
renamed `TierName` UaInMurModifier to `UserAccountTierName`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
