### PR TITLE
feat: Support cluster-roles when specifying the needed target cluster in Spaces

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -33,6 +33,10 @@ type Config struct {
 	// then the OwnerClusterName has a name of the member - it has to be same name as the name
 	// that is used for identifying the member in a Host cluster
 	OwnerClusterName string
+
+	// Labels contains all the labels of the corresponding ToolchainCluster.
+	// They will be used for filtering ToolchainCluster's based on a given list of cluster-role labels.
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // CachedToolchainCluster stores cluster client; cluster related info and previous health check probe results

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -221,6 +221,7 @@ func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.Tool
 		Type:              Type(toolchainCluster.Labels[LabelType]),
 		OperatorNamespace: toolchainCluster.Labels[labelNamespace],
 		OwnerClusterName:  toolchainCluster.Labels[labelOwnerClusterName],
+		Labels:            toolchainCluster.Labels,
 	}, nil
 }
 

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -89,6 +89,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 			HasOperatorNamespace("toolchain-member-operator").
 			HasOwnerClusterName("m1ClusterName").
 			HasAPIEndpoint("http://m1.com").
+			ContainsLabel(cluster.RoleLabel(cluster.Tenant)). // the value is not used only the key matters
 			RestConfigHasHost("http://m1.com")
 		verify.AssertClusterConfigThat(t, clusterConfigs[1]).
 			IsOfType(cluster.Member).
@@ -96,6 +97,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 			HasOperatorNamespace("toolchain-member-operator").
 			HasOwnerClusterName("m2ClusterName").
 			HasAPIEndpoint("http://m2.com").
+			ContainsLabel(cluster.RoleLabel(cluster.Tenant)). // the value is not used only the key matters
 			RestConfigHasHost("http://m2.com")
 	})
 

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -280,6 +280,11 @@ func (a *ClusterConfigAssertion) HasAPIEndpoint(apiEndpoint string) *ClusterConf
 	return a
 }
 
+func (a *ClusterConfigAssertion) ContainsLabel(label string) *ClusterConfigAssertion {
+	assert.Contains(a.t, a.clusterConfig.Labels, label)
+	return a
+}
+
 func (a *ClusterConfigAssertion) RestConfigHasHost(host string) *ClusterConfigAssertion {
 	require.NotNil(a.t, a.clusterConfig.RestConfig)
 	assert.Equal(a.t, host, a.clusterConfig.RestConfig.Host)


### PR DESCRIPTION
Add Lables filed to CachedToolchainCluster struct so that it can reflect the cluster-role labels enabling filtering on those.

Jira Ticket: https://issues.redhat.com/browse/ASC-251

Related PR's:
- api: https://github.com/codeready-toolchain/api/pull/336
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/736
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/656