### PR TITLE
Populate PropagatedClaims when creating a new MasterUserRecord

### DIFF
--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -56,6 +56,13 @@ func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier
 			TierName:     "deactivate30",
 			UserID:       userID,
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{newEmbeddedUa(test.MemberClusterName)},
+			PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
+				Sub:         "44332211",
+				UserID:      "135246",
+				AccountID:   "357468",
+				OriginalSub: "11223344",
+				Email:       "joe@redhat.com",
+			},
 		},
 	}
 	err := Modify(mur, modifiers...)


### PR DESCRIPTION
This PR populates the PropagatedClaims property with some hard coded values for testing purposes.