### PR TITLE
refactor: usersignup approved funcs

### DIFF
--- a/pkg/states/state_manager.go
+++ b/pkg/states/state_manager.go
@@ -2,30 +2,18 @@ package states
 
 import toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
-func ManuallyApproved(userSignup *toolchainv1alpha1.UserSignup) bool {
+func ApprovedManually(userSignup *toolchainv1alpha1.UserSignup) bool {
 	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateApproved)
 }
 
-// SetManuallyApproved when a user was manually approved by an admin
+// SetApprovedManually when a user was manually approved by an admin
 // Note: when a user is manually approved, the `UserSignup.Spec.States` contains a single entry: `approved`
-func SetManuallyApproved(userSignup *toolchainv1alpha1.UserSignup, approved bool) {
+func SetApprovedManually(userSignup *toolchainv1alpha1.UserSignup, approved bool) {
 	setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, approved)
 	if approved {
 		setState(userSignup, toolchainv1alpha1.UserSignupStateVerificationRequired, false)
 		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, false)
 		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, false)
-	}
-}
-
-func AutomaticallyApproved(userSignup *toolchainv1alpha1.UserSignup) bool {
-	return userSignup.Spec.States == nil
-}
-
-// SetAutomaticallyApproved when a user was automatically approved (verification passed, etc.)
-// Note: when a user is automatically approved, the `UserSignup.Spec.States` is reset
-func SetAutomaticallyApproved(userSignup *toolchainv1alpha1.UserSignup, approved bool) {
-	if approved {
-		userSignup.Spec.States = nil
 	}
 }
 

--- a/pkg/states/state_manager.go
+++ b/pkg/states/state_manager.go
@@ -2,17 +2,30 @@ package states
 
 import toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 
-func Approved(userSignup *toolchainv1alpha1.UserSignup) bool {
+func ManuallyApproved(userSignup *toolchainv1alpha1.UserSignup) bool {
 	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateApproved)
 }
 
-func SetApproved(userSignup *toolchainv1alpha1.UserSignup, val bool) {
-	setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, val)
-
-	if val {
+// SetManuallyApproved when a user was manually approved by an admin
+// Note: when a user is manually approved, the `UserSignup.Spec.States` contains a single entry: `approved`
+func SetManuallyApproved(userSignup *toolchainv1alpha1.UserSignup, approved bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, approved)
+	if approved {
 		setState(userSignup, toolchainv1alpha1.UserSignupStateVerificationRequired, false)
 		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, false)
 		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, false)
+	}
+}
+
+func AutomaticallyApproved(userSignup *toolchainv1alpha1.UserSignup) bool {
+	return userSignup.Spec.States == nil
+}
+
+// SetAutomaticallyApproved when a user was automatically approved (verification passed, etc.)
+// Note: when a user is automatically approved, the `UserSignup.Spec.States` is reset
+func SetAutomaticallyApproved(userSignup *toolchainv1alpha1.UserSignup, approved bool) {
+	if approved {
+		userSignup.Spec.States = nil
 	}
 }
 
@@ -40,10 +53,9 @@ func Deactivated(userSignup *toolchainv1alpha1.UserSignup) bool {
 	return contains(userSignup.Spec.States, toolchainv1alpha1.UserSignupStateDeactivated)
 }
 
-func SetDeactivated(userSignup *toolchainv1alpha1.UserSignup, val bool) {
-	setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, val)
-
-	if val {
+func SetDeactivated(userSignup *toolchainv1alpha1.UserSignup, deactivated bool) {
+	setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivated, deactivated)
+	if deactivated {
 		setState(userSignup, toolchainv1alpha1.UserSignupStateApproved, false)
 		setState(userSignup, toolchainv1alpha1.UserSignupStateDeactivating, false)
 	}

--- a/pkg/states/state_manager_test.go
+++ b/pkg/states/state_manager_test.go
@@ -13,20 +13,20 @@ func TestStateManager(t *testing.T) {
 
 	t.Run("test manually approved", func(t *testing.T) {
 
-		SetManuallyApproved(u, true)
+		SetApprovedManually(u, true)
 
-		require.True(t, ManuallyApproved(u))
+		require.True(t, ApprovedManually(u))
 		require.Len(t, u.Spec.States, 1)
 		require.Equal(t, toolchainv1alpha1.UserSignupStateApproved, u.Spec.States[0])
 
-		SetManuallyApproved(u, false)
+		SetApprovedManually(u, false)
 
 		require.Empty(t, u.Spec.States)
-		require.False(t, ManuallyApproved(u))
+		require.False(t, ApprovedManually(u))
 
 		SetDeactivated(u, true)
 		SetVerificationRequired(u, true)
-		SetManuallyApproved(u, true)
+		SetApprovedManually(u, true)
 
 		// Setting approved should remove verification required
 		require.False(t, VerificationRequired(u))
@@ -34,46 +34,17 @@ func TestStateManager(t *testing.T) {
 		// Setting approved should remove deactivated
 		require.False(t, Deactivated(u))
 
-		SetManuallyApproved(u, false)
+		SetApprovedManually(u, false)
 
 		SetDeactivating(u, true)
-		SetManuallyApproved(u, true)
-
-		// Setting approved should remove deactivating
-		require.False(t, Deactivating(u))
-	})
-
-	t.Run("test automatically approved", func(t *testing.T) {
-
-		SetAutomaticallyApproved(u, true)
-
-		require.True(t, AutomaticallyApproved(u))
-		require.Empty(t, u.Spec.States)
-
-		SetAutomaticallyApproved(u, false)
-		require.Empty(t, u.Spec.States) // still empty
-
-		SetDeactivated(u, true)
-		SetVerificationRequired(u, true)
-		SetAutomaticallyApproved(u, true)
-
-		// Setting approved should remove verification required
-		require.False(t, VerificationRequired(u))
-
-		// Setting approved should remove deactivated
-		require.False(t, Deactivated(u))
-
-		SetAutomaticallyApproved(u, false)
-
-		SetDeactivating(u, true)
-		SetAutomaticallyApproved(u, true)
+		SetApprovedManually(u, true)
 
 		// Setting approved should remove deactivating
 		require.False(t, Deactivating(u))
 	})
 
 	t.Run("test verification required", func(t *testing.T) {
-		SetAutomaticallyApproved(u, false)
+		SetApprovedManually(u, false)
 		SetVerificationRequired(u, true)
 
 		require.True(t, VerificationRequired(u))
@@ -119,11 +90,11 @@ func TestStateManager(t *testing.T) {
 		require.Empty(t, u.Spec.States)
 
 		SetDeactivating(u, true)
-		SetAutomaticallyApproved(u, true)
+		SetApprovedManually(u, true)
 		SetDeactivated(u, true)
 
 		// Setting deactivated should also set approved and deactivating to false
-		require.False(t, ManuallyApproved(u))
+		require.False(t, ApprovedManually(u))
 		require.False(t, Deactivating(u))
 	})
 }

--- a/pkg/states/state_manager_test.go
+++ b/pkg/states/state_manager_test.go
@@ -1,31 +1,32 @@
 package states
 
 import (
+	"testing"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestStateManager(t *testing.T) {
 
 	u := &toolchainv1alpha1.UserSignup{}
 
-	t.Run("test approved", func(t *testing.T) {
+	t.Run("test manually approved", func(t *testing.T) {
 
-		SetApproved(u, true)
+		SetManuallyApproved(u, true)
 
-		require.True(t, Approved(u))
+		require.True(t, ManuallyApproved(u))
 		require.Len(t, u.Spec.States, 1)
 		require.Equal(t, toolchainv1alpha1.UserSignupStateApproved, u.Spec.States[0])
 
-		SetApproved(u, false)
+		SetManuallyApproved(u, false)
 
-		require.Len(t, u.Spec.States, 0)
-		require.False(t, Approved(u))
+		require.Empty(t, u.Spec.States)
+		require.False(t, ManuallyApproved(u))
 
 		SetDeactivated(u, true)
 		SetVerificationRequired(u, true)
-		SetApproved(u, true)
+		SetManuallyApproved(u, true)
 
 		// Setting approved should remove verification required
 		require.False(t, VerificationRequired(u))
@@ -33,17 +34,46 @@ func TestStateManager(t *testing.T) {
 		// Setting approved should remove deactivated
 		require.False(t, Deactivated(u))
 
-		SetApproved(u, false)
+		SetManuallyApproved(u, false)
 
 		SetDeactivating(u, true)
-		SetApproved(u, true)
+		SetManuallyApproved(u, true)
+
+		// Setting approved should remove deactivating
+		require.False(t, Deactivating(u))
+	})
+
+	t.Run("test automatically approved", func(t *testing.T) {
+
+		SetAutomaticallyApproved(u, true)
+
+		require.True(t, AutomaticallyApproved(u))
+		require.Empty(t, u.Spec.States)
+
+		SetAutomaticallyApproved(u, false)
+		require.Empty(t, u.Spec.States) // still empty
+
+		SetDeactivated(u, true)
+		SetVerificationRequired(u, true)
+		SetAutomaticallyApproved(u, true)
+
+		// Setting approved should remove verification required
+		require.False(t, VerificationRequired(u))
+
+		// Setting approved should remove deactivated
+		require.False(t, Deactivated(u))
+
+		SetAutomaticallyApproved(u, false)
+
+		SetDeactivating(u, true)
+		SetAutomaticallyApproved(u, true)
 
 		// Setting approved should remove deactivating
 		require.False(t, Deactivating(u))
 	})
 
 	t.Run("test verification required", func(t *testing.T) {
-		SetApproved(u, false)
+		SetAutomaticallyApproved(u, false)
 		SetVerificationRequired(u, true)
 
 		require.True(t, VerificationRequired(u))
@@ -53,7 +83,7 @@ func TestStateManager(t *testing.T) {
 
 		SetVerificationRequired(u, false)
 
-		require.Len(t, u.Spec.States, 0)
+		require.Empty(t, u.Spec.States)
 		require.False(t, VerificationRequired(u))
 	})
 
@@ -68,7 +98,7 @@ func TestStateManager(t *testing.T) {
 
 		SetDeactivating(u, false)
 
-		require.Len(t, u.Spec.States, 0)
+		require.Empty(t, u.Spec.States)
 		require.False(t, Deactivating(u))
 
 		SetDeactivated(u, true)
@@ -86,14 +116,14 @@ func TestStateManager(t *testing.T) {
 		require.Equal(t, toolchainv1alpha1.UserSignupStateDeactivated, u.Spec.States[0])
 
 		SetDeactivated(u, false)
-		require.Len(t, u.Spec.States, 0)
+		require.Empty(t, u.Spec.States)
 
 		SetDeactivating(u, true)
-		SetApproved(u, true)
+		SetAutomaticallyApproved(u, true)
 		SetDeactivated(u, true)
 
 		// Setting deactivated should also set approved and deactivating to false
-		require.False(t, Approved(u))
+		require.False(t, ManuallyApproved(u))
 		require.False(t, Deactivating(u))
 	})
 }

--- a/pkg/test/usersignup/usersignup.go
+++ b/pkg/test/usersignup/usersignup.go
@@ -26,50 +26,22 @@ func WithOriginalSub(originalSub string) Modifier {
 	}
 }
 
-// ManuallyApproved sets the UserSignup states to [`approved`]
-func ManuallyApproved() Modifier {
+// ApprovedManually sets the UserSignup states to [`approved`]
+func ApprovedManually() Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		states.SetManuallyApproved(userSignup, true)
+		states.SetApprovedManually(userSignup, true)
 	}
 }
 
-// ManuallyApproved sets the UserSignup state to `approved` and adds a status condition
-func ManuallyApprovedAgo(before time.Duration) Modifier {
+// ApprovedManuallyAgo sets the UserSignup state to `approved` and adds a status condition
+func ApprovedManuallyAgo(before time.Duration) Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		states.SetManuallyApproved(userSignup, true)
+		states.SetApprovedManually(userSignup, true)
 		userSignup.Status.Conditions = condition.AddStatusConditions(userSignup.Status.Conditions,
 			toolchainv1alpha1.Condition{
 				Type:               toolchainv1alpha1.UserSignupApproved,
 				Status:             corev1.ConditionTrue,
 				Reason:             toolchainv1alpha1.UserSignupApprovedByAdminReason,
-				LastTransitionTime: metav1.Time{Time: time.Now().Add(-before)},
-			})
-	}
-}
-
-// AutomaticallyApproved resets the UserSignup states
-func AutomaticallyApproved() Modifier {
-	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		states.SetAutomaticallyApproved(userSignup, true)
-		userSignup.Status.Conditions = condition.AddStatusConditions(userSignup.Status.Conditions,
-			toolchainv1alpha1.Condition{
-				Type:               toolchainv1alpha1.UserSignupApproved,
-				Status:             corev1.ConditionTrue,
-				Reason:             toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
-				LastTransitionTime: metav1.Time{Time: time.Now()},
-			})
-	}
-}
-
-// AutomaticallyApproved resets the UserSignup states and adds a status condition
-func AutomaticallyApprovedAgo(before time.Duration) Modifier {
-	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		states.SetAutomaticallyApproved(userSignup, true)
-		userSignup.Status.Conditions = condition.AddStatusConditions(userSignup.Status.Conditions,
-			toolchainv1alpha1.Condition{
-				Type:               toolchainv1alpha1.UserSignupApproved,
-				Status:             corev1.ConditionTrue,
-				Reason:             toolchainv1alpha1.UserSignupApprovedAutomaticallyReason,
 				LastTransitionTime: metav1.Time{Time: time.Now().Add(-before)},
 			})
 	}


### PR DESCRIPTION
distinguish between automatic approval and manual approval (by admin)

see also:
- https://github.com/codeready-toolchain/member-operator/pull/389
- https://github.com/codeready-toolchain/host-operator/pull/702
- https://github.com/codeready-toolchain/registration-service/pull/286
- https://github.com/codeready-toolchain/sandbox-sre/pull/810
- https://github.com/codeready-toolchain/toolchain-e2e/pull/620

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
