### PR TITLE
chore: check go.mod replacement when applicable only

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,17 +54,3 @@ jobs:
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose
-
-  gomodreplacements:
-    name: go.mod replacements
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    
-    - name: check
-      run: |
-        if [[ -n "$(grep 'replace github.com/codeready-toolchain/.*' go.mod || true)" ]]; then
-          echo "forbidden replacement in go.mod"
-          exit 1
-        fi

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -54,3 +54,4 @@ jobs:
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose
+

--- a/.github/workflows/ci-check-gomod-alt.yml
+++ b/.github/workflows/ci-check-gomod-alt.yml
@@ -1,0 +1,13 @@
+# alternative workflow to ensure that the required status checks on the PR are handled
+# see https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+name: ci-check-gomod # same name
+on:
+  pull_request:
+    paths-ignore:
+      - 'go.mod'
+jobs:
+  gomodreplacements:
+    name: go.mod replacements
+    runs-on: ubuntu-20.04
+    steps:
+      - run: 'echo "No check required" '

--- a/.github/workflows/ci-check-gomod.yml
+++ b/.github/workflows/ci-check-gomod.yml
@@ -1,4 +1,4 @@
-name: ci-check
+name: ci-check-gomod
 on:
   pull_request:
     branches:

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -1,0 +1,22 @@
+name: ci-check
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'go.mod'
+
+jobs:
+  gomodreplacements:
+    name: go.mod replacements
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    
+    - name: check
+      run: |
+        if [[ -n "$(grep 'replace github.com/codeready-toolchain/.*' go.mod || true)" ]]; then
+          echo "forbidden replacement in go.mod"
+          exit 1
+        fi


### PR DESCRIPTION
Use a separate workflow triggered when changes happen on 'go.mod' only

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
