### PR TITLE
Remove user account tier checks

### DIFF
--- a/pkg/test/masteruserrecord/masteruserrecord_test.go
+++ b/pkg/test/masteruserrecord/masteruserrecord_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,7 +22,7 @@ func TestMasterUserRecordAssertion(t *testing.T) {
 	err := toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
 
-	t.Run("HasNSTemplateSet assertion", func(t *testing.T) {
+	t.Run("HasTier assertion", func(t *testing.T) {
 
 		mur := murtest.NewMasterUserRecord(t, "foo", murtest.TargetCluster(test.MemberClusterName))
 
@@ -42,12 +41,7 @@ func TestMasterUserRecordAssertion(t *testing.T) {
 			}
 			// when
 			murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-				HasNSTemplateSet(test.MemberClusterName,
-					murtest.WithTier("basic"),
-					murtest.WithNs("dev", "123abc"),
-					murtest.WithNs("code", "123abc"),
-					murtest.WithNs("stage", "123abc"),
-					murtest.WithClusterRes("654321a"))
+				HasTier(murtest.DefaultNSTemplateTier())
 			// then: all good
 			assert.False(t, mockT.CalledFailNow())
 			assert.False(t, mockT.CalledFatalf())
@@ -56,7 +50,7 @@ func TestMasterUserRecordAssertion(t *testing.T) {
 
 		t.Run("failures", func(t *testing.T) {
 
-			t.Run("missing target cluster", func(t *testing.T) {
+			t.Run("does not have matching tier", func(t *testing.T) {
 				// given
 				mockT := test.NewMockT()
 				client := test.NewFakeClient(mockT, mur)
@@ -69,270 +63,17 @@ func TestMasterUserRecordAssertion(t *testing.T) {
 					}
 					return fmt.Errorf("unexpected object key: %v", key)
 				}
+				otherTier := murtest.DefaultNSTemplateTier()
+				otherTier.Name = "other"
 				// when
 				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					HasNSTemplateSet("cluster-unknown",
-						murtest.WithTier("basic"),
-						murtest.WithNs("dev", "123abc"),
-						murtest.WithNs("code", "123abc"),
-						murtest.WithNs("stage", "123abc"),
-						murtest.WithClusterRes("654321a"))
+					HasTier(otherTier)
 				// then
 				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledErrorf())
-				assert.True(t, mockT.CalledFatalf()) // no match found for the given cluster
+				assert.True(t, mockT.CalledErrorf()) // no match found for the given tier
+				assert.False(t, mockT.CalledFatalf())
 			})
 
-			t.Run("different NSTemplateSets", func(t *testing.T) {
-				// given
-				mockT := test.NewMockT()
-				client := test.NewFakeClient(mockT, mur)
-				client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-					if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-						if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-							*obj = *mur
-							return nil
-						}
-					}
-					return fmt.Errorf("unexpected object key: %v", key)
-				}
-				// when
-				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					HasNSTemplateSet(test.MemberClusterName, murtest.WithTier("basic"))
-				// then
-				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledFatalf())
-				assert.True(t, mockT.CalledErrorf()) // assert.Equal failed
-			})
 		})
 	})
-
-	t.Run("UserAccountHasTier assertion", func(t *testing.T) {
-
-		mur := murtest.NewMasterUserRecord(t, "foo", murtest.TargetCluster(test.MemberClusterName))
-
-		t.Run("ok", func(t *testing.T) {
-			// given
-			tier := toolchainv1alpha1.NSTemplateTier{
-				ObjectMeta: v1.ObjectMeta{
-					Name: "basic",
-				},
-				Spec: toolchainv1alpha1.NSTemplateTierSpec{
-					Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-						{
-							TemplateRef: "basic-dev-123abc",
-						},
-						{
-							TemplateRef: "basic-code-123abc",
-						},
-						{
-							TemplateRef: "basic-stage-123abc",
-						},
-					},
-					ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
-						TemplateRef: "basic-clusterresources-654321a",
-					},
-				},
-			}
-			mockT := test.NewMockT()
-			client := test.NewFakeClient(mockT, mur)
-			client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-				if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-					if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-						*obj = *mur
-						return nil
-					}
-				}
-				return fmt.Errorf("unexpected object key: %v", key)
-			}
-			// when
-			murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-				UserAccountHasTier(test.MemberClusterName, tier)
-			// then: all good
-			assert.False(t, mockT.CalledFailNow())
-			assert.False(t, mockT.CalledFatalf())
-			assert.False(t, mockT.CalledErrorf())
-		})
-
-		t.Run("failures", func(t *testing.T) {
-
-			t.Run("missing stage namespace", func(t *testing.T) {
-				// given
-				tier := toolchainv1alpha1.NSTemplateTier{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "basic",
-					},
-					Spec: toolchainv1alpha1.NSTemplateTierSpec{
-						Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-							{
-								TemplateRef: "basic-dev-123abc",
-							},
-							{
-								TemplateRef: "basic-code-123abc",
-							},
-						},
-					},
-				}
-				mockT := test.NewMockT()
-				client := test.NewFakeClient(mockT, mur)
-				client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-					if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-						if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-							*obj = *mur
-							return nil
-						}
-					}
-					return fmt.Errorf("unexpected object key: %v", key)
-				}
-				// when
-				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					UserAccountHasTier(test.MemberClusterName, tier)
-				// then: all good
-				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledFatalf())
-				assert.True(t, mockT.CalledErrorf()) // assert.Equal failed
-			})
-
-			t.Run("invalid stage namespace", func(t *testing.T) {
-				// given
-				tier := toolchainv1alpha1.NSTemplateTier{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "basic",
-					},
-					Spec: toolchainv1alpha1.NSTemplateTierSpec{
-						Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-							{
-								TemplateRef: "basic-dev-123abc",
-							},
-							{
-								TemplateRef: "basic-code-123abc",
-							},
-							{
-								TemplateRef: "basic-stage-invalid",
-							},
-						},
-					},
-				}
-				mockT := test.NewMockT()
-				client := test.NewFakeClient(mockT, mur)
-				client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-					if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-						if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-							*obj = *mur
-							return nil
-						}
-					}
-					return fmt.Errorf("unexpected object key: %v", key)
-				}
-				// when
-				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					UserAccountHasTier(test.MemberClusterName, tier)
-				// then: all good
-				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledFatalf())
-				assert.True(t, mockT.CalledErrorf()) // assert.Equal failed
-			})
-
-			t.Run("missing cluster resources", func(t *testing.T) {
-				// given
-				tier := toolchainv1alpha1.NSTemplateTier{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "basic",
-					},
-					Spec: toolchainv1alpha1.NSTemplateTierSpec{
-						Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-							{
-								TemplateRef: "basic-dev-123abc",
-							},
-							{
-								TemplateRef: "basic-code-123abc",
-							},
-							{
-								TemplateRef: "basic-stage-123abc",
-							},
-						},
-					},
-				}
-				mockT := test.NewMockT()
-				client := test.NewFakeClient(mockT, mur)
-				client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-					if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-						if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-							*obj = *mur
-							return nil
-						}
-					}
-					return fmt.Errorf("unexpected object key: %v", key)
-				}
-				// when
-				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					UserAccountHasTier(test.MemberClusterName, tier)
-				// then: all good
-				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledFatalf())
-				assert.True(t, mockT.CalledErrorf()) // assert.Equal failed
-			})
-
-			t.Run("invalid cluster resources", func(t *testing.T) {
-				// given
-				tier := toolchainv1alpha1.NSTemplateTier{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "basic",
-					},
-					Spec: toolchainv1alpha1.NSTemplateTierSpec{
-						Namespaces: []toolchainv1alpha1.NSTemplateTierNamespace{
-							{
-								TemplateRef: "basic-dev-123abc",
-							},
-							{
-								TemplateRef: "basic-code-123abc",
-							},
-							{
-								TemplateRef: "basic-stage-123abc",
-							},
-						},
-						ClusterResources: &toolchainv1alpha1.NSTemplateTierClusterResources{
-							TemplateRef: "invalid",
-						},
-					},
-				}
-				mockT := test.NewMockT()
-				client := test.NewFakeClient(mockT, mur)
-				client.MockGet = func(ctx context.Context, key types.NamespacedName, obj runtimeclient.Object) error {
-					if key.Namespace == test.HostOperatorNs && key.Name == "foo" {
-						if obj, ok := obj.(*toolchainv1alpha1.MasterUserRecord); ok {
-							*obj = *mur
-							return nil
-						}
-					}
-					return fmt.Errorf("unexpected object key: %v", key)
-				}
-				// when
-				murtest.AssertThatMasterUserRecord(mockT, "foo", client).
-					UserAccountHasTier(test.MemberClusterName, tier)
-				// then: all good
-				assert.False(t, mockT.CalledFailNow())
-				assert.False(t, mockT.CalledFatalf())
-				assert.True(t, mockT.CalledErrorf()) // assert.Equal failed
-			})
-		})
-
-	})
-}
-
-func TestTierNameModifier(t *testing.T) {
-
-	t.Run("distinct MURs should have distinct NSTemplateSets", func(t *testing.T) {
-		// given
-		mur1 := murtest.NewMasterUserRecord(t, "john", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
-		mur2 := murtest.NewMasterUserRecord(t, "jack", murtest.Finalizer("finalizer.toolchain.dev.openshift.com"))
-
-		// when
-		murtest.ModifyUaInMur(mur1, test.MemberClusterName, murtest.UserAccountTierName("admin"))
-
-		// then
-		assert.Equal(t, "admin", mur1.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName) // modified
-		assert.Equal(t, "basic", mur2.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName) // unmodified
-	})
-
 }

--- a/pkg/test/useraccount/useraccount.go
+++ b/pkg/test/useraccount/useraccount.go
@@ -10,8 +10,6 @@ import (
 type UaModifier func(ua *toolchainv1alpha1.UserAccount)
 
 func NewUserAccountFromMur(mur *toolchainv1alpha1.MasterUserRecord, modifiers ...UaModifier) *toolchainv1alpha1.UserAccount {
-	// copy the NSTemplateSet with the new TierName,
-	tmplSet := *mur.Spec.UserAccounts[0].Spec.NSTemplateSet
 	ua := &toolchainv1alpha1.UserAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mur.Name,
@@ -20,10 +18,6 @@ func NewUserAccountFromMur(mur *toolchainv1alpha1.MasterUserRecord, modifiers ..
 		Spec: toolchainv1alpha1.UserAccountSpec{
 			UserID:   mur.Spec.UserID,
 			Disabled: mur.Spec.Disabled,
-			UserAccountSpecBase: toolchainv1alpha1.UserAccountSpecBase{
-				NSLimit:       mur.Spec.UserAccounts[0].Spec.NSLimit,
-				NSTemplateSet: &tmplSet,
-			},
 		},
 	}
 	Modify(ua, modifiers...)

--- a/pkg/test/useraccount/useraccount_test.go
+++ b/pkg/test/useraccount/useraccount_test.go
@@ -3,7 +3,6 @@ package useraccount_test
 import (
 	"testing"
 
-	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	murtest "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
 	uatest "github.com/codeready-toolchain/toolchain-common/pkg/test/useraccount"
 
@@ -11,16 +10,13 @@ import (
 )
 
 func TestUserAccountFromMur(t *testing.T) {
-	t.Run("UserAccount from MUR should have its own NSTemplateSet", func(t *testing.T) {
+	t.Run("UserAccount from MUR should have same values", func(t *testing.T) {
 		// given
 		mur := murtest.NewMasterUserRecord(t, "john")
 		userAcc := uatest.NewUserAccountFromMur(mur)
 
-		// when
-		murtest.ModifyUaInMur(mur, test.MemberClusterName, murtest.UserAccountTierName("admin"))
-
-		// then
-		assert.Equal(t, "admin", mur.Spec.UserAccounts[0].Spec.NSTemplateSet.TierName) // modified
-		assert.Equal(t, "basic", userAcc.Spec.NSTemplateSet.TierName)                  // unmodified
+		// when & then
+		assert.Equal(t, mur.Spec.UserID, userAcc.Spec.UserID)
+		assert.Equal(t, mur.Spec.Disabled, userAcc.Spec.Disabled)
 	})
 }


### PR DESCRIPTION
Related PR: https://github.com/codeready-toolchain/host-operator/pull/595

Relates Issues:
https://issues.redhat.com/browse/CRT-1320
https://issues.redhat.com/browse/CRT-1323

- Removes test functions related to NSLimit and NSTemplateSet in UserAccount
- Removes tier hash label from MasterUserRecord