### PR TITLE
fix: don't set tenant label in test setup part

### DIFF
--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -16,6 +16,8 @@ func TestAddToolchainClusterAsMember(t *testing.T) {
 	// given & then
 	verify.AddToolchainClusterAsMember(t, func(toolchainCluster *toolchainv1alpha1.ToolchainCluster, cl *test.FakeClient, service cluster.ToolchainClusterService) error {
 		// given
+		// let's delete the tenant label to verify that it will be added by the controller
+		delete(toolchainCluster.Labels, cluster.RoleLabel(cluster.Tenant))
 		controller, req := prepareReconcile(toolchainCluster, cl, service)
 
 		// when

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -1,6 +1,7 @@
 package verify
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -53,6 +54,7 @@ func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify
 					assert.Equal(t, labels["namespace"], cachedToolchainCluster.OperatorNamespace)
 				}
 				// check that toolchain cluster role label tenant was set only on member cluster type
+				require.NoError(t, cl.Get(context.TODO(), client.ObjectKeyFromObject(toolchainCluster), toolchainCluster))
 				expectedToolChainClusterRoleLabel := cluster.RoleLabel(cluster.Tenant)
 				_, found := toolchainCluster.Labels[expectedToolChainClusterRoleLabel]
 				if labels["type"] == string(cluster.Member) {
@@ -101,6 +103,7 @@ func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) 
 					assert.Equal(t, labels["namespace"], cachedToolchainCluster.OperatorNamespace)
 				}
 				// check that toolchain cluster role label tenant is not set on host cluster
+				require.NoError(t, cl.Get(context.TODO(), client.ObjectKeyFromObject(toolchainCluster), toolchainCluster))
 				expectedToolChainClusterRoleLabel := cluster.RoleLabel(cluster.Tenant)
 				_, found := toolchainCluster.Labels[expectedToolChainClusterRoleLabel]
 				require.False(t, found)


### PR DESCRIPTION
the current test sets the `tenant` label as part of the setup so it actually doesn't verify that the controller really sets that