### PR TITLE
Should just use preferred_username claim, not username

### DIFF
--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -122,12 +122,6 @@ func WithSubClaim(sub string) ExtraClaim {
 	}
 }
 
-func WithUsernameClaim(username string) ExtraClaim {
-	return func(token *jwt.Token) {
-		token.Claims.(*MyClaims).Username = username
-	}
-}
-
 // WithOriginalSubClaim sets the `original_sub` claim in the token to generate
 func WithOriginalSubClaim(originalSub string) ExtraClaim {
 	return func(token *jwt.Token) {
@@ -224,7 +218,6 @@ type MyClaims struct {
 	Email             string `json:"email,omitempty"`
 	EmailVerified     bool   `json:"email_verified,omitempty"`
 	OriginalSub       string `json:"original_sub"`
-	Username          string `json:"username"`
 }
 
 func (c *MyClaims) Valid() error {

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -321,26 +321,6 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "Jack:1234-FFFF", claims.OriginalSub)
 	})
-	t.Run("create token with preferred_username extra claim", func(t *testing.T) {
-		username := "kevin"
-		identity0 := &Identity{
-			ID:       uuid.Must(uuid.NewV4()),
-			Username: username,
-		}
-		// generate the token
-		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithPreferredUsernameClaim(username))
-		require.NoError(t, err)
-		// unmarshall it again
-		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
-			return &(key0.PublicKey), nil
-		})
-		require.NoError(t, err)
-		require.True(t, decodedToken.Valid)
-		claims, ok := decodedToken.Claims.(*MyClaims)
-		require.True(t, ok)
-		require.Equal(t, "kevin", claims.PreferredUsername)
-
-	})
 }
 
 func TestTokenManagerKeyService(t *testing.T) {

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -321,14 +321,14 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "Jack:1234-FFFF", claims.OriginalSub)
 	})
-	t.Run("create token with username extra claim", func(t *testing.T) {
+	t.Run("create token with preferred_username extra claim", func(t *testing.T) {
 		username := "kevin"
 		identity0 := &Identity{
 			ID:       uuid.Must(uuid.NewV4()),
 			Username: username,
 		}
 		// generate the token
-		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithUsernameClaim(username))
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithPreferredUsernameClaim(username))
 		require.NoError(t, err)
 		// unmarshall it again
 		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
@@ -338,7 +338,7 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.True(t, decodedToken.Valid)
 		claims, ok := decodedToken.Claims.(*MyClaims)
 		require.True(t, ok)
-		require.Equal(t, "kevin", claims.Username)
+		require.Equal(t, "kevin", claims.PreferredUsername)
 
 	})
 }


### PR DESCRIPTION
Removes the "username" utility function, we need to use "preferred_username" instead.