### PR TITLE
Modified to comply with openshift naming

### DIFF
--- a/pkg/identity/identity_naming_standard.go
+++ b/pkg/identity/identity_naming_standard.go
@@ -52,7 +52,7 @@ func (s *identityNamingStandard) IdentityName() string {
 //
 // The code at time of writing can be found at:
 //
-// https://github.com/openshift/oauth-server/blob/master/pkg/api/types.go#L108
+// https://github.com/openshift/oauth-server/blob/ef385cc3c9d90ee52f6db211ceb751e04ae967f5/pkg/api/types.go#L108
 //
 // If this should change, then this function must be updated to reflect the changes.
 //

--- a/pkg/identity/identity_naming_standard.go
+++ b/pkg/identity/identity_naming_standard.go
@@ -4,14 +4,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	userv1 "github.com/openshift/api/user/v1"
-	"regexp"
+	"strings"
 )
-
-const (
-	dns1123Value string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-)
-
-var dns1123ValueRegexp = regexp.MustCompile("^" + dns1123Value + "$")
 
 type NamingStandard interface {
 	ApplyToIdentity(identity *userv1.Identity)
@@ -53,10 +47,15 @@ func (s *identityNamingStandard) IdentityName() string {
 	return fmt.Sprintf("%s:%s", s.provider, s.username())
 }
 
-// isIdentityNameCompliant returns true if the specified name is RFC-1123 compliant, otherwise it returns false
+// isIdentityNameCompliant returns true if the specified name is compliant with the Openshift identity naming standard,
+// encapsulated in the code found in the urlEncodeIfNecessary() function, otherwise it returns false.
+//
+// The code at time of writing can be found at:
+//
+// https://github.com/openshift/oauth-server/blob/master/pkg/api/types.go#L108
+//
+// If this should change, then this function must be updated to reflect the changes.
+//
 func isIdentityNameCompliant(name string) bool {
-	if len(name) > 253 {
-		return false
-	}
-	return dns1123ValueRegexp.MatchString(name)
+	return !strings.ContainsAny(name, ":/")
 }

--- a/pkg/identity/identity_naming_standard_test.go
+++ b/pkg/identity/identity_naming_standard_test.go
@@ -13,20 +13,10 @@ func TestIdentityNamingStandard(t *testing.T) {
 		require.Equal(t, "rhd:john", identity.NewIdentityNamingStandard("john", "rhd").IdentityName())
 	})
 
-	t.Run("Check identity name with non-standard chars ok", func(t *testing.T) {
-		require.Equal(t, "rhd:b64:am9oblxi", identity.NewIdentityNamingStandard("john\\b", "rhd").IdentityName())
-	})
+	t.Run("Check identity name with non-standard chars encoded ok", func(t *testing.T) {
+		require.Equal(t, "rhd:b64:am9obi9i", identity.NewIdentityNamingStandard("john/b", "rhd").IdentityName())
 
-	t.Run("Check identity name with excessive length ok", func(t *testing.T) {
-		userID := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" +
-			"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789" +
-			"abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789"
-
-		require.Equal(t, "rhd:b64:YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1"+
-			"dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMT"+
-			"IzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5"+
-			"YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5YWJjZGVmZ2"+
-			"hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5", identity.NewIdentityNamingStandard(userID, "rhd").IdentityName())
+		require.Equal(t, "rhd:b64:amFjazphYmM", identity.NewIdentityNamingStandard("jack:abc", "rhd").IdentityName())
 	})
 
 	t.Run("Check apply to identity ok", func(t *testing.T) {
@@ -37,12 +27,12 @@ func TestIdentityNamingStandard(t *testing.T) {
 		require.Equal(t, "jill", id.ProviderUserName)
 	})
 
-	t.Run("Check apply to identity ok", func(t *testing.T) {
+	t.Run("Check apply to identity ok for userID with minus prefix", func(t *testing.T) {
 		id := &v1.Identity{}
-		identity.NewIdentityNamingStandard("jill", "rhd").ApplyToIdentity(id)
-		require.Equal(t, "rhd:jill", id.Name)
+		identity.NewIdentityNamingStandard("-194567", "rhd").ApplyToIdentity(id)
+		require.Equal(t, "rhd:-194567", id.Name)
 		require.Equal(t, "rhd", id.ProviderName)
-		require.Equal(t, "jill", id.ProviderUserName)
+		require.Equal(t, "-194567", id.ProviderUserName)
 	})
 
 	t.Run("Check apply to identity non-standard chars ok", func(t *testing.T) {


### PR DESCRIPTION
This PR modifies the identity name compliance check to ensure the name is compliant with Openshift's naming standard, not the DNS-1123 standard as previous.

Fixes https://issues.redhat.com/browse/CRT-1449