### PR TITLE
Include the provisioning configuration in the CachedToolchainCluster

### DIFF
--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -19,9 +19,14 @@ import (
 func NewReconciler(mgr manager.Manager, namespace string, timeout time.Duration) *Reconciler {
 	cacheLog := log.Log.WithName("toolchaincluster_cache")
 	clusterCacheService := cluster.NewToolchainClusterService(mgr.GetClient(), cacheLog, namespace, timeout)
+	return NewReconcilerWithClusterCache(mgr.GetClient(), mgr.GetScheme(), clusterCacheService)
+}
+
+// NewReconcilerWithClusterCache returns a new reconciler initializer with the provided variables
+func NewReconcilerWithClusterCache(cl client.Client, scheme *runtime.Scheme, clusterCacheService cluster.ToolchainClusterService) *Reconciler {
 	return &Reconciler{
-		client:              mgr.GetClient(),
-		scheme:              mgr.GetScheme(),
+		client:              cl,
+		scheme:              scheme,
 		clusterCacheService: clusterCacheService,
 	}
 }

--- a/pkg/test/config/toolchainconfig.go
+++ b/pkg/test/config/toolchainconfig.go
@@ -96,6 +96,9 @@ func CapacityThresholds() *CapacityThresholdsOption {
 	return c
 }
 
+// This should only be used for setting the default resource capacity (aka memory utilization) threshold. The per-member options
+// are ignored. The memory utilization threshold is now configured using SpaceProvisionerConfig and can be set in the host-operator
+// tests using the modifiers in the NewMemberCluster* functions in host-operator/test package.
 func (c CapacityThresholdsOption) ResourceCapacityThreshold(defaultThreshold int, perMember ...PerMemberClusterOptionInt) CapacityThresholdsOption {
 	c.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
 		config.Spec.Host.CapacityThresholds.ResourceCapacityThreshold.DefaultThreshold = &defaultThreshold
@@ -107,6 +110,8 @@ func (c CapacityThresholdsOption) ResourceCapacityThreshold(defaultThreshold int
 	return c
 }
 
+// Deprecated: This does effectively nothing. The max number of spaces is now configured per-cluster using the NewMemberCluster* functions in the
+// host-operator/test package.
 func (c CapacityThresholdsOption) MaxNumberOfSpaces(perMember ...PerMemberClusterOptionInt) CapacityThresholdsOption {
 	c.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
 		config.Spec.Host.CapacityThresholds.MaxNumberOfSpacesPerMemberCluster = map[string]int{}

--- a/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -7,9 +7,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type CreateOption func(*toolchainv1alpha1.SpaceProvisionerConfig)
+type ModifyOption func(*toolchainv1alpha1.SpaceProvisionerConfig)
 
-func NewSpaceProvisionerConfig(name string, namespace string, opts ...CreateOption) *toolchainv1alpha1.SpaceProvisionerConfig {
+func NewSpaceProvisionerConfig(name string, namespace string, opts ...ModifyOption) *toolchainv1alpha1.SpaceProvisionerConfig {
 	spc := &toolchainv1alpha1.SpaceProvisionerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -24,27 +24,33 @@ func NewSpaceProvisionerConfig(name string, namespace string, opts ...CreateOpti
 	return spc
 }
 
-func ReferencingToolchainCluster(name string) CreateOption {
+func ReferencingToolchainCluster(name string) ModifyOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Spec.ToolchainCluster = name
 	}
 }
 
-func Enabled(enabled bool) CreateOption {
+func Enabled(enabled bool) ModifyOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Spec.Enabled = enabled
 	}
 }
 
-func WithReadyConditionValid() CreateOption {
+func WithPlacementRoles(placementRoles ...string) ModifyOption {
+	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
+		spc.Spec.PlacementRoles = placementRoles
+	}
+}
+
+func WithReadyConditionValid() ModifyOption {
 	return WithReadyCondition(corev1.ConditionTrue, toolchainv1alpha1.SpaceProvisionerConfigValidReason)
 }
 
-func WithReadyConditionInvalid(reason string) CreateOption {
+func WithReadyConditionInvalid(reason string) ModifyOption {
 	return WithReadyCondition(corev1.ConditionFalse, reason)
 }
 
-func WithReadyCondition(status corev1.ConditionStatus, reason string) CreateOption {
+func WithReadyCondition(status corev1.ConditionStatus, reason string) ModifyOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spc.Status.Conditions, toolchainv1alpha1.Condition{
 			Type:   toolchainv1alpha1.ConditionReady,
@@ -54,13 +60,13 @@ func WithReadyCondition(status corev1.ConditionStatus, reason string) CreateOpti
 	}
 }
 
-func MaxNumberOfSpaces(number uint) CreateOption {
+func MaxNumberOfSpaces(number uint) ModifyOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Spec.CapacityThresholds.MaxNumberOfSpaces = number
 	}
 }
 
-func MaxMemoryUtilizationPercent(number uint) CreateOption {
+func MaxMemoryUtilizationPercent(number uint) ModifyOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Spec.CapacityThresholds.MaxMemoryUtilizationPercent = number
 	}

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -27,9 +27,9 @@ func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify
 	memberLabels := []map[string]string{
 		Labels("", "", test.NameHost),
 		Labels(cluster.Member, "", test.NameHost),
-		Labels(cluster.Member, "member-ns", test.NameHost)}
+		Labels(cluster.Member, "member-ns", test.NameHost),
+	}
 	for _, labels := range memberLabels {
-
 		t.Run("add member ToolchainCluster", func(t *testing.T) {
 			for _, withCA := range []bool{true, false} {
 				toolchainCluster, sec := test.NewToolchainCluster("east", "secret", status, labels)
@@ -76,7 +76,8 @@ func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) 
 	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
 	memberLabels := []map[string]string{
 		Labels(cluster.Host, "", test.NameMember),
-		Labels(cluster.Host, "host-ns", test.NameMember)}
+		Labels(cluster.Host, "host-ns", test.NameMember),
+	}
 	for _, labels := range memberLabels {
 
 		t.Run("add host ToolchainCluster", func(t *testing.T) {
@@ -143,7 +144,8 @@ func AddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T, functionToVerify
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "secret",
 			Namespace: "test-namespace",
-		}}
+		},
+	}
 	cl := test.NewFakeClient(t, toolchainCluster, secret)
 	service := newToolchainClusterService(t, cl, false)
 
@@ -288,5 +290,33 @@ func (a *ClusterConfigAssertion) ContainsLabel(label string) *ClusterConfigAsser
 func (a *ClusterConfigAssertion) RestConfigHasHost(host string) *ClusterConfigAssertion {
 	require.NotNil(a.t, a.clusterConfig.RestConfig)
 	assert.Equal(a.t, host, a.clusterConfig.RestConfig.Host)
+	return a
+}
+
+func (a *ClusterConfigAssertion) ProvisioningIsEnabled(enabled bool) *ClusterConfigAssertion {
+	assert.Equal(a.t, enabled, a.clusterConfig.Provisioning.Enabled)
+	return a
+}
+
+func (a *ClusterConfigAssertion) ProvisioningHasMaxMemoryPercent(threshold uint) *ClusterConfigAssertion {
+	assert.Equal(a.t, threshold, a.clusterConfig.Provisioning.CapacityThresholds.MaxMemoryUtilizationPercent)
+	return a
+}
+
+func (a *ClusterConfigAssertion) ProvisioningHasMaxNumberOfSpaces(threshold uint) *ClusterConfigAssertion {
+	assert.Equal(a.t, threshold, a.clusterConfig.Provisioning.CapacityThresholds.MaxNumberOfSpaces)
+	return a
+}
+
+func (a *ClusterConfigAssertion) ProvisioningHasPlacementRole(placementRole string) *ClusterConfigAssertion {
+	assert.Contains(a.t, a.clusterConfig.Provisioning.PlacementRoles, placementRole)
+	return a
+}
+
+func (a *ClusterConfigAssertion) ProvisioningHasExactlyPlacementRoles(placementRoles ...string) *ClusterConfigAssertion {
+	assert.Equal(a.t, len(placementRoles), len(a.clusterConfig.Provisioning.PlacementRoles))
+	for _, pr := range placementRoles {
+		assert.Contains(a.t, a.clusterConfig.Provisioning.PlacementRoles, pr)
+	}
 	return a
 }


### PR DESCRIPTION
Because the provisioning decisions and toolchain cluster configuration are done using the combination of `ToolchainConfig` and `CachedToolchainCluster` objects, this adds the provisioning configuration (loaded from `SpaceProvisionerConfig` objects) to the `CachedToolchainCluster`. 

Doing it this way, we don't have to modify much of the logic elsewhere (mainly in the tests) - we just move the configuration done with `ToolchainConfig` to configuration done with `CachedToolchainCluster`. These two things usually coincide in the codebase so the change is easy.

Note that we keep the default memory usage threshold in the `ToolchainConfig` because there is no place for it in the `SpaceProvisionerConfig` "framework". We can think about dropping it in some future PR.

Note that this is WIP. There still some test failures in the e2e tests and therefore some debugging log statements sprinkled here and there in this code, too.

JIRA issue: https://issues.redhat.com/browse/KSPACE-46

Related PRs:
host-operator: https://github.com/codeready-toolchain/host-operator/pull/977
toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/905