### PR TITLE
Set tier label on useraccount

### DIFF
--- a/pkg/test/useraccount/useraccount.go
+++ b/pkg/test/useraccount/useraccount.go
@@ -16,6 +16,9 @@ func NewUserAccountFromMur(mur *toolchainv1alpha1.MasterUserRecord, modifiers ..
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mur.Name,
 			Namespace: test.MemberOperatorNs,
+			Labels: map[string]string{
+				toolchainv1alpha1.TierLabelKey: mur.Spec.TierName,
+			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
 			UserID:   mur.Spec.UserID,

--- a/pkg/test/useraccount/useraccount_assertion.go
+++ b/pkg/test/useraccount/useraccount_assertion.go
@@ -90,6 +90,16 @@ func (a *Assertion) MatchMasterUserRecord(mur *toolchainv1alpha1.MasterUserRecor
 	return a
 }
 
+// HasLabelWithValue verifies that the UserAccount has
+// a label with the given key and value
+func (a *Assertion) HasLabelWithValue(key, value string) *Assertion {
+	err := a.loadUaAssertion()
+	require.NoError(a.t, err)
+	require.NotNil(a.t, a.userAccount.Labels)
+	assert.Equal(a.t, value, a.userAccount.Labels[key])
+	return a
+}
+
 func (a *Assertion) HasSpec(spec toolchainv1alpha1.UserAccountSpec) *Assertion {
 	err := a.loadUaAssertion()
 	require.NoError(a.t, err)


### PR DESCRIPTION
- Updates the `NewUserAccountFromMur` func to set the tier label
- Adds `HasLabelWithValue` assertion on UserAccount

Related PR: https://github.com/codeready-toolchain/host-operator/pull/580