### PR TITLE
utility func to hash

### DIFF
--- a/pkg/hash/encode.go
+++ b/pkg/hash/encode.go
@@ -1,0 +1,18 @@
+package hash
+
+import (
+	"crypto/md5" // nolint:gosec
+	"encoding/hex"
+)
+
+func EncodeString(value string) string {
+	return Encode([]byte(value))
+}
+
+func Encode(value []byte) string {
+	md5hash := md5.New() // nolint:gosec
+	// Ignore the error, as this implementation cannot return one
+	_, _ = md5hash.Write(value)
+	hash := hex.EncodeToString(md5hash.Sum(nil))
+	return hash
+}

--- a/pkg/hash/encode_test.go
+++ b/pkg/hash/encode_test.go
@@ -1,0 +1,27 @@
+package hash_test
+
+import (
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncode(t *testing.T) {
+	// given
+	value := "random_content"
+	// when
+	result := hash.Encode([]byte(value))
+	// then
+	assert.Equal(t, "25ec617dda1a9ac8f4a2dc346adee4dd", result) // see `echo -n "random_content" | md5`
+}
+
+func TestEncodeString(t *testing.T) {
+	// given
+	value := "random_content"
+	// when
+	result := hash.EncodeString(value)
+	// then
+	assert.Equal(t, "25ec617dda1a9ac8f4a2dc346adee4dd", result) // see `echo -n "random_content" | md5`
+}

--- a/pkg/test/tier/templateRefs.go
+++ b/pkg/test/tier/templateRefs.go
@@ -1,12 +1,11 @@
 package tier
 
 import (
-	"crypto/md5" // nolint:gosec
-	"encoding/hex"
 	"encoding/json"
 	"sort"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 )
 
 // ComputeTemplateRefsHash computes the hash of the `.spec.namespaces[].templateRef` + `.spec.clusteResource.TemplateRef`
@@ -23,11 +22,7 @@ func ComputeTemplateRefsHash(tier *toolchainv1alpha1.NSTemplateTier) (string, er
 	if err != nil {
 		return "", err
 	}
-	md5hash := md5.New() // nolint:gosec
-	// Ignore the error, as this implementation cannot return one
-	_, _ = md5hash.Write(m)
-	hash := hex.EncodeToString(md5hash.Sum(nil))
-	return hash, nil
+	return hash.Encode(m), nil
 }
 
 // TemplateTierHashLabel returns the label key to specify the version of the templates of the given tier

--- a/pkg/test/usersignup/usersignup.go
+++ b/pkg/test/usersignup/usersignup.go
@@ -1,13 +1,12 @@
 package usersignup
 
 import (
-	"crypto/md5" // nolint:gosec
-	"encoding/hex"
 	"strconv"
 	"time"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
+	"github.com/codeready-toolchain/toolchain-common/pkg/hash"
 	"github.com/codeready-toolchain/toolchain-common/pkg/states"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/gofrs/uuid"
@@ -103,10 +102,7 @@ func WithStateLabel(stateValue string) Modifier {
 
 func WithEmail(email string) Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		md5hash := md5.New() // nolint:gosec
-		// Ignore the error, as this implementation cannot return one
-		_, _ = md5hash.Write([]byte(email))
-		emailHash := hex.EncodeToString(md5hash.Sum(nil))
+		emailHash := hash.EncodeString(email)
 		userSignup.ObjectMeta.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey] = emailHash
 		userSignup.ObjectMeta.Annotations[toolchainv1alpha1.UserSignupUserEmailAnnotationKey] = email
 	}
@@ -189,11 +185,7 @@ func NewUserSignupObjectMeta(name, email string) metav1.ObjectMeta {
 	if name == "" {
 		name = uuid.Must(uuid.NewV4()).String()
 	}
-
-	md5hash := md5.New() // nolint:gosec
-	// Ignore the error, as this implementation cannot return one
-	_, _ = md5hash.Write([]byte(email))
-	emailHash := hex.EncodeToString(md5hash.Sum(nil))
+	emailHash := hash.EncodeString(email)
 
 	return metav1.ObjectMeta{
 		Name:      name,


### PR DESCRIPTION
make it generic since the logic to hash with md5 is used in multiple places

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
