### PR TITLE
ignore also subfolders

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -26,7 +26,7 @@ coverage:
     - "build/*"
     - "example/*"
     - "openshift-ci/*"
-    - "pkg/test/*"
+    - "pkg/test/**/*"
 
 # See http://docs.codecov.io/docs/pull-request-comments-1
 comment:


### PR DESCRIPTION
from https://docs.codecov.com/docs/ignoring-paths

> The pattern folder/* will not match recursively in the folder.
Please use this folder/**/*, which will exclude all files within the given folder.

:man_facepalming: 