### PR TITLE
Update common libraries to use PropagatedClaims

### DIFF
--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -93,7 +93,7 @@ func ModifyUaInMur(mur *toolchainv1alpha1.MasterUserRecord, targetCluster string
 
 func UserID(userID string) MurModifier {
 	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
-		mur.Spec.UserID = userID
+		mur.Spec.PropagatedClaims.UserID = userID
 		return nil
 	}
 }

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -8,7 +8,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/condition"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/gofrs/uuid"
 	"github.com/redhat-cop/operator-utils/pkg/util"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,6 @@ func NewMasterUserRecords(t *testing.T, size int, nameFmt string, modifiers ...M
 }
 
 func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier) *toolchainv1alpha1.MasterUserRecord {
-	userID := uuid.Must(uuid.NewV4()).String()
 	mur := &toolchainv1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   test.HostOperatorNs,
@@ -54,8 +52,8 @@ func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier
 			TierName:     "deactivate30",
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{newEmbeddedUa(test.MemberClusterName)},
 			PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
-				Sub:         "44332211",
-				UserID:      userID,
+				Sub:         "UserID123",
+				UserID:      "135246",
 				AccountID:   "357468",
 				OriginalSub: "11223344",
 				Email:       "joe@redhat.com",

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -210,7 +210,7 @@ func ProvisionedMur(provisionedTime *metav1.Time) MurModifier {
 // UserIDFromUserSignup creates a MurModifier to change the userID value to match the provided usersignup
 func UserIDFromUserSignup(userSignup *toolchainv1alpha1.UserSignup) MurModifier {
 	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
-		mur.Spec.UserID = userSignup.Name
+		mur.Spec.PropagatedClaims.UserID = userSignup.Name
 		return nil
 	}
 }

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -45,12 +45,10 @@ func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier
 	userID := uuid.Must(uuid.NewV4()).String()
 	mur := &toolchainv1alpha1.MasterUserRecord{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: test.HostOperatorNs,
-			Name:      userName,
-			Labels:    map[string]string{},
-			Annotations: map[string]string{
-				toolchainv1alpha1.MasterUserRecordEmailAnnotationKey: "joe@redhat.com",
-			},
+			Namespace:   test.HostOperatorNs,
+			Name:        userName,
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			TierName:     "deactivate30",

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -93,6 +93,13 @@ func UserID(userID string) MurModifier {
 	}
 }
 
+func Sub(sub string) MurModifier {
+	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
+		mur.Spec.PropagatedClaims.Sub = sub
+		return nil
+	}
+}
+
 func StatusCondition(con toolchainv1alpha1.Condition) MurModifier {
 	return func(mur *toolchainv1alpha1.MasterUserRecord) error {
 		mur.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(mur.Status.Conditions, con)

--- a/pkg/test/masteruserrecord/masteruserrecord.go
+++ b/pkg/test/masteruserrecord/masteruserrecord.go
@@ -54,11 +54,10 @@ func NewMasterUserRecord(t *testing.T, userName string, modifiers ...MurModifier
 		},
 		Spec: toolchainv1alpha1.MasterUserRecordSpec{
 			TierName:     "deactivate30",
-			UserID:       userID,
 			UserAccounts: []toolchainv1alpha1.UserAccountEmbedded{newEmbeddedUa(test.MemberClusterName)},
 			PropagatedClaims: toolchainv1alpha1.PropagatedClaims{
 				Sub:         "44332211",
-				UserID:      "135246",
+				UserID:      userID,
 				AccountID:   "357468",
 				OriginalSub: "11223344",
 				Email:       "joe@redhat.com",

--- a/pkg/test/masteruserrecord/masteruserrecord_assertion.go
+++ b/pkg/test/masteruserrecord/masteruserrecord_assertion.go
@@ -202,13 +202,6 @@ func (a *MasterUserRecordAssertion) HasAnnotationWithValue(key, value string) *M
 	return a
 }
 
-func (a *MasterUserRecordAssertion) HasOriginalSub(sub string) *MasterUserRecordAssertion {
-	err := a.loadMasterUserRecord()
-	require.NoError(a.t, err)
-	assert.Equal(a.t, sub, a.mur.Spec.OriginalSub)
-	return a
-}
-
 func (a *MasterUserRecordAssertion) HasTargetCluster(targetcluster string) *MasterUserRecordAssertion {
 	err := a.loadMasterUserRecord()
 	require.NoError(a.t, err)

--- a/pkg/test/useraccount/useraccount.go
+++ b/pkg/test/useraccount/useraccount.go
@@ -18,12 +18,8 @@ func NewUserAccountFromMur(mur *toolchainv1alpha1.MasterUserRecord, modifiers ..
 			Labels: map[string]string{
 				toolchainv1alpha1.TierLabelKey: mur.Spec.TierName,
 			},
-			Annotations: map[string]string{
-				toolchainv1alpha1.UserEmailAnnotationKey: mur.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey],
-			},
 		},
 		Spec: toolchainv1alpha1.UserAccountSpec{
-			UserID:           mur.Spec.UserID,
 			Disabled:         mur.Spec.Disabled,
 			PropagatedClaims: mur.Spec.PropagatedClaims,
 		},

--- a/pkg/test/useraccount/useraccount_assertion.go
+++ b/pkg/test/useraccount/useraccount_assertion.go
@@ -76,11 +76,9 @@ func (a *Assertion) HasNoFinalizer() *Assertion {
 func (a *Assertion) MatchMasterUserRecord(mur *toolchainv1alpha1.MasterUserRecord) *Assertion {
 	err := a.loadUaAssertion()
 	require.NoError(a.t, err)
-	assert.Equal(a.t, mur.Spec.UserID, a.userAccount.Spec.UserID)
+	assert.Equal(a.t, mur.Spec.PropagatedClaims, a.userAccount.Spec.PropagatedClaims)
 	assert.Equal(a.t, mur.Spec.Disabled, a.userAccount.Spec.Disabled)
-	assert.Equal(a.t, mur.Spec.OriginalSub, a.userAccount.Spec.OriginalSub)
 	assert.NotNil(a.t, a.userAccount.Annotations)
-	assert.Equal(a.t, mur.Annotations[toolchainv1alpha1.MasterUserRecordEmailAnnotationKey], a.userAccount.Annotations[toolchainv1alpha1.UserEmailAnnotationKey])
 	return a
 }
 

--- a/pkg/test/useraccount/useraccount_assertion.go
+++ b/pkg/test/useraccount/useraccount_assertion.go
@@ -78,7 +78,6 @@ func (a *Assertion) MatchMasterUserRecord(mur *toolchainv1alpha1.MasterUserRecor
 	require.NoError(a.t, err)
 	assert.Equal(a.t, mur.Spec.PropagatedClaims, a.userAccount.Spec.PropagatedClaims)
 	assert.Equal(a.t, mur.Spec.Disabled, a.userAccount.Spec.Disabled)
-	assert.NotNil(a.t, a.userAccount.Annotations)
 	return a
 }
 

--- a/pkg/test/useraccount/useraccount_test.go
+++ b/pkg/test/useraccount/useraccount_test.go
@@ -16,7 +16,7 @@ func TestUserAccountFromMur(t *testing.T) {
 		userAcc := uatest.NewUserAccountFromMur(mur)
 
 		// when & then
-		assert.Equal(t, mur.Spec.UserID, userAcc.Spec.UserID)
+		assert.Equal(t, mur.Spec.PropagatedClaims, userAcc.Spec.PropagatedClaims)
 		assert.Equal(t, mur.Spec.Disabled, userAcc.Spec.Disabled)
 	})
 }


### PR DESCRIPTION
This is a companion PR to https://github.com/codeready-toolchain/host-operator/pull/943 which refactors the MasterUserRecordController to only use the user's SSO claim values from PropagatedClaims and nowhere else.