### PR TITLE
exclude test helper files from coverage

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,6 +26,7 @@ coverage:
     - "build/*"
     - "example/*"
     - "openshift-ci/*"
+    - "pkg/test/*"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:


### PR DESCRIPTION
`pkg/test/` folder contains files used only for tests - let's drop them from the coverage