### PR TITLE
chore(build): use token to upload to codecov

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         version: v1.45.0
         skip-pkg-cache: true
         skip-build-cache: true


### PR DESCRIPTION
workaround to upload failures - see https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954/5

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
