### PR TITLE
Add NSTemplateSet modifier to fill namespace and clusterresource refs

### DIFF
--- a/pkg/test/nstemplateset/nstemplateset.go
+++ b/pkg/test/nstemplateset/nstemplateset.go
@@ -18,6 +18,27 @@ const (
 
 type Option func(*toolchainv1alpha1.NSTemplateSet)
 
+func WithReferencesFor(nstemplateTier *toolchainv1alpha1.NSTemplateTier) Option {
+	return func(nstmplSet *toolchainv1alpha1.NSTemplateSet) {
+		namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, len(nstemplateTier.Spec.Namespaces))
+		for i, ns := range nstemplateTier.Spec.Namespaces {
+			namespaces[i] = toolchainv1alpha1.NSTemplateSetNamespace{
+				TemplateRef: ns.TemplateRef,
+			}
+		}
+		var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
+		if nstemplateTier.Spec.ClusterResources != nil {
+			clusterResources = &toolchainv1alpha1.NSTemplateSetClusterResources{
+				TemplateRef: nstemplateTier.Spec.ClusterResources.TemplateRef,
+			}
+		}
+
+		nstmplSet.Spec.TierName = nstemplateTier.Name
+		nstmplSet.Spec.Namespaces = namespaces
+		nstmplSet.Spec.ClusterResources = clusterResources
+	}
+}
+
 func WithReadyCondition() Option {
 	return func(nstmplSet *toolchainv1alpha1.NSTemplateSet) {
 		nstmplSet.Status.Conditions = []toolchainv1alpha1.Condition{

--- a/pkg/test/nstemplateset/nstemplateset.go
+++ b/pkg/test/nstemplateset/nstemplateset.go
@@ -22,9 +22,7 @@ func WithReferencesFor(nstemplateTier *toolchainv1alpha1.NSTemplateTier) Option 
 	return func(nstmplSet *toolchainv1alpha1.NSTemplateSet) {
 		namespaces := make([]toolchainv1alpha1.NSTemplateSetNamespace, len(nstemplateTier.Spec.Namespaces))
 		for i, ns := range nstemplateTier.Spec.Namespaces {
-			namespaces[i] = toolchainv1alpha1.NSTemplateSetNamespace{
-				TemplateRef: ns.TemplateRef,
-			}
+			namespaces[i] = toolchainv1alpha1.NSTemplateSetNamespace(ns)
 		}
 		var clusterResources *toolchainv1alpha1.NSTemplateSetClusterResources
 		if nstemplateTier.Spec.ClusterResources != nil {


### PR DESCRIPTION
Adds a NSTemplateSet modifier to fill namespace and clusterresource refs for a given tier.

Related PR: https://github.com/codeready-toolchain/host-operator/pull/568
