### PR TITLE
feat: new SocialEvent name generator

### DIFF
--- a/pkg/socialevent/socialevent_name_generator.go
+++ b/pkg/socialevent/socialevent_name_generator.go
@@ -1,0 +1,30 @@
+package socialevent
+
+import (
+	"crypto/rand"
+	"math/big"
+	"strings"
+)
+
+// NewName SocialEvent names (a.k.a, activation codes) are generated in a standard format,
+// 4 blocks of 4 case insensitive, alphanumeric characters separated by a minus sign delimiter, like so:
+// XXXX-XXXX-XXXX-XXXX
+// In order to minimise entry errors, a limited character set will be used with visually ambiguous characters excluded:
+// Letters:		abcdefghjklmnpqrstuvwxyz
+// Figures:		23456789
+// This will provide 32^16 possible activation codes, which is expected to be sufficient
+// to counter brute force attacks for the typical duration of most events.
+func NewName() string {
+	chars := []rune{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 'u', 'v', 'w', 'x', 'y', 'z', '2', '3', '4', '5', '6', '7', '8', '9'}
+	code := &strings.Builder{}
+	for i := 0; i < 4; i++ {
+		if code.Len() > 0 { // insert a `-` separator between each group of 4 characters
+			code.WriteRune('-')
+		}
+		for j := 0; j < 4; j++ {
+			p, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+			code.WriteRune(chars[p.Int64()])
+		}
+	}
+	return code.String()
+}

--- a/pkg/socialevent/socialevent_name_generator.go
+++ b/pkg/socialevent/socialevent_name_generator.go
@@ -6,9 +6,8 @@ import (
 	"strings"
 )
 
-// NewName SocialEvent names (a.k.a, activation codes) are generated in a standard format,
-// 4 blocks of 4 case insensitive, alphanumeric characters separated by a minus sign delimiter, like so:
-// XXXX-XXXX-XXXX-XXXX
+// NewName SocialEvent names (a.k.a, activation codes) are composed of 1 block of
+// 5 case insensitive, alphanumeric characters separated by a minus sign delimiter, like so: XXXXX
 // In order to minimise entry errors, a limited character set will be used with visually ambiguous characters excluded:
 // Letters:		abcdefghjklmnpqrstuvwxyz
 // Figures:		23456789
@@ -17,14 +16,9 @@ import (
 func NewName() string {
 	chars := []rune{'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 'u', 'v', 'w', 'x', 'y', 'z', '2', '3', '4', '5', '6', '7', '8', '9'}
 	code := &strings.Builder{}
-	for i := 0; i < 4; i++ {
-		if code.Len() > 0 { // insert a `-` separator between each group of 4 characters
-			code.WriteRune('-')
-		}
-		for j := 0; j < 4; j++ {
-			p, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
-			code.WriteRune(chars[p.Int64()])
-		}
+	for i := 0; i < 5; i++ {
+		p, _ := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		code.WriteRune(chars[p.Int64()])
 	}
 	return code.String()
 }

--- a/pkg/socialevent/socialevent_name_generator_test.go
+++ b/pkg/socialevent/socialevent_name_generator_test.go
@@ -1,0 +1,34 @@
+package socialevent_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/socialevent"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSocialEventName(t *testing.T) {
+
+	t.Run("single code", func(t *testing.T) {
+		// when
+		code := socialevent.NewName()
+		// then
+		match, err := regexp.Match("^[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", []byte(code))
+		require.NoError(t, err)
+		assert.True(t, match, "code '%s' did not match the expected format", code)
+	})
+
+	t.Run("multiple codes", func(t *testing.T) {
+		// generate a bucket of activation codes and verifies that the fothere is no collision
+		codes := make(map[string]bool, 10000)
+		for i := 0; i < 1000; i++ {
+			code := socialevent.NewName()
+			_, found := codes[code]
+			require.False(t, found)
+			codes[code] = true
+		}
+	})
+}

--- a/pkg/socialevent/socialevent_name_generator_test.go
+++ b/pkg/socialevent/socialevent_name_generator_test.go
@@ -16,7 +16,7 @@ func TestNewSocialEventName(t *testing.T) {
 		// when
 		code := socialevent.NewName()
 		// then
-		match, err := regexp.Match("^[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$", []byte(code))
+		match, err := regexp.Match("^[a-z0-9]{5}$", []byte(code))
 		require.NoError(t, err)
 		assert.True(t, match, "code '%s' did not match the expected format", code)
 	})


### PR DESCRIPTION
generates unique random names in the `XXXX-XXXX-XXXX-XXXX` format,
using the `abcdefghjklmnpqrstuvwxyz` letters and `23456789` figures,
making it a valid resource name which can also be used as an
activation code.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
