### PR TITLE
KSPACE-43: Adding common GetClusters func

### DIFF
--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -103,6 +103,24 @@ func GetCachedToolchainCluster(name string) (*CachedToolchainCluster, bool) {
 	return clusterCache.getCachedToolchainCluster(name, true)
 }
 
+// GetClustersFunc a func that returns all the clusters from the cache
+type GetClustersFunc func(conditions ...Condition) []*CachedToolchainCluster
+
+// Clusters the func to retrieve all the clusters
+var Clusters GetClustersFunc = GetClusters
+
+// GetClusters returns the kube clients for all the clusters from the cache of the clusters
+func GetClusters(conditions ...Condition) []*CachedToolchainCluster {
+	clusters := clusterCache.getCachedToolchainClusters(conditions...)
+	if len(clusters) == 0 {
+		if clusterCache.refreshCache != nil {
+			clusterCache.refreshCache()
+		}
+		clusters = clusterCache.getCachedToolchainClusters(conditions...)
+	}
+	return clusters
+}
+
 // GetHostClusterFunc a func that returns the Host cluster from the cache,
 // along with a bool to indicate if there was a match or not
 type GetHostClusterFunc func() (*CachedToolchainCluster, bool)

--- a/pkg/cluster/cache.go
+++ b/pkg/cluster/cache.go
@@ -103,14 +103,14 @@ func GetCachedToolchainCluster(name string) (*CachedToolchainCluster, bool) {
 	return clusterCache.getCachedToolchainCluster(name, true)
 }
 
-// GetClustersFunc a func that returns all the clusters from the cache
-type GetClustersFunc func(conditions ...Condition) []*CachedToolchainCluster
+// GetToolchainClustersCachedFunc a func that returns all the clusters from the cache
+type GetToolchainClustersCachedFunc func(conditions ...Condition) []*CachedToolchainCluster
 
-// Clusters the func to retrieve all the clusters
-var Clusters GetClustersFunc = GetClusters
+// ToolchainClustersCached the func to retrieve all the clusters
+var ToolchainClustersCached GetToolchainClustersCachedFunc = GetToolchainClustersCached
 
-// GetClusters returns the kube clients for all the clusters from the cache of the clusters
-func GetClusters(conditions ...Condition) []*CachedToolchainCluster {
+// GetToolchainClustersCached returns the kube clients for all the clusters from the cache of the clusters
+func GetToolchainClustersCached(conditions ...Condition) []*CachedToolchainCluster {
 	clusters := clusterCache.getCachedToolchainClusters(conditions...)
 	if len(clusters) == 0 {
 		if clusterCache.refreshCache != nil {
@@ -142,24 +142,6 @@ func GetHostCluster() (*CachedToolchainCluster, bool) {
 		}
 	}
 	return clusters[0], true
-}
-
-// GetMemberClustersFunc a func that returns the member clusters from the cache
-type GetMemberClustersFunc func(conditions ...Condition) []*CachedToolchainCluster
-
-// MemberClusters the func to retrieve the member clusters
-var MemberClusters GetMemberClustersFunc = GetMemberClusters
-
-// GetMemberClusters returns the kube clients for the host clusters from the cache of the clusters
-func GetMemberClusters(conditions ...Condition) []*CachedToolchainCluster {
-	clusters := clusterCache.getCachedToolchainClusters(conditions...)
-	if len(clusters) == 0 {
-		if clusterCache.refreshCache != nil {
-			clusterCache.refreshCache()
-		}
-		clusters = clusterCache.getCachedToolchainClusters(conditions...)
-	}
-	return clusters
 }
 
 // Role defines the role of the cluster.

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -75,7 +75,7 @@ func TestGetClusters(t *testing.T) {
 			// no clusters
 
 			//when
-			clusters := GetClusters()
+			clusters := GetToolchainClustersCached()
 
 			//then
 			assert.Empty(t, clusters)
@@ -92,7 +92,7 @@ func TestGetClusters(t *testing.T) {
 			clusterCache.addCachedToolchainCluster(member2)
 
 			//when
-			clusters := GetClusters()
+			clusters := GetToolchainClustersCached()
 
 			//then
 			assert.Len(t, clusters, 3)
@@ -112,7 +112,7 @@ func TestGetClusters(t *testing.T) {
 			}
 
 			//when
-			clusters := GetClusters()
+			clusters := GetToolchainClustersCached()
 
 			//then
 			assert.Len(t, clusters, 1)
@@ -134,7 +134,7 @@ func TestGetClusters(t *testing.T) {
 			clusterCache.addCachedToolchainCluster(member3)
 
 			//when
-			clusters := GetClusters(Ready)
+			clusters := GetToolchainClustersCached(Ready)
 
 			//then
 			assert.Len(t, clusters, 3)

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -227,9 +227,9 @@ func IsReady(clusterStatus *toolchainv1alpha1.ToolchainClusterStatus) bool {
 	return false
 }
 
-func ListToolchainClusterConfigs(cl client.Client, namespace string, timeout time.Duration) ([]*Config, error) {
+func ListToolchainClusterConfigs(ctx context.Context, cl client.Client, namespace string, timeout time.Duration) ([]*Config, error) {
 	toolchainClusters := &toolchainv1alpha1.ToolchainClusterList{}
-	if err := cl.List(context.TODO(), toolchainClusters, client.InNamespace(namespace)); err != nil {
+	if err := cl.List(ctx, toolchainClusters, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
 	var configs []*Config

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -81,7 +81,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 
 	t.Run("list members", func(t *testing.T) {
 		// when
-		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, time.Second)
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(context.TODO(), cl, m1.Namespace, time.Second)
 
 		// then
 		require.NoError(t, err)
@@ -105,7 +105,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 	t.Run("list host", func(t *testing.T) {
 		// when
 
-		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, host.Namespace, time.Second)
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(context.TODO(), cl, host.Namespace, time.Second)
 
 		// then
 		require.NoError(t, err)
@@ -124,7 +124,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		cl := test.NewFakeClient(t, host, noise, secNoise)
 
 		// when
-		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, time.Second)
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(context.TODO(), cl, m1.Namespace, time.Second)
 
 		// then
 		require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		}
 
 		// when
-		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, time.Second)
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(context.TODO(), cl, m1.Namespace, time.Second)
 
 		// then
 		require.Error(t, err)
@@ -154,7 +154,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		}
 
 		// when
-		clusterConfigs, err := cluster.ListToolchainClusterConfigs(cl, m1.Namespace, time.Second)
+		clusterConfigs, err := cluster.ListToolchainClusterConfigs(context.TODO(), cl, m1.Namespace, time.Second)
 
 		// then
 		require.Error(t, err)

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -19,18 +19,20 @@ const (
 
 // ToolchainClusterAttributes required attributes for obtaining ToolchainCluster status
 type ToolchainClusterAttributes struct {
-	GetClusterFunc func() (*cluster.CachedToolchainCluster, bool)
-	Period         time.Duration
-	Timeout        time.Duration
+	GetClustersFunc cluster.GetClustersFunc
+	Period          time.Duration
+	Timeout         time.Duration
 }
 
 // GetToolchainClusterConditions uses the provided ToolchainCluster attributes to determine status conditions
 func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAttributes) []toolchainv1alpha1.Condition {
 	// look up cluster connection status
-	toolchainCluster, ok := attrs.GetClusterFunc()
-	if !ok {
+	toolchainClusters := attrs.GetClustersFunc()
+
+	if len(toolchainClusters) != 1 {
 		return []toolchainv1alpha1.Condition{*NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotFoundReason, ErrMsgClusterConnectionNotFound)}
 	}
+	toolchainCluster := toolchainClusters[0]
 
 	// check conditions of cluster connection
 	if !cluster.IsReady(toolchainCluster.ClusterStatus) {

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -19,20 +19,19 @@ const (
 
 // ToolchainClusterAttributes required attributes for obtaining ToolchainCluster status
 type ToolchainClusterAttributes struct {
-	GetClustersFunc cluster.GetClustersFunc
-	Period          time.Duration
-	Timeout         time.Duration
+	GetClusterFunc func() (*cluster.CachedToolchainCluster, bool)
+	Period         time.Duration
+	Timeout        time.Duration
 }
 
 // GetToolchainClusterConditions uses the provided ToolchainCluster attributes to determine status conditions
 func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAttributes) []toolchainv1alpha1.Condition {
 	// look up cluster connection status
-	toolchainClusters := attrs.GetClustersFunc()
+	toolchainCluster, ok := attrs.GetClusterFunc()
 
-	if len(toolchainClusters) != 1 {
+	if !ok {
 		return []toolchainv1alpha1.Condition{*NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotFoundReason, ErrMsgClusterConnectionNotFound)}
 	}
-	toolchainCluster := toolchainClusters[0]
 
 	// check conditions of cluster connection
 	if !cluster.IsReady(toolchainCluster.ClusterStatus) {

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -27,9 +27,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 		t.Run("condition ready", func(t *testing.T) {
 			// given
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterReady(),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterReady(),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -51,9 +51,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 			// given
 			msg := "the cluster connection was not found"
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterNotOk(),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterNotOk(),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -75,9 +75,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 		t.Run("condition cluster ok but not ready", func(t *testing.T) {
 			// given
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterOkButNotReady(fakeToolchainClusterMsg),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterOkButNotReady(fakeToolchainClusterMsg),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -100,9 +100,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 			// given
 			msg := "the cluster connection is not ready"
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterOkButNotReady(""),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterOkButNotReady(""),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -125,9 +125,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 			// given
 			msg := "the cluster connection is not ready"
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterOkWithClusterOfflineCondition(),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterOkWithClusterOfflineCondition(),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -150,9 +150,9 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 			// given
 			msg := "exceeded the maximum duration since the last probe: 13s"
 			readyAttrs := ToolchainClusterAttributes{
-				GetClusterFunc: newGetHostClusterLastProbeTimeExceeded(),
-				Period:         10 * time.Second,
-				Timeout:        3 * time.Second,
+				GetClustersFunc: newGetHostClusterLastProbeTimeExceeded(),
+				Period:          10 * time.Second,
+				Timeout:         3 * time.Second,
 			}
 			expected := toolchainv1alpha1.Condition{
 				Type:    toolchainv1alpha1.ConditionReady,
@@ -173,23 +173,23 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 	})
 }
 
-func newGetHostClusterReady() cluster.GetHostClusterFunc {
+func newGetHostClusterReady() cluster.GetClustersFunc {
 	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, metav1.Now(), fakeToolchainClusterReason, "")
 }
 
-func newGetHostClusterNotOk() cluster.GetHostClusterFunc {
+func newGetHostClusterNotOk() cluster.GetClustersFunc {
 	return NewFakeGetHostCluster(false, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, metav1.Now(), fakeToolchainClusterReason, fakeToolchainClusterMsg)
 }
 
-func newGetHostClusterOkButNotReady(message string) cluster.GetHostClusterFunc {
+func newGetHostClusterOkButNotReady(message string) cluster.GetClustersFunc {
 	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, metav1.Now(), fakeToolchainClusterReason, message)
 }
 
-func newGetHostClusterOkWithClusterOfflineCondition() cluster.GetHostClusterFunc {
+func newGetHostClusterOkWithClusterOfflineCondition() cluster.GetClustersFunc {
 	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterOffline, corev1.ConditionFalse, metav1.Now(), fakeToolchainClusterReason, fakeToolchainClusterMsg)
 }
 
-func newGetHostClusterLastProbeTimeExceeded() cluster.GetHostClusterFunc {
+func newGetHostClusterLastProbeTimeExceeded() cluster.GetClustersFunc {
 	tenMinsAgo := metav1.Now().Add(time.Duration(-10) * time.Minute)
 	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, metav1.NewTime(tenMinsAgo), fakeToolchainClusterReason, fakeToolchainClusterMsg)
 }
@@ -197,13 +197,14 @@ func newGetHostClusterLastProbeTimeExceeded() cluster.GetHostClusterFunc {
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status and lastProbeTime.
 // If ok == false, then the function returns nil for the cluster.
-func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClusterConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string) cluster.GetHostClusterFunc {
+func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClusterConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string) cluster.GetClustersFunc {
 	if !ok {
-		return func() (*cluster.CachedToolchainCluster, bool) {
-			return nil, false
+		return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
+			return nil
 		}
 	}
-	return func() (*cluster.CachedToolchainCluster, bool) {
+
+	return func(conditions ...cluster.Condition) []*cluster.CachedToolchainCluster {
 		toolchainClusterValue := &cluster.CachedToolchainCluster{
 			Config: &cluster.Config{
 				OperatorNamespace: test.HostOperatorNs,
@@ -222,6 +223,6 @@ func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClu
 			toolchainClusterValue.ClusterStatus.Conditions[0].Message = message
 		}
 
-		return toolchainClusterValue, true
+		return []*cluster.CachedToolchainCluster{toolchainClusterValue}
 	}
 }


### PR DESCRIPTION
This is a Follow-up PR for #359,

- Adding a new common function `GetClusters()` to fetch the clusters from cache as we have dropped the cluster type
- Updated the related function to use the common func instead of `GetHostCluster()` and `GetMemberClusters()`
- Updated the unit test cases as per the given change
- Keeping the `GetHostCluster()` and `GetMemberClusters()` for now and delete them once their dependencies are removed in host, member, registration-service .
- The PRs in other repos which will use this GetCluster() and their paired e2e PRs 
     - Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/990
          - Paired e2e for host Toolchain-E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/921
     - Registration Service - https://github.com/codeready-toolchain/registration-service/pull/413
          - Paired e2e for host Toolchain-E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/922
     - Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/543
          - Paired e2e for host Toolchain-E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/923