### PR TITLE
Move new SpaceBinding func to common

### DIFF
--- a/pkg/spacebinding/spacebinding.go
+++ b/pkg/spacebinding/spacebinding.go
@@ -1,0 +1,43 @@
+package spacebinding
+
+import (
+	"fmt"
+	"hash/crc32"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const defaultSpaceRole = "admin"
+
+func NewSpaceBinding(mur *toolchainv1alpha1.MasterUserRecord, space *toolchainv1alpha1.Space, creator string) *toolchainv1alpha1.SpaceBinding {
+	labels := map[string]string{
+		toolchainv1alpha1.SpaceCreatorLabelKey:                 creator,
+		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: mur.Name,
+		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            space.Name,
+	}
+
+	return &toolchainv1alpha1.SpaceBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: mur.Namespace,
+			Name:      spaceBindingName(space.Name, mur.Name),
+			Labels:    labels,
+		},
+		Spec: toolchainv1alpha1.SpaceBindingSpec{
+			MasterUserRecord: mur.Name,
+			Space:            space.Name,
+			SpaceRole:        defaultSpaceRole,
+		},
+	}
+}
+
+// spaceBindingName generates a unique name for the SpaceBinding resource to create,
+// based on the name of the Space and the name of the associated MasterUserRecord
+func spaceBindingName(spaceName, murName string) string {
+	c := crc32.Checksum([]byte(fmt.Sprintf("%s-%s", spaceName, murName)), crc32.IEEETable)
+	if len(spaceName) > 50 {
+		return fmt.Sprintf("%s-%x", spaceName[:50], c)
+	}
+	return fmt.Sprintf("%s-%x", spaceName, c)
+}

--- a/pkg/spacebinding/spacebinding_test.go
+++ b/pkg/spacebinding/spacebinding_test.go
@@ -1,0 +1,54 @@
+package spacebinding
+
+import (
+	"testing"
+
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	. "github.com/codeready-toolchain/toolchain-common/pkg/test/masteruserrecord"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewSpaceBinding(t *testing.T) {
+	// given
+	userSignup := commonsignup.NewUserSignup(commonsignup.WithName("johny"))
+	space := newSpace(userSignup, test.MemberClusterName, "smith", "advanced")
+	mur := NewMasterUserRecord(t, "johny", TargetCluster(test.MemberClusterName), TierName("deactivate90"))
+
+	// when
+	actualSpaceBinding := NewSpaceBinding(mur, space, userSignup.Name)
+
+	// then
+	assert.Equal(t, "johny", actualSpaceBinding.Spec.MasterUserRecord)
+	assert.Equal(t, "smith", actualSpaceBinding.Spec.Space)
+	assert.Equal(t, "admin", actualSpaceBinding.Spec.SpaceRole)
+
+	require.NotNil(t, actualSpaceBinding.Labels)
+	assert.Equal(t, userSignup.Name, actualSpaceBinding.Labels[toolchainv1alpha1.SpaceCreatorLabelKey])
+	assert.Equal(t, "johny", actualSpaceBinding.Labels[toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey])
+	assert.Equal(t, "smith", actualSpaceBinding.Labels[toolchainv1alpha1.SpaceBindingSpaceLabelKey])
+}
+
+func newSpace(userSignup *toolchainv1alpha1.UserSignup, targetCluster, compliantUserName, tier string) *toolchainv1alpha1.Space {
+	labels := map[string]string{
+		toolchainv1alpha1.SpaceCreatorLabelKey: userSignup.Name,
+	}
+
+	space := &toolchainv1alpha1.Space{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: userSignup.Namespace,
+			Name:      compliantUserName,
+			Labels:    labels,
+		},
+		Spec: toolchainv1alpha1.SpaceSpec{
+			TargetCluster: targetCluster,
+			TierName:      tier,
+		},
+	}
+	return space
+}


### PR DESCRIPTION
Moving some functions from host-operator to toolchain-common. It will be consumed by sandbox-cli as well.