### PR TITLE
Make NSTemplateTier generator generic

### DIFF
--- a/controllers/label_event_handler_test.go
+++ b/controllers/label_event_handler_test.go
@@ -121,7 +121,7 @@ func TestMapToControllerByMatchingLabel(t *testing.T) {
 	t.Run("resource without labels", func(t *testing.T) {
 		// given
 		objMeta := metav1.ObjectMeta{
-			Name: "bar",
+			Name:   "bar",
 			Labels: nil,
 		}
 		obj := corev1.Namespace{

--- a/go.mod
+++ b/go.mod
@@ -26,10 +26,12 @@ require (
 )
 
 require (
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-github/v52 v52.0.0
 	github.com/migueleliasweb/go-github-mock v0.0.18
 	golang.org/x/oauth2 v0.7.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 )
 
@@ -101,7 +103,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
 	k8s.io/component-base v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,7 @@ github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmV
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator.go
@@ -2,7 +2,6 @@ package nstemplatetiers
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 
@@ -145,9 +144,6 @@ func loadTemplatesByTiers(metadata map[string]string, files map[string][]byte) (
 
 	results := make(map[string]*tierData)
 	for name, content := range files {
-		if name == "metadata.yaml" {
-			continue
-		}
 		// split the name using the `/` separator
 		parts := strings.Split(name, "/")
 		// skip any name that does not have 2 parts
@@ -352,7 +348,7 @@ func (t *TierGenerator) initNSTemplateTiers() error {
 			nsTemplateTier = fromData.rawTemplates.nsTemplateTier
 			sourceTierName = fromData.name
 		}
-		objs, err := t.newNSTemplateTier(sourceTierName, tierName, *nsTemplateTier, tierTemplates, parameters)
+		objs, err := t.newNSTemplateTier(sourceTierName, tierName, nsTemplateTier, tierTemplates, parameters)
 		if err != nil {
 			return err
 		}
@@ -431,9 +427,9 @@ func (t *TierGenerator) createNSTemplateTiers() error {
 //	      templateRef: appstudio-admin-ab12cd34-ab12cd34
 //
 // ------
-func (t *TierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]runtimeclient.Object, error) {
+func (t *TierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier *template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]runtimeclient.Object, error) {
 	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
-	if reflect.DeepEqual(nsTemplateTier, template{}) {
+	if nsTemplateTier == nil {
 		return nil, fmt.Errorf("tier %s is missing a tier.yaml file", tierName)
 	}
 

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator.go
@@ -1,0 +1,470 @@
+package nstemplatetiers
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	commonTemplate "github.com/codeready-toolchain/toolchain-common/pkg/template"
+	templatev1 "github.com/openshift/api/template/v1"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var log = logf.Log.WithName("templates")
+
+type EnsureObject func(toEnsure runtimeclient.Object, canUpdate bool) (bool, error)
+
+type TierGenerator struct {
+	ensureObject    EnsureObject
+	namespace       string
+	scheme          *runtime.Scheme
+	templatesByTier map[string]*tierData
+}
+
+type tierData struct {
+	name          string
+	rawTemplates  *templates
+	tierTemplates []*toolchainv1alpha1.TierTemplate
+	objects       []runtimeclient.Object
+	basedOnTier   *BasedOnTier
+}
+
+// templates: namespaces and other cluster-scoped resources belonging to a given tier ("advanced", "base", "team", etc.) and the NSTemplateTier that combines them
+type templates struct {
+	nsTemplateTier     *template           // NSTemplateTier resource with tier-scoped configuration and references to namespace and cluster templates in its spec, in a single template file
+	clusterTemplate    *template           // other cluster-scoped resources, in a single template file
+	namespaceTemplates map[string]template // namespace templates (including roles, limits, etc.) indexed by type ("dev", "stage")
+	spaceroleTemplates map[string]template // spacerole templates (including rolebindings, etc.) indexed by role ("admin", "viewer", etc.)
+	basedOnTier        *template           // a special config defining which tier should be reused and which parameters should be overridden
+}
+
+// template: a template's content and its latest git revision
+type template struct {
+	revision string
+	content  []byte
+}
+
+// GenerateTiers processes the given metadata and files, generates TierTemplates and NSTemplateTiers, and ensures them via the provided EnsureObject function
+func GenerateTiers(s *runtime.Scheme, ensureObject EnsureObject, namespace string, metadata map[string]string, files map[string][]byte) error {
+	generator, err := newNSTemplateTierGenerator(s, ensureObject, namespace, metadata, files)
+	if err != nil {
+		return errors.Wrap(err, "unable to init NSTemplateTier generator")
+	}
+
+	// create the TierTemplate resources
+	err = generator.createTierTemplates()
+	if err != nil {
+		return errors.Wrap(err, "unable to create TierTemplates")
+	}
+
+	// create the NSTemplateTier resources
+	err = generator.createNSTemplateTiers()
+	if err != nil {
+		return errors.Wrap(err, "unable to create NSTemplateTiers")
+	}
+	return nil
+}
+
+// newNSTemplateTierGenerator loads templates from the provided assets and processes the tierTemplates and NSTemplateTiers
+func newNSTemplateTierGenerator(s *runtime.Scheme, ensureObject EnsureObject, namespace string, metadata map[string]string, files map[string][]byte) (*TierGenerator, error) {
+
+	templatesByTier, err := loadTemplatesByTiers(metadata, files)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &TierGenerator{
+		ensureObject:    ensureObject,
+		namespace:       namespace,
+		scheme:          s,
+		templatesByTier: templatesByTier,
+	}
+
+	// process tierTemplates
+	if err := c.initTierTemplates(); err != nil {
+		return nil, err
+	}
+
+	// process NSTemplateTiers
+	if err := c.initNSTemplateTiers(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// BasedOnTier defines which tier is supposed to be reused and which parameters should be modified
+// An example:
+//
+// from: base
+// parameters:
+//   - name: IDLER_TIMEOUT_SECONDS
+//     value: 43200
+//
+// Which defines that for creating baseextendedidling tier the base tier should be used and
+// the parameter IDLER_TIMEOUT_SECONDS should be set to 43200
+type BasedOnTier struct {
+	Revision   string
+	From       string                 `json:"from"`
+	Parameters []templatev1.Parameter `json:"parameters,omitempty" protobuf:"bytes,4,rep,name=parameters"`
+}
+
+// loadTemplatesByTiers loads the files and dispatches them by tiers, assuming the given files has the following structure:
+//
+// advanced/
+//
+//	based_on_tier.yaml
+//
+// base1ns/
+//
+//	cluster.yaml
+//	ns_dev.yaml
+//	ns_stage.yaml
+//	spacerole_admin.yaml
+//	tier.yaml
+//
+// team/
+//
+//	based_on_tier.yaml
+//
+// The output is a map of `tierData` indexed by tier.
+// Each `tierData` object contains itself a map of `template` objects indexed by the namespace type (`namespaceTemplates`);
+// an optional `template` for the cluster resources (`clusterTemplate`) and the NSTemplateTier resource object.
+// Each `template` object contains a `revision` (`string`) and the `content` of the template to apply (`[]byte`)
+func loadTemplatesByTiers(metadata map[string]string, files map[string][]byte) (map[string]*tierData, error) {
+
+	results := make(map[string]*tierData)
+	for name, content := range files {
+		if name == "metadata.yaml" {
+			continue
+		}
+		// split the name using the `/` separator
+		parts := strings.Split(name, "/")
+		// skip any name that does not have 2 parts
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("unable to load templates: invalid name format for file '%s'", name)
+		}
+		tier := parts[0]
+		filename := parts[1]
+		if _, exists := results[tier]; !exists {
+			results[tier] = &tierData{
+				name: tier,
+				rawTemplates: &templates{
+					namespaceTemplates: map[string]template{},
+					spaceroleTemplates: map[string]template{},
+				},
+			}
+		}
+
+		tmpl := template{
+			revision: metadata[strings.TrimSuffix(name, ".yaml")],
+			content:  content,
+		}
+		switch {
+		case filename == "tier.yaml":
+			results[tier].rawTemplates.nsTemplateTier = &tmpl
+		case filename == "cluster.yaml":
+			results[tier].rawTemplates.clusterTemplate = &tmpl
+		case strings.HasPrefix(filename, "ns_"):
+			kind := strings.TrimSuffix(strings.TrimPrefix(filename, "ns_"), ".yaml")
+			results[tier].rawTemplates.namespaceTemplates[kind] = tmpl
+		case strings.HasPrefix(filename, "spacerole_"):
+			role := strings.TrimSuffix(strings.TrimPrefix(filename, "spacerole_"), ".yaml")
+			results[tier].rawTemplates.spaceroleTemplates[role] = tmpl
+		case filename == "based_on_tier.yaml":
+			basedOnTier := &BasedOnTier{}
+			if err := yaml.Unmarshal(content, basedOnTier); err != nil {
+				return nil, errors.Wrapf(err, "unable to unmarshal '%s'", name)
+			}
+			results[tier].rawTemplates.basedOnTier = &tmpl
+			results[tier].basedOnTier = basedOnTier
+		default:
+			return nil, errors.Errorf("unable to load templates: unknown scope for file '%s'", name)
+		}
+	}
+
+	// check that none of the tiers uses combination of based_on_tier.yaml file together with any template file
+	for tier, tierData := range results {
+		if tierData.rawTemplates.basedOnTier != nil &&
+			(tierData.rawTemplates.clusterTemplate != nil ||
+				len(tierData.rawTemplates.namespaceTemplates) > 0 ||
+				tierData.rawTemplates.nsTemplateTier != nil) {
+			return nil, fmt.Errorf("the tier %s contains a mix of based_on_tier.yaml file together with a regular template file", tier)
+		}
+	}
+	return results, nil
+}
+
+// initTierTemplates generates all TierTemplate resources, and adds them to the tier map indexed by tier name
+func (t *TierGenerator) initTierTemplates() error {
+
+	// process tiers in alphabetical order
+	tiers := make([]string, 0, len(t.templatesByTier))
+	for tier := range t.templatesByTier {
+		tiers = append(tiers, tier)
+	}
+	sort.Strings(tiers)
+	for _, tier := range tiers {
+		tierData := t.templatesByTier[tier]
+		basedOnTierFileRevision := ""
+		var parameters []templatev1.Parameter
+		if tierData.basedOnTier != nil {
+			parameters = tierData.basedOnTier.Parameters
+			basedOnTierFileRevision = tierData.rawTemplates.basedOnTier.revision
+			tierData = t.templatesByTier[tierData.basedOnTier.From]
+		}
+		tierTemplates, err := t.newTierTemplates(basedOnTierFileRevision, tierData, tier, parameters)
+		if err != nil {
+			return err
+		}
+		t.templatesByTier[tier].tierTemplates = tierTemplates
+	}
+
+	return nil
+}
+
+func (t *TierGenerator) newTierTemplates(basedOnTierFileRevision string, tierData *tierData, tier string, parameters []templatev1.Parameter) ([]*toolchainv1alpha1.TierTemplate, error) {
+	decoder := serializer.NewCodecFactory(t.scheme).UniversalDeserializer()
+
+	// namespace templates
+	kinds := make([]string, 0, len(tierData.rawTemplates.namespaceTemplates))
+	for kind := range tierData.rawTemplates.namespaceTemplates {
+		kinds = append(kinds, kind)
+	}
+	tierTmpls := []*toolchainv1alpha1.TierTemplate{}
+	sort.Strings(kinds)
+	for _, kind := range kinds {
+		tmpl := tierData.rawTemplates.namespaceTemplates[kind]
+		tierTmpl, err := t.newTierTemplate(decoder, basedOnTierFileRevision, tier, kind, tmpl, parameters)
+		if err != nil {
+			return nil, err
+		}
+		tierTmpls = append(tierTmpls, tierTmpl)
+	}
+	// space roles templates
+	roles := make([]string, 0, len(tierData.rawTemplates.spaceroleTemplates))
+	for role := range tierData.rawTemplates.spaceroleTemplates {
+		roles = append(roles, role)
+	}
+	sort.Strings(roles)
+	for _, role := range roles {
+		tmpl := tierData.rawTemplates.spaceroleTemplates[role]
+		tierTmpl, err := t.newTierTemplate(decoder, basedOnTierFileRevision, tier, role, tmpl, parameters)
+		if err != nil {
+			return nil, err
+		}
+		tierTmpls = append(tierTmpls, tierTmpl)
+	}
+	// cluster resources templates
+	if tierData.rawTemplates.clusterTemplate != nil {
+		tierTmpl, err := t.newTierTemplate(decoder, basedOnTierFileRevision, tier, toolchainv1alpha1.ClusterResourcesTemplateType, *tierData.rawTemplates.clusterTemplate, parameters)
+		if err != nil {
+			return nil, err
+		}
+		tierTmpls = append(tierTmpls, tierTmpl)
+	}
+	return tierTmpls, nil
+}
+
+// createTierTemplates creates all TierTemplate resources from the tier map
+func (t *TierGenerator) createTierTemplates() error {
+	// create the templates
+	for _, tierTmpls := range t.templatesByTier {
+		for _, tierTmpl := range tierTmpls.tierTemplates {
+			log.Info("creating TierTemplate", "namespace", tierTmpl.Namespace, "name", tierTmpl.Name)
+			// using the "standard" client since we don't need to support updates on such resources, they should be immutable
+			if _, err := t.ensureObject(tierTmpl, false); err != nil {
+				return errors.Wrapf(err, "unable to create the '%s' TierTemplate in namespace '%s'", tierTmpl.Name, tierTmpl.Namespace)
+			}
+			log.Info("TierTemplate resource created", "namespace", tierTmpl.Namespace, "name", tierTmpl.Name)
+		}
+	}
+	return nil
+}
+
+// newTierTemplate generates a TierTemplate resource for a given tier and kind
+func (t *TierGenerator) newTierTemplate(decoder runtime.Decoder, basedOnTierFileRevision, tier, kind string, tmpl template, parameters []templatev1.Parameter) (*toolchainv1alpha1.TierTemplate, error) {
+	if basedOnTierFileRevision == "" {
+		basedOnTierFileRevision = tmpl.revision
+	}
+	revision := fmt.Sprintf("%s-%s", basedOnTierFileRevision, tmpl.revision)
+	name := newTierTemplateName(tier, kind, revision)
+	tmplObj := &templatev1.Template{}
+	_, _, err := decoder.Decode(tmpl.content, nil, tmplObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to generate '%s' TierTemplate manifest", name)
+	}
+	setParams(parameters, tmplObj)
+
+	return &toolchainv1alpha1.TierTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: t.namespace,
+			Name:      name, // link to the TierTemplate resource, whose name is: `<tierName>-<nsType>-<revision>`,
+		},
+		Spec: toolchainv1alpha1.TierTemplateSpec{
+			Revision: revision,
+			TierName: tier,
+			Type:     kind,
+			Template: *tmplObj,
+		},
+	}, nil
+}
+
+// setParams sets the value for each of the keys in the given parameter set to the template, but only if the key exists there
+func setParams(parametersToSet []templatev1.Parameter, tmpl *templatev1.Template) {
+	for _, paramToSet := range parametersToSet {
+		for i, param := range tmpl.Parameters {
+			if param.Name == paramToSet.Name {
+				tmpl.Parameters[i].Value = paramToSet.Value
+				break
+			}
+		}
+	}
+}
+
+// newTierTemplateName a utility func to generate a TierTemplate name, based on the given tier, kind and revision.
+// note: the resource name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
+func newTierTemplateName(tier, kind, revision string) string {
+	return strings.ToLower(fmt.Sprintf("%s-%s-%s", tier, kind, revision))
+}
+
+// newNSTemplateTiers generates all NSTemplateTier resources and adds them to the tier map
+func (t *TierGenerator) initNSTemplateTiers() error {
+
+	for tierName, tierData := range t.templatesByTier {
+		nsTemplateTier := tierData.rawTemplates.nsTemplateTier
+		tierTemplates := tierData.tierTemplates
+		sourceTierName := tierName
+		var parameters []templatev1.Parameter
+		if tierData.basedOnTier != nil {
+			parameters = tierData.basedOnTier.Parameters
+			fromData := t.templatesByTier[tierData.basedOnTier.From]
+			nsTemplateTier = fromData.rawTemplates.nsTemplateTier
+			sourceTierName = fromData.name
+		}
+		objs, err := t.newNSTemplateTier(sourceTierName, tierName, *nsTemplateTier, tierTemplates, parameters)
+		if err != nil {
+			return err
+		}
+		t.templatesByTier[tierName].objects = objs
+	}
+
+	return nil
+}
+
+// createNSTemplateTiers creates the NSTemplateTier resources from the tier map
+func (t *TierGenerator) createNSTemplateTiers() error {
+
+	for tierName, tierData := range t.templatesByTier {
+		if len(tierData.objects) != 1 {
+			return fmt.Errorf("there is an unexpected number of NSTemplateTier object to be applied for tier name '%s'; expected: 1; actual: %d", tierName, len(tierData.objects))
+		}
+
+		unstructuredObj, ok := tierData.objects[0].(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("unable to cast NSTemplateTier '%s' to Unstructured object '%+v'", tierName, tierData.objects[0])
+		}
+		tier := &toolchainv1alpha1.NSTemplateTier{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(unstructuredObj.Object, tier); err != nil {
+			return err
+		}
+
+		labels := tier.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels[toolchainv1alpha1.ProviderLabelKey] = toolchainv1alpha1.ProviderLabelValue
+		updated, err := t.ensureObject(tier, true)
+		if err != nil {
+			return errors.Wrapf(err, "unable to create or update the '%s' NSTemplateTier", tierName)
+		}
+		tierLog := log.WithValues("name", tierName)
+		if tier.Spec.ClusterResources != nil {
+			tierLog = tierLog.WithValues("clusterResourcesTemplate", tier.Spec.ClusterResources.TemplateRef)
+		}
+		for i, nsTemplate := range tier.Spec.Namespaces {
+			tierLog = tierLog.WithValues(fmt.Sprintf("namespaceTemplate-%d", i), nsTemplate.TemplateRef)
+		}
+		for role, nsTemplate := range tier.Spec.SpaceRoles {
+			tierLog = tierLog.WithValues(fmt.Sprintf("spaceRoleTemplate-%s", role), nsTemplate.TemplateRef)
+		}
+		if updated {
+			tierLog.Info("NSTemplateTier was either updated or created")
+		} else {
+			tierLog.Info("NSTemplateTier wasn't updated nor created: the spec was already set as expected")
+		}
+	}
+	return nil
+}
+
+// NewNSTemplateTier generates a complete NSTemplateTier object via Openshift Template based on the contents of tier.yaml and
+// by embedding the `<tier>-code.yaml`, `<tier>-dev.yaml` and `<tier>-stage.yaml` and cluster.yaml references.
+//
+// After processing the Openshift Template the NSTemplateTier should look something like:
+// ------
+// kind: NSTemplateTier
+//
+//	metadata:
+//	  name: appstudio
+//	spec:
+//	  deactivationTimeoutDays: 30
+//	  clusterResources:
+//	    templateRef: appstudio-clusterresources-07cac69-07cac69
+//	  namespaces:
+//	  - templateRef: appstudio-code-cb6fbd2-cb6fbd2
+//	  - templateRef: appstudio-dev-4d49fe0-4d49fe0
+//	  - templateRef: appstudio-stage-4d49fe0-4d49fe0
+//	  spaceRoles:
+//	    admin:
+//	      templateRef: appstudio-admin-ab12cd34-ab12cd34
+//	    viewer:
+//	      templateRef: appstudio-admin-ab12cd34-ab12cd34
+//
+// ------
+func (t *TierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTemplateTier template, tierTemplates []*toolchainv1alpha1.TierTemplate, parameters []templatev1.Parameter) ([]runtimeclient.Object, error) {
+	decoder := serializer.NewCodecFactory(scheme.Scheme).UniversalDeserializer()
+	if reflect.DeepEqual(nsTemplateTier, template{}) {
+		return nil, fmt.Errorf("tier %s is missing a tier.yaml file", tierName)
+	}
+
+	tmplObj := &templatev1.Template{}
+	_, _, err := decoder.Decode(nsTemplateTier.content, nil, tmplObj)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to generate '%s' NSTemplateTier manifest", tierName)
+	}
+
+	tmplProcessor := commonTemplate.NewProcessor(t.scheme)
+	params := map[string]string{"NAMESPACE": t.namespace}
+
+	for _, tierTmpl := range tierTemplates {
+		switch tierTmpl.Spec.Type {
+		// ClusterResources
+		case toolchainv1alpha1.ClusterResourcesTemplateType:
+			params["CLUSTER_TEMPL_REF"] = tierTmpl.Name
+		// Namespaces and Space Roles
+		default:
+			tmplType := strings.ToUpper(tierTmpl.Spec.Type) // code, dev, stage
+			key := tmplType + "_TEMPL_REF"                  // eg. CODE_TEMPL_REF
+			params[key] = tierTmpl.Name
+		}
+	}
+	setParams(parameters, tmplObj)
+	toolchainObjects, err := tmplProcessor.Process(tmplObj.DeepCopy(), params)
+	if err != nil {
+		return nil, err
+	}
+	for i := range toolchainObjects {
+		toolchainObjects[i].SetName(strings.Replace(toolchainObjects[i].GetName(), sourceTierName, tierName, 1))
+	}
+	return toolchainObjects, nil
+}

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -121,7 +121,10 @@ func basedOnOtherTier(expectedTiers map[string]bool, tier string) bool {
 
 func getTestTemplates(t *testing.T) map[string][]byte {
 	templates := map[string][]byte{}
-	err := fs.WalkDir(testTemplateFiles, ".", func(path string, d fs.DirEntry, _ error) error {
+	err := fs.WalkDir(testTemplateFiles, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if d.IsDir() {
 			return nil
 		}

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -469,12 +469,12 @@ func TestGenerateTiers(t *testing.T) {
 				// given
 				clt := test.NewFakeClient(t)
 				testTemplates := getTestTemplates(t)
-				delete(testTemplates, "base/tier.yaml")
+				delete(testTemplates, "appstudio/tier.yaml")
 
 				// when
 				err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), testTemplates)
 				// then
-				require.EqualError(t, err, "unable to init NSTemplateTier generator: tier base is missing a tier.yaml file")
+				require.EqualError(t, err, "unable to init NSTemplateTier generator: tier appstudio is missing a tier.yaml file")
 			})
 
 			t.Run("failed to update nstemplatetiers", func(t *testing.T) {
@@ -501,9 +501,6 @@ func TestGenerateTiers(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
 			})
-		})
-
-		t.Run("tiertemplates", func(t *testing.T) {
 
 			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
 				// given

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -1,0 +1,954 @@
+package nstemplatetiers
+
+import (
+	"bytes"
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"testing"
+	texttemplate "text/template"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	commonclient "github.com/codeready-toolchain/toolchain-common/pkg/client"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ghodss/yaml"
+	"github.com/gofrs/uuid"
+	templatev1 "github.com/openshift/api/template/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+//go:embed testdata/nstemplatetiers*
+var testTemplateFiles embed.FS
+
+var expectedTestTiers = map[string]bool{
+	"advanced":  true, // tier_name: true/false (if based on the other tier)
+	"base":      false,
+	"nocluster": false,
+	"appstudio": false,
+}
+
+func getTestMetadata() map[string]string {
+	return map[string]string{
+		"advanced/based_on_tier":          "abcd123",
+		"base/tier":                       "123456z",
+		"base/cluster":                    "654321a",
+		"base/ns_dev":                     "123456b",
+		"base/ns_stage":                   "123456c",
+		"base/spacerole_admin":            "123456d",
+		"nocluster/tier":                  "1234567y",
+		"nocluster/ns_dev":                "123456j",
+		"nocluster/ns_stage":              "1234567", // here, a number string
+		"nocluster/spacerole_admin":       "123456k",
+		"appstudio/tier":                  "123456z",
+		"appstudio/cluster":               "654321a",
+		"appstudio/ns_tenant":             "123456b",
+		"appstudio/spacerole_admin":       "123456c",
+		"appstudio/spacerole_maintainer":  "123456d",
+		"appstudio/spacerole_contributor": "123456e",
+	}
+}
+
+func nsTypes(tier string) []string {
+	switch tier {
+	case "appstudio":
+		return []string{"tenant"}
+	case "appstudio-env":
+		return []string{"env"}
+	case "base1ns", "base1nsnoidling", "base1ns6didler", "test":
+		return []string{"dev"}
+	default:
+		return []string{"dev", "stage"}
+	}
+}
+
+func roles(tier string) []string {
+	switch tier {
+	case "appstudio", "appstudio-env":
+		return []string{"admin", "maintainer", "contributor"}
+	default:
+		return []string{"admin"}
+	}
+}
+
+func isNamespaceType(expectedTiers map[string]bool, typeName string) bool {
+	for _, tier := range tiers(expectedTiers) {
+		for _, t := range nsTypes(tier) {
+			if t == typeName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isSpaceRole(expectedTiers map[string]bool, roleName string) bool {
+	for _, tier := range tiers(expectedTiers) {
+		for _, r := range roles(tier) {
+			if r == roleName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func tiers(expectedTiers map[string]bool) []string {
+	tt := make([]string, 0, len(expectedTiers))
+	for tier := range expectedTiers {
+		tt = append(tt, tier)
+	}
+	return tt
+}
+
+func basedOnOtherTier(expectedTiers map[string]bool, tier string) bool {
+	return expectedTiers[tier]
+}
+
+func getTestTemplates(t *testing.T) map[string][]byte {
+	templates := map[string][]byte{}
+	err := fs.WalkDir(testTemplateFiles, ".", func(path string, d fs.DirEntry, _ error) error {
+		if d.IsDir() {
+			return nil
+		}
+		file, err := testTemplateFiles.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		templates[filepath.Join(filepath.Base(filepath.Dir(path)), d.Name())] = file
+		return nil
+	})
+	require.NoError(t, err)
+	return templates
+}
+
+func TestGenerateTiers(t *testing.T) {
+
+	s := addToScheme(t)
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	t.Run("ok", func(t *testing.T) {
+
+		expectedTemplateRefs := map[string]map[string]interface{}{
+			"advanced": {
+				"clusterresources": "advanced-clusterresources-abcd123-654321a",
+				"namespaces": []string{
+					"advanced-dev-abcd123-123456b",
+					"advanced-stage-abcd123-123456c",
+				},
+				"spaceRoles": map[string]string{
+					"admin": "advanced-admin-abcd123-123456d",
+				},
+			},
+			"base": {
+				"clusterresources": "base-clusterresources-654321a-654321a",
+				"namespaces": []string{
+					"base-dev-123456b-123456b",
+					"base-stage-123456c-123456c",
+				},
+				"spaceRoles": map[string]string{
+					"admin": "base-admin-123456d-123456d",
+				},
+			},
+			"nocluster": {
+				"namespaces": []string{
+					"nocluster-dev-123456j-123456j",
+					"nocluster-stage-1234567-1234567",
+				},
+				"spaceRoles": map[string]string{
+					"admin": "nocluster-admin-123456k-123456k",
+				},
+			},
+			"appstudio": {
+				"clusterresources": "appstudio-clusterresources-654321a-654321a",
+				"namespaces": []string{
+					"appstudio-tenant-123456b-123456b",
+				},
+				"spaceRoles": map[string]string{
+					"admin":       "appstudio-admin-123456c-123456c",
+					"maintainer":  "appstudio-maintainer-123456d-123456d",
+					"contributor": "appstudio-contributor-123456e-123456e",
+				},
+			},
+		}
+
+		t.Run("create only", func(t *testing.T) {
+			// given
+			namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
+			clt := test.NewFakeClient(t)
+			// verify that no NSTemplateTier resources exist prior to creation
+			nsTmplTiers := toolchainv1alpha1.NSTemplateTierList{}
+			err := clt.List(context.TODO(), &nsTmplTiers, runtimeclient.InNamespace(namespace))
+			require.NoError(t, err)
+			require.Empty(t, nsTmplTiers.Items)
+			// verify that no TierTemplate resources exist prior to creation
+			tierTmpls := toolchainv1alpha1.TierTemplateList{}
+			err = clt.List(context.TODO(), &tierTmpls, runtimeclient.InNamespace(namespace))
+			require.NoError(t, err)
+			require.Empty(t, tierTmpls.Items)
+
+			// when
+			err = GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+
+			// then
+			require.NoError(t, err)
+
+			// verify that TierTemplates were created
+			tierTmpls = toolchainv1alpha1.TierTemplateList{}
+			err = clt.List(context.TODO(), &tierTmpls, runtimeclient.InNamespace(namespace))
+			require.NoError(t, err)
+			require.Len(t, tierTmpls.Items, 16) // 4 items for advanced and base tiers + 3 for nocluster tier + 5 for appstudio
+			names := []string{}
+			for _, tierTmpl := range tierTmpls.Items {
+				names = append(names, tierTmpl.Name)
+			}
+			require.ElementsMatch(t, []string{
+				"advanced-clusterresources-abcd123-654321a",
+				"advanced-dev-abcd123-123456b",
+				"advanced-stage-abcd123-123456c",
+				"advanced-admin-abcd123-123456d",
+				"base-clusterresources-654321a-654321a",
+				"base-dev-123456b-123456b",
+				"base-stage-123456c-123456c",
+				"base-admin-123456d-123456d",
+				"nocluster-dev-123456j-123456j",
+				"nocluster-stage-1234567-1234567",
+				"nocluster-admin-123456k-123456k",
+				"appstudio-clusterresources-654321a-654321a",
+				"appstudio-tenant-123456b-123456b",
+				"appstudio-admin-123456c-123456c",
+				"appstudio-maintainer-123456d-123456d",
+				"appstudio-contributor-123456e-123456e",
+			}, names)
+
+			// verify that 4 NSTemplateTier CRs were created:
+			for _, tierName := range []string{"advanced", "base", "nocluster", "appstudio"} {
+				tier := toolchainv1alpha1.NSTemplateTier{}
+				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), tier.ObjectMeta.Generation)
+
+				// check the `clusterresources` templateRef
+				if tier.Name == "nocluster" {
+					assert.Nil(t, tier.Spec.ClusterResources) // "nocluster" tier should not have cluster resources set
+				} else {
+					require.NotNil(t, tier.Spec.ClusterResources)
+					assert.Equal(t, expectedTemplateRefs[tierName]["clusterresources"], tier.Spec.ClusterResources.TemplateRef)
+				}
+
+				// check the `namespaces` templateRefs
+				actualNamespaceTmplRefs := make([]string, len(tier.Spec.Namespaces))
+				for i, ns := range tier.Spec.Namespaces {
+					actualNamespaceTmplRefs[i] = ns.TemplateRef
+				}
+				assert.ElementsMatch(t, expectedTemplateRefs[tierName]["namespaces"], actualNamespaceTmplRefs)
+
+				// check the `spaceRoles` templateRefs
+				actualSpaceRoleTmplRefs := make(map[string]string, len(tier.Spec.SpaceRoles))
+				for i, r := range tier.Spec.SpaceRoles {
+					actualSpaceRoleTmplRefs[i] = r.TemplateRef
+				}
+				for role, tmpl := range expectedTemplateRefs[tierName]["spaceRoles"].(map[string]string) {
+					assert.Equal(t, tmpl, actualSpaceRoleTmplRefs[role])
+				}
+			}
+		})
+
+		t.Run("create then update with same tier templates", func(t *testing.T) {
+			// given
+			namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
+			clt := test.NewFakeClient(t)
+
+			// when
+			err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+			require.NoError(t, err)
+
+			// when calling CreateOrUpdateResources a second time
+			err = GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+
+			// then
+			require.NoError(t, err)
+			// verify that all TierTemplate CRs were updated
+			tierTmpls := toolchainv1alpha1.TierTemplateList{}
+			err = clt.List(context.TODO(), &tierTmpls, runtimeclient.InNamespace(namespace))
+			require.NoError(t, err)
+			require.Len(t, tierTmpls.Items, 16) // 4 items for advanced and base tiers + 3 for nocluster tier + 4 for appstudio
+			for _, tierTmpl := range tierTmpls.Items {
+				assert.Equal(t, int64(1), tierTmpl.ObjectMeta.Generation) // unchanged
+			}
+
+			// verify that 4 NSTemplateTier CRs were created:
+			for _, tierName := range []string{"advanced", "base", "nocluster", "appstudio"} {
+				tier := toolchainv1alpha1.NSTemplateTier{}
+				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
+				require.NoError(t, err)
+				assert.Equal(t, int64(1), tier.ObjectMeta.Generation)
+
+				// check the `clusterresources` templateRef
+				if tier.Name == "nocluster" {
+					assert.Nil(t, tier.Spec.ClusterResources)
+				} else {
+					require.NotNil(t, tier.Spec.ClusterResources)
+					assert.Equal(t, expectedTemplateRefs[tierName]["clusterresources"], tier.Spec.ClusterResources.TemplateRef)
+				}
+
+				// check the `namespaces` templateRefs
+				actualTemplateRefs := make([]string, len(tier.Spec.Namespaces))
+				for i, ns := range tier.Spec.Namespaces {
+					actualTemplateRefs[i] = ns.TemplateRef
+				}
+				assert.ElementsMatch(t, expectedTemplateRefs[tierName]["namespaces"], actualTemplateRefs)
+
+				// check the `spaceRoles` templateRefs
+				actualSpaceRoleTmplRefs := make(map[string]string, len(tier.Spec.SpaceRoles))
+				for i, r := range tier.Spec.SpaceRoles {
+					actualSpaceRoleTmplRefs[i] = r.TemplateRef
+				}
+				for role, tmpl := range expectedTemplateRefs[tierName]["spaceRoles"].(map[string]string) {
+					assert.Equal(t, tmpl, actualSpaceRoleTmplRefs[role])
+				}
+			}
+		})
+
+		t.Run("create then update with new tier templates", func(t *testing.T) {
+			// given
+			namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
+			clt := test.NewFakeClient(t)
+
+			// when
+			err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+			require.NoError(t, err)
+
+			// given a new set of tier templates (same content but new revisions, which is what we'll want to check here)
+			metadata := map[string]string{
+				"advanced/based_on_tier":          "111111a",
+				"base/cluster":                    "222222a",
+				"base/ns_dev":                     "222222b",
+				"base/ns_stage":                   "222222c",
+				"base/spacerole_admin":            "222222d",
+				"nocluster/ns_dev":                "333333a",
+				"nocluster/ns_stage":              "333333b",
+				"nocluster/spacerole_admin":       "333333c",
+				"appstudio/cluster":               "444444a",
+				"appstudio/ns_tenant":             "444444b",
+				"appstudio/spacerole_admin":       "444444c",
+				"appstudio/spacerole_maintainer":  "444444d",
+				"appstudio/spacerole_contributor": "444444e",
+			}
+
+			// when calling CreateOrUpdateResources a second time
+			err = GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, metadata, getTestTemplates(t))
+
+			// then
+			require.NoError(t, err)
+			// verify that all TierTemplate CRs for the new revisions were created
+			tierTmpls := toolchainv1alpha1.TierTemplateList{}
+			err = clt.List(context.TODO(), &tierTmpls, runtimeclient.InNamespace(namespace))
+			require.NoError(t, err)
+			require.Len(t, tierTmpls.Items, 32) // two versions of: 4 items for advanced and base tiers + 3 for nocluster tier + 4 for appstudio
+			for _, tierTmpl := range tierTmpls.Items {
+				assert.Equal(t, int64(1), tierTmpl.ObjectMeta.Generation) // unchanged
+			}
+
+			expectedTemplateRefs := map[string]map[string]interface{}{
+				"advanced": {
+					"clusterresources": "advanced-clusterresources-111111a-222222a",
+					"namespaces": []string{
+						"advanced-dev-111111a-222222b",
+						"advanced-stage-111111a-222222c",
+					},
+					"spaceRoles": map[string]string{
+						"admin": "advanced-admin-111111a-222222d",
+					},
+				},
+				"base": {
+					"clusterresources": "base-clusterresources-222222a-222222a",
+					"namespaces": []string{
+						"base-dev-222222b-222222b",
+						"base-stage-222222c-222222c",
+					},
+					"spaceRoles": map[string]string{
+						"admin": "base-admin-222222d-222222d",
+					},
+				},
+				"nocluster": {
+					"namespaces": []string{
+						"nocluster-dev-333333a-333333a",
+						"nocluster-stage-333333b-333333b",
+					},
+					"spaceRoles": map[string]string{
+						"admin": "nocluster-admin-333333c-333333c",
+					},
+				},
+				"appstudio": {
+					"clusterresources": "appstudio-clusterresources-444444a-444444a",
+					"namespaces": []string{
+						"appstudio-dev-444444a-444444a",
+						"appstudio-stage-444444b-444444b",
+					},
+					"spaceRoles": map[string]string{
+						"admin":       "appstudio-admin-444444c-444444c",
+						"maintainer":  "appstudio-maintainer-444444d-444444d",
+						"contributor": "appstudio-contributor-444444e-444444e",
+					},
+				},
+			}
+			// verify that the 3 NStemplateTier CRs were updated
+			for _, tierName := range []string{"advanced", "base", "nocluster"} {
+				tier := toolchainv1alpha1.NSTemplateTier{}
+				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
+				require.NoError(t, err)
+				assert.Equal(t, int64(2), tier.ObjectMeta.Generation)
+
+				// check the `clusteresources` templateRefs
+				if tier.Name == "nocluster" {
+					assert.Nil(t, tier.Spec.ClusterResources)
+				} else {
+					require.NotNil(t, tier.Spec.ClusterResources)
+					assert.Equal(t, expectedTemplateRefs[tierName]["clusterresources"], tier.Spec.ClusterResources.TemplateRef)
+				}
+
+				// check the `namespaces` templateRefs
+				actualTemplateRefs := make([]string, len(tier.Spec.Namespaces))
+				for i, ns := range tier.Spec.Namespaces {
+					actualTemplateRefs[i] = ns.TemplateRef
+				}
+				assert.ElementsMatch(t, expectedTemplateRefs[tierName]["namespaces"], actualTemplateRefs)
+
+				// check the `spaceRoles` templateRefs
+				actualSpaceRoleTmplRefs := make(map[string]string, len(tier.Spec.SpaceRoles))
+				for i, r := range tier.Spec.SpaceRoles {
+					actualSpaceRoleTmplRefs[i] = r.TemplateRef
+				}
+				for role, tmpl := range expectedTemplateRefs[tierName]["spaceRoles"].(map[string]string) {
+					assert.Equal(t, tmpl, actualSpaceRoleTmplRefs[role])
+				}
+			}
+		})
+	})
+
+	t.Run("failures", func(t *testing.T) {
+
+		namespace := "host-operator" + uuid.Must(uuid.NewV4()).String()[:7]
+
+		t.Run("nstemplatetiers", func(t *testing.T) {
+
+			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
+				// given
+				clt := test.NewFakeClient(t)
+				clt.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
+					if obj.GetObjectKind().GroupVersionKind().Kind == "NSTemplateTier" {
+						// simulate a client/server error
+						return errors.Errorf("an error")
+					}
+					return clt.Client.Create(ctx, obj, opts...)
+				}
+
+				// when
+				err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+				// then
+				require.Error(t, err)
+				assert.Regexp(t, "unable to create or update the '\\w+' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: an error", err.Error())
+			})
+
+			t.Run("failed to update nstemplatetiers", func(t *testing.T) {
+				// given
+				// initialize the client with an existing `advanced` NSTemplatetier
+				clt := test.NewFakeClient(t, &toolchainv1alpha1.NSTemplateTier{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "advanced",
+					},
+				})
+				clt.MockUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
+					if obj.GetObjectKind().GroupVersionKind().Kind == "NSTemplateTier" {
+						// simulate a client/server error
+						return errors.Errorf("an error")
+					}
+					return clt.Client.Update(ctx, obj, opts...)
+				}
+
+				// when
+				err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+
+				// then
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "unable to create NSTemplateTiers: unable to create or update the 'advanced' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: unable to update the resource")
+			})
+		})
+
+		t.Run("tiertemplates", func(t *testing.T) {
+
+			t.Run("failed to create nstemplatetiers", func(t *testing.T) {
+				// given
+				clt := test.NewFakeClient(t)
+				clt.MockCreate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.CreateOption) error {
+					if _, ok := obj.(*toolchainv1alpha1.TierTemplate); ok {
+						// simulate a client/server error
+						return errors.Errorf("an error")
+					}
+					return clt.Client.Create(ctx, obj, opts...)
+				}
+
+				// when
+				err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), getTestTemplates(t))
+
+				// then
+				require.Error(t, err)
+				assert.Regexp(t, fmt.Sprintf("unable to create the '\\w+-\\w+-\\w+-\\w+' TierTemplate in namespace '%s'", namespace), err.Error()) // we can't tell for sure which namespace will fail first, but the error should match the given regex
+			})
+		})
+	})
+}
+
+func TestLoadTemplatesByTiers(t *testing.T) {
+
+	logf.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	t.Run("ok", func(t *testing.T) {
+		t.Run("with test assets", func(t *testing.T) {
+			// when
+			tmpls, err := loadTemplatesByTiers(getTestMetadata(), getTestTemplates(t))
+			// then
+			require.NoError(t, err)
+			require.Len(t, tmpls, 4)
+			require.NotContains(t, "foo", tmpls) // make sure that the `foo: bar` entry was ignored
+
+			for _, tier := range tiers(expectedTestTiers) {
+				t.Run(tier, func(t *testing.T) {
+					for _, typeName := range nsTypes(tier) {
+						t.Run("ns-"+typeName, func(t *testing.T) {
+							require.NotNil(t, tmpls[tier])
+							if basedOnOtherTier(expectedTestTiers, tier) {
+								assert.Empty(t, tmpls[tier].rawTemplates.namespaceTemplates[typeName].revision)
+								assert.Empty(t, tmpls[tier].rawTemplates.namespaceTemplates[typeName].content)
+							} else {
+								assert.NotEmpty(t, tmpls[tier].rawTemplates.namespaceTemplates[typeName].revision)
+								assert.NotEmpty(t, tmpls[tier].rawTemplates.namespaceTemplates[typeName].content)
+							}
+						})
+					}
+					for _, role := range roles(tier) {
+						t.Run("spacerole-"+role, func(t *testing.T) {
+							if basedOnOtherTier(expectedTestTiers, tier) {
+								assert.Empty(t, tmpls[tier].rawTemplates.spaceroleTemplates[role].revision)
+								assert.Empty(t, tmpls[tier].rawTemplates.spaceroleTemplates[role].content)
+							} else {
+								assert.NotEmpty(t, tmpls[tier].rawTemplates.spaceroleTemplates[role].revision)
+								assert.NotEmpty(t, tmpls[tier].rawTemplates.spaceroleTemplates[role].content)
+							}
+						})
+					}
+					t.Run("cluster", func(t *testing.T) {
+						require.NotNil(t, tmpls[tier].rawTemplates)
+						if basedOnOtherTier(expectedTestTiers, tier) {
+							assert.Nil(t, tmpls[tier].rawTemplates.clusterTemplate)
+						} else if tier != "nocluster" {
+							require.NotNil(t, tmpls[tier].rawTemplates.clusterTemplate)
+							assert.NotEmpty(t, tmpls[tier].rawTemplates.clusterTemplate.revision)
+							assert.NotEmpty(t, tmpls[tier].rawTemplates.clusterTemplate.content)
+						} else {
+							require.Nil(t, tmpls[tier].rawTemplates.clusterTemplate)
+						}
+					})
+					t.Run("based_on_tier", func(t *testing.T) {
+						if basedOnOtherTier(expectedTestTiers, tier) {
+							require.NotNil(t, tmpls[tier].basedOnTier)
+						} else {
+							require.Nil(t, tmpls[tier].basedOnTier)
+						}
+					})
+				})
+			}
+		})
+	})
+
+	t.Run("failures", func(t *testing.T) {
+
+		t.Run("unparseable content", func(t *testing.T) {
+			// given
+			testTemplates := getTestTemplates(t)
+			testTemplates["advanced/based_on_tier.yaml"] = []byte("foo::bar")
+
+			// when
+			_, err := loadTemplatesByTiers(getTestMetadata(), testTemplates)
+			// then
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unable to unmarshal 'advanced/based_on_tier.yaml': yaml: unmarshal errors:")
+		})
+
+		t.Run("invalid name format", func(t *testing.T) {
+			// given
+			dummyMetadata := map[string]string{
+				`.DS_Store`: `metadata.yaml`, // '/advanced/foo.yaml' is not a valid filename
+			}
+			dummyTemplates := map[string][]byte{
+				".DS_Store": []byte(`foo:bar`), // just make sure the asset exists
+			}
+
+			// when
+			_, err := loadTemplatesByTiers(dummyMetadata, dummyTemplates)
+			// then
+			require.Error(t, err)
+			assert.EqualError(t, err, "unable to load templates: invalid name format for file '.DS_Store'")
+		})
+
+		t.Run("invalid filename scope", func(t *testing.T) {
+			// given
+			dummyMetadata := map[string]string{
+				`metadata.yaml`: `advanced/foo.yaml`, // '/advanced/foo.yaml' is not a valid filename
+			}
+			dummyTemplates := map[string][]byte{
+				"advanced/foo.yaml": []byte(`foo:bar`), // just make sure the asset exists
+			}
+
+			// when
+			_, err := loadTemplatesByTiers(dummyMetadata, dummyTemplates)
+			// then
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unable to load templates: unknown scope for file 'advanced/foo.yaml'")
+		})
+
+		t.Run("should fail when tier contains a mix of based_on_tier.yaml file together with a regular template file", func(t *testing.T) {
+			// given
+			s := addToScheme(t)
+			clt := test.NewFakeClient(t)
+
+			for _, tmplName := range []string{"cluster.yaml", "ns_dev.yaml", "ns_stage.yaml", "tier.yaml"} {
+				t.Run("for template name "+tmplName, func(t *testing.T) {
+					// given
+					filePath := fmt.Sprintf("advanced/%s", tmplName)
+					dummyMetadata := getTestMetadata()
+					dummyMetadata[filePath] = "123"
+
+					dummyTemplates := getTestTemplates(t)
+					dummyTemplates[filePath] = []byte("")
+
+					// when
+					_, err := newNSTemplateTierGenerator(s, ensureObjectFuncForClient(clt), test.HostOperatorNs, dummyMetadata, dummyTemplates)
+
+					// then
+					require.EqualError(t, err, "the tier advanced contains a mix of based_on_tier.yaml file together with a regular template file")
+				})
+			}
+		})
+	})
+}
+
+func TestNewNSTemplateTier(t *testing.T) {
+
+	s := scheme.Scheme
+	err := toolchainv1alpha1.AddToScheme(s)
+	require.NoError(t, err)
+
+	t.Run("ok", func(t *testing.T) {
+
+		t.Run("with test assets", func(t *testing.T) {
+			// given
+			namespace := "host-operator-" + uuid.Must(uuid.NewV4()).String()[:7]
+			tc, err := newNSTemplateTierGenerator(s, nil, namespace, getTestMetadata(), getTestTemplates(t))
+			require.NoError(t, err)
+			clusterResourcesRevisions := map[string]string{
+				"advanced":  "abcd123-654321a",
+				"base":      "654321a-654321a",
+				"appstudio": "654321a-654321a",
+			}
+			namespaceRevisions := map[string]map[string]string{
+				"advanced": {
+					"dev":   "abcd123-123456b",
+					"stage": "abcd123-123456c",
+				},
+				"base": {
+					"dev":   "123456b-123456b",
+					"stage": "123456c-123456c",
+				},
+				"nocluster": {
+					"dev":   "123456j-123456j",
+					"stage": "1234567-1234567",
+				},
+				"appstudio": {
+					"tenant": "123456b-123456b",
+				},
+			}
+			spaceRoleRevisions := map[string]map[string]string{
+				"advanced": {
+					"admin": "abcd123-123456d",
+				},
+				"base": {
+					"admin": "123456d-123456d",
+				},
+				"nocluster": {
+					"admin": "123456k-123456k",
+				},
+				"appstudio": {
+					"admin":       "123456c-123456c",
+					"maintainer":  "123456d-123456d",
+					"contributor": "123456e-123456e",
+				},
+			}
+			for tier := range namespaceRevisions {
+				t.Run(tier, func(t *testing.T) {
+					// given
+					objects := tc.templatesByTier[tier].objects
+					require.Len(t, objects, 1, "expected only 1 NSTemplateTier toolchain object")
+					// when
+					actual := runtimeObjectToNSTemplateTier(t, s, objects[0])
+
+					// then
+					expected, err := newNSTemplateTierFromYAML(s, tier, namespace, clusterResourcesRevisions[tier], namespaceRevisions[tier], spaceRoleRevisions[tier])
+					require.NoError(t, err)
+					// here we don't compare objects because the generated NSTemplateTier
+					// has no specific values for the `TypeMeta`: the `APIVersion: toolchain.dev.openshift.com/v1alpha1`
+					// and `Kind: NSTemplateTier` should be set by the client using the registered GVK
+					assert.Equal(t, expected.ObjectMeta, actual.ObjectMeta)
+					assert.Equal(t, expected.Spec, actual.Spec)
+				})
+			}
+		})
+	})
+}
+
+func TestNewTierTemplate(t *testing.T) {
+	s := addToScheme(t)
+	namespace := "host-operator-" + uuid.Must(uuid.NewV4()).String()[:7]
+
+	t.Run("ok", func(t *testing.T) {
+
+		t.Run("with test assets", func(t *testing.T) {
+			// given
+
+			// when
+			tc, err := newNSTemplateTierGenerator(s, nil, namespace, getTestMetadata(), getTestTemplates(t))
+
+			// then
+			require.NoError(t, err)
+			decoder := serializer.NewCodecFactory(s).UniversalDeserializer()
+
+			resourceNameRE, err := regexp.Compile(`[a-z0-9\.-]+`)
+			require.NoError(t, err)
+			for tier, tmpls := range tc.templatesByTier {
+				t.Run(tier, func(t *testing.T) {
+					for _, actual := range tmpls.tierTemplates {
+						assert.Equal(t, namespace, actual.Namespace)
+						assert.True(t, resourceNameRE.MatchString(actual.Name)) // verifies that the TierTemplate name complies with the DNS-1123 spec
+						assert.NotEmpty(t, actual.Spec.Revision)
+						assert.NotEmpty(t, actual.Spec.TierName)
+						assert.NotEmpty(t, actual.Spec.Type)
+						assert.NotEmpty(t, actual.Spec.Template)
+						assert.NotEmpty(t, actual.Spec.Template.Name)
+
+						if actual.Spec.Type == "clusterresources" {
+							assertClusterResourcesTemplate(t, decoder, actual.Spec.Template, expectedTestTiers, tier)
+						} else if isNamespaceType(expectedTestTiers, actual.Spec.Type) {
+							assertNamespaceTemplate(t, decoder, actual.Spec.Template, expectedTestTiers, tier, actual.Spec.Type)
+						} else if isSpaceRole(expectedTestTiers, actual.Spec.Type) {
+							assertSpaceRoleTemplate(t, decoder, actual.Spec.Template, expectedTestTiers, tier, actual.Spec.Type)
+						} else {
+							t.Errorf("unexpected type of template: '%s'", actual.Spec.Type)
+						}
+					}
+				})
+			}
+		})
+	})
+
+	t.Run("failures", func(t *testing.T) {
+
+		t.Run("invalid template", func(t *testing.T) {
+			// given
+			testTemplates := getTestTemplates(t)
+			testTemplates["base/ns_dev.yaml"] = []byte("invalid")
+			// when
+			_, err := newNSTemplateTierGenerator(s, nil, namespace, getTestMetadata(), testTemplates)
+
+			// then
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unable to generate 'advanced-dev-abcd123-123456b' TierTemplate manifest: couldn't get version/kind; json parse error")
+		})
+	})
+}
+
+func ensureObjectFuncForClient(cl runtimeclient.Client) EnsureObject {
+	return func(toEnsure runtimeclient.Object, canUpdate bool) (bool, error) {
+		if !canUpdate {
+			if err := cl.Create(context.TODO(), toEnsure); err != nil && !apierrors.IsAlreadyExists(err) {
+				return false, err
+			}
+			return true, nil
+		}
+		applyCl := commonclient.NewApplyClient(cl)
+		return applyCl.ApplyObject(context.TODO(), toEnsure, commonclient.ForceUpdate(true))
+	}
+}
+
+func assertClusterResourcesTemplate(t *testing.T, decoder runtime.Decoder, actual templatev1.Template, expectedTiers map[string]bool, tier string) {
+	if !basedOnOtherTier(expectedTiers, tier) {
+		expected := templatev1.Template{}
+		content := getTestTemplates(t)[(fmt.Sprintf("%s/cluster.yaml", tier))]
+		_, _, err := decoder.Decode(content, nil, &expected)
+		require.NoError(t, err)
+		assert.Equal(t, expected, actual)
+		assert.NotEmpty(t, actual.Objects)
+	}
+}
+
+func assertNamespaceTemplate(t *testing.T, decoder runtime.Decoder, actual templatev1.Template, expectedTiers map[string]bool, tier, typeName string) {
+	var templatePath string
+	if basedOnOtherTier(expectedTiers, tier) {
+		templatePath = expectedTemplateFromBasedOnTierConfig(t, tier, fmt.Sprintf("ns_%s.yaml", typeName))
+	} else {
+		templatePath = fmt.Sprintf("%s/ns_%s.yaml", tier, typeName)
+	}
+	content := getTestTemplates(t)[templatePath]
+	expected := templatev1.Template{}
+	_, _, err := decoder.Decode(content, nil, &expected)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+	assert.NotEmpty(t, actual.Objects)
+}
+
+func assertSpaceRoleTemplate(t *testing.T, decoder runtime.Decoder, actual templatev1.Template, expectedTiers map[string]bool, tier, roleName string) {
+	var templatePath string
+	if basedOnOtherTier(expectedTiers, tier) {
+		templatePath = expectedTemplateFromBasedOnTierConfig(t, tier, fmt.Sprintf("spacerole_%s.yaml", roleName))
+	} else {
+		templatePath = fmt.Sprintf("%s/spacerole_%s.yaml", tier, roleName)
+	}
+	content := getTestTemplates(t)[templatePath]
+	expected := templatev1.Template{}
+	_, _, err := decoder.Decode(content, nil, &expected)
+	require.NoError(t, err)
+	assert.Equal(t, expected, actual)
+	// there are no space role permissions for appstudio-env because the user doesn't have any permissions in the namespace
+	if tier != "appstudio-env" {
+		assert.NotEmpty(t, actual.Objects)
+	} else {
+		assert.Empty(t, actual.Objects)
+	}
+}
+
+func expectedTemplateFromBasedOnTierConfig(t *testing.T, tier, templateFileName string) string {
+	basedOnTierContent := getTestTemplates(t)[(fmt.Sprintf("%s/based_on_tier.yaml", tier))]
+	basedOnTier := BasedOnTier{}
+	require.NoError(t, yaml.Unmarshal(basedOnTierContent, &basedOnTier))
+	return fmt.Sprintf("%s/%s", basedOnTier.From, templateFileName)
+}
+
+func TestNewNSTemplateTiers(t *testing.T) {
+
+	// given
+	s := addToScheme(t)
+
+	t.Run("ok", func(t *testing.T) {
+		// given
+		namespace := "host-operator-" + uuid.Must(uuid.NewV4()).String()[:7]
+		// when
+		tc, err := newNSTemplateTierGenerator(s, nil, namespace, getTestMetadata(), getTestTemplates(t))
+		require.NoError(t, err)
+		// then
+		require.Len(t, tc.templatesByTier, 4)
+		for _, name := range []string{"advanced", "base", "nocluster", "appstudio"} {
+			tierData, found := tc.templatesByTier[name]
+			tierObjs := tierData.objects
+			require.Len(t, tierObjs, 1, "expected only 1 NSTemplateTier toolchain object")
+			tier := runtimeObjectToNSTemplateTier(t, s, tierObjs[0])
+
+			require.True(t, found)
+			assert.Equal(t, name, tier.ObjectMeta.Name)
+			assert.Equal(t, namespace, tier.ObjectMeta.Namespace)
+			for _, ns := range tier.Spec.Namespaces {
+				assert.NotEmpty(t, ns.TemplateRef, "expected namespace reference not empty for tier %v", name)
+			}
+			if name == "nocluster" {
+				assert.Nil(t, tier.Spec.ClusterResources)
+			} else {
+				require.NotNil(t, tier.Spec.ClusterResources)
+				assert.NotEmpty(t, tier.Spec.ClusterResources.TemplateRef)
+			}
+		}
+	})
+}
+
+// newNSTemplateTierFromYAML generates toolchainv1alpha1.NSTemplateTier using a golang template which is applied to the given tier.
+func newNSTemplateTierFromYAML(s *runtime.Scheme, tier, namespace string, clusterResourcesRevision string, namespaceRevisions map[string]string, spaceRoleRevisions map[string]string) (*toolchainv1alpha1.NSTemplateTier, error) {
+	expectedTmpl, err := texttemplate.New("template").Parse(`
+{{ $tier := .Tier}}
+kind: NSTemplateTier
+apiVersion: toolchain.dev.openshift.com/v1alpha1
+metadata:
+  namespace: {{ .Namespace }}
+  name: {{ .Tier }}
+spec:
+  deactivationTimeoutDays: {{ .DeactivationTimeout }} 
+  {{ if .ClusterResourcesRevision }}clusterResources:
+    templateRef: {{ .Tier }}-clusterresources-{{ .ClusterResourcesRevision }}
+  {{ end }}
+  namespaces: 
+{{ range $type, $revision := .NamespaceRevisions }}
+    - templateRef: {{ $tier }}-{{ $type }}-{{ $revision }}
+{{ end }}
+  spaceRoles: 
+{{ range $role, $revision := .SpaceRoleRevisions }}    
+    {{ $role }}:
+      templateRef: {{ $tier }}-{{ $role }}-{{ $revision }}
+{{ end }}
+`)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(nil)
+	err = expectedTmpl.Execute(buf, struct {
+		Tier                     string
+		Namespace                string
+		ClusterResourcesRevision string
+		NamespaceRevisions       map[string]string
+		SpaceRoleRevisions       map[string]string
+		DeactivationTimeout      int
+	}{
+		Tier:                     tier,
+		Namespace:                namespace,
+		ClusterResourcesRevision: clusterResourcesRevision,
+		NamespaceRevisions:       namespaceRevisions,
+		SpaceRoleRevisions:       spaceRoleRevisions,
+	})
+	if err != nil {
+		return nil, err
+	}
+	result := &toolchainv1alpha1.NSTemplateTier{}
+	codecFactory := serializer.NewCodecFactory(s)
+	_, _, err = codecFactory.UniversalDeserializer().Decode(buf.Bytes(), nil, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func runtimeObjectToNSTemplateTier(t *testing.T, s *runtime.Scheme, tierObj runtime.Object) *toolchainv1alpha1.NSTemplateTier {
+	tier := &toolchainv1alpha1.NSTemplateTier{}
+	err := s.Convert(tierObj, tier, nil)
+	require.NoError(t, err)
+	return tier
+}
+
+func addToScheme(t *testing.T) *runtime.Scheme {
+	s := scheme.Scheme
+	err := toolchainv1alpha1.AddToScheme(s)
+	require.NoError(t, err)
+	err = templatev1.Install(s)
+	require.NoError(t, err)
+	return s
+}

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -795,7 +795,7 @@ func TestNewTierTemplate(t *testing.T) {
 }
 
 func ensureObjectFuncForClient(cl runtimeclient.Client) EnsureObject {
-	return func(toEnsure runtimeclient.Object, canUpdate bool) (bool, error) {
+	return func(toEnsure runtimeclient.Object, canUpdate bool, _ string) (bool, error) {
 		if !canUpdate {
 			if err := cl.Create(context.TODO(), toEnsure); err != nil && !apierrors.IsAlreadyExists(err) {
 				return false, err

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -465,6 +465,18 @@ func TestGenerateTiers(t *testing.T) {
 				assert.Regexp(t, "unable to create or update the '\\w+' NSTemplateTier: unable to create resource of kind: NSTemplateTier, version: v1alpha1: an error", err.Error())
 			})
 
+			t.Run("missing tier.yaml file", func(t *testing.T) {
+				// given
+				clt := test.NewFakeClient(t)
+				testTemplates := getTestTemplates(t)
+				delete(testTemplates, "base/tier.yaml")
+
+				// when
+				err := GenerateTiers(s, ensureObjectFuncForClient(clt), namespace, getTestMetadata(), testTemplates)
+				// then
+				require.EqualError(t, err, "unable to init NSTemplateTier generator: tier base is missing a tier.yaml file")
+			})
+
 			t.Run("failed to update nstemplatetiers", func(t *testing.T) {
 				// given
 				// initialize the client with an existing `advanced` NSTemplatetier

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/advanced/based_on_tier.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/advanced/based_on_tier.yaml
@@ -1,0 +1,5 @@
+from: base
+parameters:
+- name: IDLER_TIMEOUT_SECONDS
+  # 144 hours
+  value: "518400"

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/cluster.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/cluster.yaml
@@ -1,0 +1,35 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-cluster-resources
+objects:
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${SPACE_NAME}-compute
+  spec:
+    quota:
+      hard:
+        limits.cpu: 20000m
+        limits.memory: ${MEMORY_LIMIT}
+        limits.ephemeral-storage: 7Gi
+        requests.cpu: 1750m
+        requests.memory: ${MEMORY_REQUEST}
+        requests.storage: 15Gi
+        requests.ephemeral-storage: 7Gi
+        count/persistentvolumeclaims: "5"
+    selector:
+      annotations: null
+      labels:
+        matchLabels:
+          toolchain.dev.openshift.com/space: ${SPACE_NAME}
+parameters:
+- name: SPACE_NAME
+  required: true
+- name: IDLER_TIMEOUT_SECONDS
+  # 12 hours
+  value: "43200"
+- name: MEMORY_LIMIT
+  value: "7Gi"
+- name: MEMORY_REQUEST
+  value: "7Gi"

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/ns_tenant.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/ns_tenant.yaml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-tenant
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}
+      openshift.io/display-name: ${SPACE_NAME}
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      name: ${SPACE_NAME}-tenant
+      appstudio.redhat.com/workspace_name: ${SPACE_NAME}
+    name: ${SPACE_NAME}-tenant
+
+parameters:
+- name: SPACE_NAME
+  required: true
+- name: MEMBER_OPERATOR_NAMESPACE
+  value: toolchain-member-operator

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_admin.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_admin.yaml
@@ -1,0 +1,159 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-spacerole-admin
+objects:
+
+# ServiceAccounts that represents the AppStudio user - the token of this SA is used by the proxy for forwarding the requests from UI (or any other client)
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}
+
+# RoleBinding that grants limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+# Role(s) and RoleBinding(s) that grant limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-admin-user-actions
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - applications
+    - components
+    - componentdetectionqueries
+    verbs:
+    - "*"
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - spiaccesstokenbindings
+    - spiaccesschecks
+    - spiaccesstokens
+    - spifilecontentrequests
+    - spiaccesstokendataupdates
+    verbs:
+    - '*'
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - promotionruns
+    - snapshotenvironmentbindings
+    - snapshots
+    - environments
+    verbs:
+    - '*'
+  - apiGroups:
+      - appstudio.redhat.com
+    resources:
+      - deploymentttargets
+      - deploymenttargetclaims
+    verbs:
+      - '*'
+  - apiGroups:
+    - managed-gitops.redhat.com
+    resources:
+      - gitopsdeployments
+      - gitopsdeploymentmanagedenvironments
+      - gitopsdeploymentrepositorycredentials
+      - gitopsdeploymentsyncruns
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+    - tekton.dev
+    resources:
+    - pipelineruns
+    verbs:
+    - '*'
+  - apiGroups:
+    - results.tekton.dev
+    resources:
+    - results
+    - records
+    verbs:
+    - get
+    - list
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - integrationtestscenarios
+    verbs:
+    - '*'
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - enterprisecontractpolicies
+    verbs:
+    - '*'
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - releases
+    - releasestrategies
+    - releaseplans
+    verbs:
+    - '*'
+  - apiGroups:
+    - appstudio.redhat.com
+    resources:
+    - releaseplanadmissions
+    verbs:
+    - '*'
+  - apiGroups:
+    - jvmbuildservice.io
+    resources:
+    - jbsconfigs
+    - artifactbuilds
+    verbs:
+    - '*'
+  - apiGroups:
+    - ''
+    resources:
+    - configmaps
+    verbs:
+    - '*'
+  - apiGroups:
+    - ''
+    resources:
+    - secrets
+    verbs:
+    - '*'
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}-user-actions
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: appstudio-admin-user-actions
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: appstudio-${USERNAME}
+
+# Role & RoleBinding that grants view permissions to the user's SA
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: appstudio-${USERNAME}
+
+parameters:
+- name: USERNAME
+  required: true
+- name: NAMESPACE
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_contributor.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_contributor.yaml
@@ -1,0 +1,171 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-spacerole-contributor # name is used in e2e tests
+objects:
+  # ServiceAccounts that represents the AppStudio user - the token of this SA is used by the proxy for forwarding the requests from UI (or any other client)
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      namespace: ${NAMESPACE}
+      name: appstudio-${USERNAME}
+
+  # RoleBinding that grants limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+  # Role(s) and RoleBinding(s) that grant limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      namespace: ${NAMESPACE}
+      name: appstudio-contributor-user-actions
+    rules:
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - applications
+          - components
+          - componentdetectionqueries
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - promotionruns
+          - snapshotenvironmentbindings
+          - snapshots
+          - environments
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - deploymentttargets
+          - deploymenttargetclaims
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - managed-gitops.redhat.com
+        resources:
+          - gitopsdeployments
+          - gitopsdeploymentmanagedenvironments
+          - gitopsdeploymentrepositorycredentials
+          - gitopsdeploymentsyncruns
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - tekton.dev
+        resources:
+          - pipelineruns
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - results.tekton.dev
+        resources:
+          - results
+          - records
+        verbs:
+          - get
+          - list
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - integrationtestscenarios
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - enterprisecontractpolicies
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - releases
+          - releasestrategies
+          - releaseplans
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - releaseplanadmissions
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - jvmbuildservice.io
+        resources:
+          - jbsconfigs
+          - artifactbuilds
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - appstudio.redhat.com
+        resources:
+          - spiaccesstokenbindings
+          - spiaccesschecks
+          - spiaccesstokens
+          - spifilecontentrequest
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ''
+        resources:
+          - configmaps
+        verbs:
+          - get
+          - list
+          - watch
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      namespace: ${NAMESPACE}
+      name: appstudio-${USERNAME}-user-actions
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: appstudio-contributor-user-actions
+    subjects:
+      - apiGroup: ""
+        kind: ServiceAccount
+        name: appstudio-${USERNAME}
+  # Role & RoleBinding that grants view permissions to the user's SA
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      namespace: ${NAMESPACE}
+      name: appstudio-${USERNAME}-view-user
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: view
+    subjects:
+      - kind: User
+        name: ${USERNAME}
+
+parameters:
+  - name: NAMESPACE
+    required: true
+  - name: USERNAME
+    required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_maintainer.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/spacerole_maintainer.yaml
@@ -1,0 +1,177 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-spacerole-maintainer
+objects:
+
+# ServiceAccounts that represents the AppStudio user - the token of this SA is used by the proxy for forwarding the requests from UI (or any other client)
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}
+
+# RoleBinding that grants limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+# Role(s) and RoleBinding(s) that grant limited CRUD permissions on AppStudio components CRDs & secrets to the user's SA
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-maintainer-user-actions
+  rules:
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - applications
+        - components
+        - componentdetectionqueries
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - promotionruns
+        - snapshotenvironmentbindings
+        - snapshots
+        - environments
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - deploymentttargets
+        - deploymenttargetclaims
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - managed-gitops.redhat.com
+      resources:
+        - gitopsdeployments
+        - gitopsdeploymentmanagedenvironments
+        - gitopsdeploymentrepositorycredentials
+        - gitopsdeploymentsyncruns
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - tekton.dev
+      resources:
+        - pipelineruns
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - results.tekton.dev
+      resources:
+        - results
+        - records
+      verbs:
+        - get
+        - list
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - integrationtestscenarios
+      verbs:
+        - '*'
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - enterprisecontractpolicies
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - releases
+        - releasestrategies
+        - releaseplans
+      verbs:
+        - '*'
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - releaseplanadmissions
+      verbs:
+        - '*'
+    - apiGroups:
+        - jvmbuildservice.io
+      resources:
+        - jbsconfigs
+        - artifactbuilds
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+    - apiGroups:
+        - appstudio.redhat.com
+      resources:
+        - spiaccesstokenbindings
+        - spiaccesschecks
+        - spiaccesstokens
+        - spifilecontentrequests
+        - spiaccesstokendataupdates
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - patch
+    - apiGroups:
+        - ''
+      resources:
+        - configmaps
+      verbs:
+        - get
+        - list
+        - watch
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}-user-actions
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: appstudio-maintainer-user-actions
+  subjects:
+    - apiGroup: ""
+      kind: ServiceAccount
+      name: appstudio-${USERNAME}
+# Role & RoleBinding that grants view permissions to the user's SA
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: appstudio-${USERNAME}-view
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: view
+  subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: appstudio-${USERNAME}
+
+parameters:
+- name: USERNAME
+  required: true
+- name: NAMESPACE
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/tier.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/appstudio/tier.yaml
@@ -1,0 +1,29 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: appstudio-tier
+objects:
+- kind: NSTemplateTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: appstudio
+    namespace: ${NAMESPACE}
+  spec:
+    clusterResources:
+      templateRef: ${CLUSTER_TEMPL_REF}
+    namespaces:
+      - templateRef: ${TENANT_TEMPL_REF}
+    spaceRoles:
+      admin:
+        templateRef: ${ADMIN_TEMPL_REF}
+      maintainer:
+        templateRef: ${MAINTAINER_TEMPL_REF}
+      contributor:
+        templateRef: ${CONTRIBUTOR_TEMPL_REF}
+parameters:
+- name: NAMESPACE
+- name: CLUSTER_TEMPL_REF
+- name: TENANT_TEMPL_REF
+- name: ADMIN_TEMPL_REF
+- name: MAINTAINER_TEMPL_REF
+- name: CONTRIBUTOR_TEMPL_REF

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/cluster.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/cluster.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    toolchain.dev.openshift.com/provider: codeready-toolchain
+  name: base-cluster-resources
+objects:
+- apiVersion: quota.openshift.io/v1
+  kind: ClusterResourceQuota
+  metadata:
+    name: for-${SPACE_NAME}
+  spec:
+    quota:
+      hard:
+        limits.cpu: ${CPU_LIMIT}
+        limits.memory: 7Gi
+        requests.storage: 7Gi
+        persistentvolumeclaims: "5"
+    selector:
+      annotations: null
+      labels:
+        matchLabels:
+          toolchain.dev.openshift.com/space: ${SPACE_NAME}
+parameters:
+- name: SPACE_NAME
+  required: true
+- name: CPU_LIMIT
+  value: 4000m

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/ns_dev.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/ns_dev.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    toolchain.dev.openshift.com/provider: codeready-toolchain
+  name: base-dev
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}-dev
+      openshift.io/display-name: ${SPACE_NAME}-dev
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${SPACE_NAME}-dev
+    name: ${SPACE_NAME}-dev
+parameters:
+- name: SPACE_NAME
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/ns_stage.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/ns_stage.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    toolchain.dev.openshift.com/provider: codeready-toolchain
+  name: base-stage
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}-stage
+      openshift.io/display-name: ${SPACE_NAME}-stage
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${SPACE_NAME}-stage
+    name: ${SPACE_NAME}-stage
+parameters:
+- name: SPACE_NAME
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/spacerole_admin.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/spacerole_admin.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: base-spacerole-admin
+objects:
+
+# Rolebindings that grant permissions to the users in their own namespaces
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: ${USERNAME}-rbac-edit
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+
+parameters:
+- name: USERNAME
+  required: true
+- name: NAMESPACE
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/tier.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/base/tier.yaml
@@ -1,0 +1,25 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: base-tier
+objects:
+- kind: NSTemplateTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: base
+    namespace: ${NAMESPACE}
+  spec:
+    clusterResources:
+      templateRef: ${CLUSTER_TEMPL_REF}
+    namespaces:
+      - templateRef: ${DEV_TEMPL_REF}
+      - templateRef: ${STAGE_TEMPL_REF}
+    spaceRoles:
+      admin:
+        templateRef: ${ADMIN_TEMPL_REF}
+parameters:
+- name: NAMESPACE
+- name: CLUSTER_TEMPL_REF
+- name: DEV_TEMPL_REF
+- name: STAGE_TEMPL_REF
+- name: ADMIN_TEMPL_REF

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/ns_dev.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/ns_dev.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    toolchain.dev.openshift.com/provider: codeready-toolchain
+  name: nocluster-dev
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}-dev
+      openshift.io/display-name: ${SPACE_NAME}-dev
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${SPACE_NAME}-dev
+    name: ${SPACE_NAME}-dev
+parameters:
+- name: SPACE_NAME
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/ns_stage.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/ns_stage.yaml
@@ -1,0 +1,21 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  labels:
+    toolchain.dev.openshift.com/provider: codeready-toolchain
+  name: nocluster-stage
+objects:
+- apiVersion: v1
+  kind: Namespace
+  metadata:
+    annotations:
+      openshift.io/description: ${SPACE_NAME}-stage
+      openshift.io/display-name: ${SPACE_NAME}-stage
+      openshift.io/requester: ${SPACE_NAME}
+    labels:
+      toolchain.dev.openshift.com/provider: codeready-toolchain
+      name: ${SPACE_NAME}-stage
+    name: ${SPACE_NAME}-stage
+parameters:
+- name: SPACE_NAME
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/spacerole_admin.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/spacerole_admin.yaml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: base-spacerole-admin
+objects:
+
+# Rolebindings that grant permissions to the users in their own namespaces
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: user-rbac-edit
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    namespace: ${NAMESPACE}
+    name: user-rbac-edit
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rbac-edit
+  subjects:
+    - kind: User
+      name: ${USERNAME}
+
+parameters:
+- name: USERNAME
+  required: true
+- name: NAMESPACE
+  required: true

--- a/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/tier.yaml
+++ b/pkg/template/nstemplatetiers/testdata/nstemplatetiers/nocluster/tier.yaml
@@ -1,0 +1,22 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: nocluster-tier
+objects:
+- kind: NSTemplateTier
+  apiVersion: toolchain.dev.openshift.com/v1alpha1
+  metadata:
+    name: nocluster
+    namespace: ${NAMESPACE}
+  spec:
+    namespaces:
+      - templateRef: ${DEV_TEMPL_REF}
+      - templateRef: ${STAGE_TEMPL_REF}
+    spaceRoles:
+      admin:
+        templateRef: ${ADMIN_TEMPL_REF}
+parameters:
+- name: NAMESPACE
+- name: DEV_TEMPL_REF
+- name: STAGE_TEMPL_REF
+- name: ADMIN_TEMPL_REF


### PR DESCRIPTION
This PR moves the logic of nstemplatetier_generator.go from host-operator to toolchain-common and make it generic so it can be used by a ksctl command for generating NSTemplateTier & TierTemplate manifests locally in a GitOps repository.
There is almost no change in the logic of the generator, it should work in the same way as it was before, just with the difference that it doesn't load templates from the assets, but takes them from the map passed as a parameter.

[KUBESAW-59](https://issues.redhat.com/browse/KUBESAW-59)

related PR in host-operator repo https://github.com/codeready-toolchain/host-operator/pull/1006