### PR TITLE
PLNSRVCE-1166: add openshift route type to scheme for registration service proxy plugin support

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -6,6 +6,8 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	routev1 "github.com/openshift/api/route/v1"
 )
 
 // AddToScheme adds all required resources to the default Scheme
@@ -15,6 +17,7 @@ func AddToScheme(s *runtime.Scheme) error {
 		toolchainv1alpha1.AddToScheme,
 		corev1.AddToScheme,
 		authenticationv1.AddToScheme, // used by the registration service proxy to verify cached tokens
+		routev1.Install,              // used by the registration service to access proxy plugin endpoints exposed via openshift routes
 	)
 	return addToSchemes.AddToScheme(s)
 }


### PR DESCRIPTION
otherwise the registration service gets the error

`no kind is registered for the type v1.Route in scheme \"pkg/runtime/scheme.go:100\"` 

when trying to look up the openshift route associated with the new proxy plugin support 

/assign @alexeykazakov 
/assign @rajivnathan 