### PR TITLE
Split ci-build.yml

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,31 @@
+name: ci-build
+on:
+  push:
+    branches:
+      - master
+    tags-ignore:
+      - '*.*'
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  golangci:
+    name: GolangCI Lint
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: 1.20.x
+        
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v4
+      with:
+        version: v1.52.0
+        skip-pkg-cache: true
+        skip-build-cache: true
+        args: --config=./.golangci.yml --verbose

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -38,23 +38,3 @@ jobs:
         flags: unittests # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
-    
-  golangci:
-    name: GolangCI Lint
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Lint
-      uses: golangci/golangci-lint-action@v4
-      with:
-        version: v1.52.0
-        skip-pkg-cache: true
-        skip-build-cache: true
-        args: --config=./.golangci.yml --verbose


### PR DESCRIPTION
split the ci-build.yml file into following two files

test-with-coverage.yml
linters.yml
By updating pull_request_target to have tokens the workflow automatically checks out the code from master and not from PR. 
This fix is needed only for the tests to upload codecov report, not for linters and hence spliting the workflow