### PR TITLE
KUBESAW-43: Replace the special ToolchainClusterCondition with the standard toolchain Condition

### DIFF
--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -64,50 +64,50 @@ func (hc *HealthChecker) getClusterHealthStatus(ctx context.Context) *toolchainv
 	return &clusterStatus
 }
 
-func clusterReadyCondition() toolchainv1alpha1.ToolchainClusterCondition {
+func clusterReadyCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
-	return toolchainv1alpha1.ToolchainClusterCondition{
+	return toolchainv1alpha1.Condition{
 		Type:               toolchainv1alpha1.ToolchainClusterReady,
 		Status:             corev1.ConditionTrue,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterReadyReason,
 		Message:            healthzOk,
-		LastProbeTime:      currentTime,
-		LastTransitionTime: &currentTime,
+		LastTransitionTime: currentTime,
+		LastUpdatedTime:    &currentTime,
 	}
 }
 
-func clusterNotReadyCondition() toolchainv1alpha1.ToolchainClusterCondition {
+func clusterNotReadyCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
-	return toolchainv1alpha1.ToolchainClusterCondition{
+	return toolchainv1alpha1.Condition{
 		Type:               toolchainv1alpha1.ToolchainClusterReady,
 		Status:             corev1.ConditionFalse,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReadyReason,
 		Message:            healthzNotOk,
-		LastProbeTime:      currentTime,
-		LastTransitionTime: &currentTime,
+		LastTransitionTime: currentTime,
+		LastUpdatedTime:    &currentTime,
 	}
 }
 
-func clusterOfflineCondition() toolchainv1alpha1.ToolchainClusterCondition {
+func clusterOfflineCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
-	return toolchainv1alpha1.ToolchainClusterCondition{
+	return toolchainv1alpha1.Condition{
 		Type:               toolchainv1alpha1.ToolchainClusterOffline,
 		Status:             corev1.ConditionTrue,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReachableReason,
 		Message:            clusterNotReachableMsg,
-		LastProbeTime:      currentTime,
-		LastTransitionTime: &currentTime,
+		LastTransitionTime: currentTime,
+		LastUpdatedTime:    &currentTime,
 	}
 }
 
-func clusterNotOfflineCondition() toolchainv1alpha1.ToolchainClusterCondition {
+func clusterNotOfflineCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
-	return toolchainv1alpha1.ToolchainClusterCondition{
+	return toolchainv1alpha1.Condition{
 		Type:               toolchainv1alpha1.ToolchainClusterOffline,
 		Status:             corev1.ConditionFalse,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterReachableReason,
 		Message:            clusterReachableMsg,
-		LastProbeTime:      currentTime,
-		LastTransitionTime: &currentTime,
+		LastTransitionTime: currentTime,
+		LastUpdatedTime:    &currentTime,
 	}
 }

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -67,7 +67,7 @@ func (hc *HealthChecker) getClusterHealthStatus(ctx context.Context) *toolchainv
 func clusterReadyCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
 	return toolchainv1alpha1.Condition{
-		Type:               toolchainv1alpha1.ToolchainClusterReady,
+		Type:               toolchainv1alpha1.ConditionReady,
 		Status:             corev1.ConditionTrue,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterReadyReason,
 		Message:            healthzOk,
@@ -79,7 +79,7 @@ func clusterReadyCondition() toolchainv1alpha1.Condition {
 func clusterNotReadyCondition() toolchainv1alpha1.Condition {
 	currentTime := metav1.Now()
 	return toolchainv1alpha1.Condition{
-		Type:               toolchainv1alpha1.ToolchainClusterReady,
+		Type:               toolchainv1alpha1.ConditionReady,
 		Status:             corev1.ConditionFalse,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReadyReason,
 		Message:            healthzNotOk,

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -71,14 +71,8 @@ func clusterReadyCondition() toolchainv1alpha1.Condition {
 		Status:             corev1.ConditionTrue,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterReadyReason,
 		Message:            healthzOk,
-<<<<<<< HEAD
+		LastUpdatedTime:    &currentTime,
 		LastTransitionTime: currentTime,
-		LastUpdatedTime:    &currentTime,
-=======
-		LastProbeTime:      currentTime,
-		LastUpdatedTime:    &currentTime,
-		LastTransitionTime: &currentTime,
->>>>>>> master
 	}
 }
 
@@ -89,14 +83,8 @@ func clusterNotReadyCondition() toolchainv1alpha1.Condition {
 		Status:             corev1.ConditionFalse,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReadyReason,
 		Message:            healthzNotOk,
-<<<<<<< HEAD
+		LastUpdatedTime:    &currentTime,
 		LastTransitionTime: currentTime,
-		LastUpdatedTime:    &currentTime,
-=======
-		LastProbeTime:      currentTime,
-		LastUpdatedTime:    &currentTime,
-		LastTransitionTime: &currentTime,
->>>>>>> master
 	}
 }
 
@@ -107,14 +95,8 @@ func clusterOfflineCondition() toolchainv1alpha1.Condition {
 		Status:             corev1.ConditionTrue,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterNotReachableReason,
 		Message:            clusterNotReachableMsg,
-<<<<<<< HEAD
+		LastUpdatedTime:    &currentTime,
 		LastTransitionTime: currentTime,
-		LastUpdatedTime:    &currentTime,
-=======
-		LastProbeTime:      currentTime,
-		LastUpdatedTime:    &currentTime,
-		LastTransitionTime: &currentTime,
->>>>>>> master
 	}
 }
 
@@ -125,13 +107,7 @@ func clusterNotOfflineCondition() toolchainv1alpha1.Condition {
 		Status:             corev1.ConditionFalse,
 		Reason:             toolchainv1alpha1.ToolchainClusterClusterReachableReason,
 		Message:            clusterReachableMsg,
-<<<<<<< HEAD
+		LastUpdatedTime:    &currentTime,
 		LastTransitionTime: currentTime,
-		LastUpdatedTime:    &currentTime,
-=======
-		LastProbeTime:      currentTime,
-		LastUpdatedTime:    &currentTime,
-		LastTransitionTime: &currentTime,
->>>>>>> master
 	}
 }

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -148,14 +148,14 @@ ExpConditions:
 }
 func healthy() toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.ToolchainClusterReady,
+		Type:    toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionTrue,
 		Reason:  "ClusterReady",
 		Message: "/healthz responded with ok",
 	}
 }
 func unhealthy() toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterReady,
+	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ConditionReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  "ClusterNotReady",
 		Message: "/healthz responded without ok",

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -41,59 +41,59 @@ func TestClusterHealthChecks(t *testing.T) {
 	tests := map[string]struct {
 		tctype            string
 		apiendpoint       string
-		clusterconditions []toolchainv1alpha1.ToolchainClusterCondition
+		clusterconditions []toolchainv1alpha1.Condition
 		status            toolchainv1alpha1.ToolchainClusterStatus
 	}{
 		//ToolchainCluster.status doesn't contain any conditions
 		"UnstableNoCondition": {
 			tctype:            "unstable",
 			apiendpoint:       "http://unstable.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{unhealthy(), notOffline()},
+			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
 		"StableNoCondition": {
 			tctype:            "stable",
 			apiendpoint:       "http://cluster.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{healthy()},
+			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
 		"NotFoundNoCondition": {
 			tctype:            "not-found",
 			apiendpoint:       "http://not-found.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{offline()},
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
 		//ToolchainCluster.status already contains conditions
 		"UnstableContainsCondition": {
 			tctype:            "unstable",
 			apiendpoint:       "http://unstable.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{unhealthy(), notOffline()},
+			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
 			status:            withStatus(healthy()),
 		},
 		"StableContainsCondition": {
 			tctype:            "stable",
 			apiendpoint:       "http://cluster.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{healthy()},
+			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
 			status:            withStatus(offline()),
 		},
 		"NotFoundContainsCondition": {
 			tctype:            "not-found",
 			apiendpoint:       "http://not-found.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{offline()},
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
 			status:            withStatus(healthy()),
 		},
 		//if the connection cannot be established at beginning, then it should be offline
 		"OfflineConnectionNotEstablished": {
 			tctype:            "failing",
 			apiendpoint:       "http://failing.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{offline()},
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
 		//if no zones nor region is retrieved, then keep the current
 		"NoZoneKeepCurrent": {
 			tctype:            "stable",
 			apiendpoint:       "http://cluster.com",
-			clusterconditions: []toolchainv1alpha1.ToolchainClusterCondition{healthy()},
+			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
 			status:            withStatus(offline()),
 		},
 	}
@@ -123,12 +123,12 @@ func TestClusterHealthChecks(t *testing.T) {
 	}
 }
 
-func withStatus(conditions ...toolchainv1alpha1.ToolchainClusterCondition) toolchainv1alpha1.ToolchainClusterStatus {
+func withStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1alpha1.ToolchainClusterStatus {
 	return toolchainv1alpha1.ToolchainClusterStatus{
 		Conditions: conditions,
 	}
 }
-func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...toolchainv1alpha1.ToolchainClusterCondition) {
+func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...toolchainv1alpha1.Condition) {
 	tc := &toolchainv1alpha1.ToolchainCluster{}
 	err := cl.Get(context.TODO(), test.NamespacedName("test-namespace", clusterName), tc)
 	require.NoError(t, err)
@@ -146,30 +146,30 @@ ExpConditions:
 		assert.Failf(t, "condition not found", "the list of conditions %v doesn't contain the expected condition %v", tc.Status.Conditions, expCond)
 	}
 }
-func healthy() toolchainv1alpha1.ToolchainClusterCondition {
-	return toolchainv1alpha1.ToolchainClusterCondition{
+func healthy() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.ToolchainClusterReady,
 		Status:  corev1.ConditionTrue,
 		Reason:  "ClusterReady",
 		Message: "/healthz responded with ok",
 	}
 }
-func unhealthy() toolchainv1alpha1.ToolchainClusterCondition {
-	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterReady,
+func unhealthy() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterReady,
 		Status:  corev1.ConditionFalse,
 		Reason:  "ClusterNotReady",
 		Message: "/healthz responded without ok",
 	}
 }
-func offline() toolchainv1alpha1.ToolchainClusterCondition {
-	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterOffline,
+func offline() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterOffline,
 		Status:  corev1.ConditionTrue,
 		Reason:  "ClusterNotReachable",
 		Message: "cluster is not reachable",
 	}
 }
-func notOffline() toolchainv1alpha1.ToolchainClusterCondition {
-	return toolchainv1alpha1.ToolchainClusterCondition{Type: toolchainv1alpha1.ToolchainClusterOffline,
+func notOffline() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterOffline,
 		Status:  corev1.ConditionFalse,
 		Reason:  "ClusterReachable",
 		Message: "cluster is reachable",

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -54,7 +54,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	cachedCluster, ok := cluster.GetCachedToolchainCluster(toolchainCluster.Name)
 	if !ok {
 		err := fmt.Errorf("cluster %s not found in cache", toolchainCluster.Name)
-		toolchainCluster.Status.Conditions = []toolchainv1alpha1.ToolchainClusterCondition{clusterOfflineCondition()}
+		toolchainCluster.Status.Conditions = []toolchainv1alpha1.Condition{clusterOfflineCondition()}
 		if err := r.Client.Status().Update(ctx, toolchainCluster); err != nil {
 			reqLogger.Error(err, "failed to update the status of ToolchainCluster")
 		}

--- a/go.mod
+++ b/go.mod
@@ -114,4 +114,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf

--- a/go.mod
+++ b/go.mod
@@ -113,4 +113,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/codeready-toolchain/toolchain-common
 
 go 1.20
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
-
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/go-logr/logr v1.2.3
@@ -115,4 +113,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-common
 go 1.20
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
+	github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7
 	github.com/go-logr/logr v1.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -112,5 +112,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69

--- a/go.mod
+++ b/go.mod
@@ -113,3 +113,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/codeready-toolchain/toolchain-common
 
 go 1.20
 
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7
+
 require (
 	github.com/codeready-toolchain/api v0.0.0-20240514085958-3b5237399fe5
 	github.com/go-logr/logr v1.2.3
@@ -113,4 +115,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f
+

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-common
 go 1.20
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240502171347-8db815b922bd
+	github.com/codeready-toolchain/api v0.0.0-20240507023248-73662d6db2c5
 	github.com/go-logr/logr v1.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -113,4 +113,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf
+replace github.com/codeready-toolchain/api => github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
-github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
+github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
-github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
+github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
-github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f h1:SU/YIxkyXbvXfZMLsxdHb71X0Bs3WHe6vfev9N25VUI=
+github.com/fbm3307/toolchainapi v0.0.0-20240513145519-e72bfb85209f/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7 h1:o5JLcHCVS1BlZevw2mh1mH+iKwn9fLUrT1Ek8NFjvPY=
+github.com/codeready-toolchain/api v0.0.0-20240530120602-c11598ccffb7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -165,8 +167,6 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69 h1:WiMpRk3NnsEeCVzQzD2gzc2EFx15eWCrkdfmGeG2ltU=
-github.com/fbm3307/toolchainapi v0.0.0-20240529064820-9bb19ad24c69/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7 h1:iH+MPU2iq6KN6v161Y0VrlEfp1gyz6zEBDjFkGDwHRU=
-github.com/fbm3307/toolchainapi v0.0.0-20240515061911-dc93afe9cbd7/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b h1:fF3V9dFDmZCzbV2rWkII7b/LJ9hj5yL2zR0vdaXzeK4=
+github.com/fbm3307/toolchainapi v0.0.0-20240527070911-f37a60567c8b/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
-github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf h1:s2k7giZJOHA3EYRya8EqqbkUl4vHJYG2s5g2XL4Eezo=
+github.com/fbm3307/toolchainapi v0.0.0-20240502095518-0d75583a5baf/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb h1:YvEVAetaNYLAyuwO8AmKTtWD9M7SZPhbBzTVMXhrGas=
-github.com/codeready-toolchain/api v0.0.0-20240424103940-03edc96d88fb/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -167,6 +165,8 @@ github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZM
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967 h1:6NHrU9WNkeCnAniKFUb6YhUxKkccYidj5fD/yY912y0=
+github.com/fbm3307/toolchainapi v0.0.0-20240425095952-cd8e9731b967/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -398,7 +398,7 @@ type clusterOption func(*CachedToolchainCluster)
 
 // Ready an option to state the cluster as "ready"
 var ready clusterOption = func(c *CachedToolchainCluster) {
-	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.ToolchainClusterCondition{
+	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ToolchainClusterReady,
 		Status: v1.ConditionTrue,
 	})
@@ -406,7 +406,7 @@ var ready clusterOption = func(c *CachedToolchainCluster) {
 
 // clusterNotReady an option to state the cluster as "not ready"
 var notReady clusterOption = func(c *CachedToolchainCluster) {
-	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.ToolchainClusterCondition{
+	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.Condition{
 		Type:   toolchainv1alpha1.ToolchainClusterReady,
 		Status: v1.ConditionFalse,
 	})

--- a/pkg/cluster/cache_whitebox_test.go
+++ b/pkg/cluster/cache_whitebox_test.go
@@ -399,7 +399,7 @@ type clusterOption func(*CachedToolchainCluster)
 // Ready an option to state the cluster as "ready"
 var ready clusterOption = func(c *CachedToolchainCluster) {
 	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.Condition{
-		Type:   toolchainv1alpha1.ToolchainClusterReady,
+		Type:   toolchainv1alpha1.ConditionReady,
 		Status: v1.ConditionTrue,
 	})
 }
@@ -407,7 +407,7 @@ var ready clusterOption = func(c *CachedToolchainCluster) {
 // clusterNotReady an option to state the cluster as "not ready"
 var notReady clusterOption = func(c *CachedToolchainCluster) {
 	c.ClusterStatus.Conditions = append(c.ClusterStatus.Conditions, toolchainv1alpha1.Condition{
-		Type:   toolchainv1alpha1.ToolchainClusterReady,
+		Type:   toolchainv1alpha1.ConditionReady,
 		Status: v1.ConditionFalse,
 	})
 }

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -218,7 +218,7 @@ func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.Tool
 
 func IsReady(clusterStatus *toolchainv1alpha1.ToolchainClusterStatus) bool {
 	for _, condition := range clusterStatus.Conditions {
-		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
+		if condition.Type == toolchainv1alpha1.ConditionReady {
 			if condition.Status == v1.ConditionTrue {
 				return true
 			}

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -68,7 +68,7 @@ func TestDeleteToolchainClusterWhenDoesNotExist(t *testing.T) {
 
 func TestListToolchainClusterConfigs(t *testing.T) {
 	// given
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
 
 	m1, sec1 := test.NewToolchainClusterWithEndpoint("east", test.HostOperatorNs, "secret1", "http://m1.com", status, map[string]string{"ownerClusterName": "m1ClusterName", "namespace": test.MemberOperatorNs, cluster.RoleLabel(cluster.Tenant): ""})

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -19,7 +19,7 @@ import (
 func TestRefreshCacheInService(t *testing.T) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster, sec := test.NewToolchainCluster("east", test.HostOperatorNs, "secret", status, map[string]string{"ownerClusterName": test.NameMember, "namespace": test.MemberOperatorNs})
 	s := scheme.Scheme
 	err := toolchainv1alpha1.AddToScheme(s)
@@ -74,7 +74,7 @@ func TestRefreshCacheInService(t *testing.T) {
 func TestUpdateClientBasedOnRestConfig(t *testing.T) {
 	// given
 	defer gock.Off()
-	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster1, sec1 := test.NewToolchainCluster("east", test.HostOperatorNs, "secret1", statusTrue,
 		map[string]string{"namespace": test.HostOperatorNs})
 

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -47,7 +47,7 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	foundLastProbeTime := false
 	for _, condition := range toolchainCluster.ClusterStatus.Conditions {
 		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
-			lastProbeTime = condition.LastProbeTime
+			lastProbeTime = condition.LastTransitionTime
 			foundLastProbeTime = true
 		}
 	}

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -46,7 +46,7 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	var lastUpdatedTime metav1.Time
 	foundLastProbeTime := false
 	for _, condition := range toolchainCluster.ClusterStatus.Conditions {
-		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
+		if condition.Type == toolchainv1alpha1.ConditionReady {
 			lastUpdatedTime = *condition.LastUpdatedTime
 			foundLastProbeTime = true
 		}

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -43,11 +43,11 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 		return []toolchainv1alpha1.Condition{*NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, genericErrMsg)}
 	}
 
-	var lastProbeTime metav1.Time
+	var lastUpdatedTime metav1.Time
 	foundLastProbeTime := false
 	for _, condition := range toolchainCluster.ClusterStatus.Conditions {
 		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
-			lastProbeTime = *condition.LastUpdatedTime
+			lastUpdatedTime = *condition.LastUpdatedTime
 			foundLastProbeTime = true
 		}
 
@@ -58,7 +58,7 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	}
 	maxDuration := attrs.Period + attrs.Timeout
 	// check that the last probe time is within limits. It should be less than period + timeout
-	timeSinceLastProbe := time.Since(lastProbeTime.Time)
+	timeSinceLastProbe := time.Since(lastUpdatedTime.Time)
 	if timeSinceLastProbe > maxDuration {
 		err := fmt.Errorf("%s: %s", ErrMsgClusterConnectionLastProbeTimeExceeded, maxDuration.String())
 		logger.Error(err, fmt.Sprintf("the last probe for %s happened before: %s, see: %+v", toolchainCluster.Name, timeSinceLastProbe.String(), toolchainCluster.ClusterStatus))

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -47,12 +47,7 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	foundLastProbeTime := false
 	for _, condition := range toolchainCluster.ClusterStatus.Conditions {
 		if condition.Type == toolchainv1alpha1.ToolchainClusterReady {
-			lastProbeTime = func() metav1.Time {
-				if condition.LastUpdatedTime != nil {
-					return *condition.LastUpdatedTime
-				}
-				return condition.LastProbeTime
-			}()
+			lastProbeTime = *condition.LastUpdatedTime
 			foundLastProbeTime = true
 		}
 

--- a/pkg/status/toolchaincluster.go
+++ b/pkg/status/toolchaincluster.go
@@ -44,15 +44,15 @@ func GetToolchainClusterConditions(logger logr.Logger, attrs ToolchainClusterAtt
 	}
 
 	var lastUpdatedTime metav1.Time
-	foundLastProbeTime := false
+	foundLastUpdatedTime := false
 	for _, condition := range toolchainCluster.ClusterStatus.Conditions {
 		if condition.Type == toolchainv1alpha1.ConditionReady {
 			lastUpdatedTime = *condition.LastUpdatedTime
-			foundLastProbeTime = true
+			foundLastUpdatedTime = true
 		}
 
 	}
-	if !foundLastProbeTime {
+	if !foundLastUpdatedTime {
 		lastProbeNotFoundMsg := "the time of the last probe could not be determined"
 		return []toolchainv1alpha1.Condition{*NewComponentErrorCondition(toolchainv1alpha1.ToolchainStatusClusterConnectionNotReadyReason, lastProbeNotFoundMsg)}
 	}

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -18,9 +18,8 @@ import (
 
 var fakeToolchainClusterReason = "AToolchainClusterReason"
 var fakeToolchainClusterMsg = "AToolchainClusterMsg"
-var probtime = metav1.Now()
-var probtime1 = metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Minute))
-var updatetime = metav1.NewTime(metav1.Now().Add(time.Duration(-3) * time.Second))
+var updatetime1 = metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Minute))
+var updatetime = metav1.Now()
 var log = logf.Log.WithName("toolchaincluster_test")
 
 func TestGetToolchainClusterConditions(t *testing.T) {
@@ -177,33 +176,29 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 }
 
 func newGetHostClusterReady() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, probtime1, fakeToolchainClusterReason, "", &updatetime)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, fakeToolchainClusterReason, "", &updatetime)
 }
 
 func newGetHostClusterNotOk() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(false, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, probtime, fakeToolchainClusterReason, fakeToolchainClusterMsg, nil)
+	return NewFakeGetHostCluster(false, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime)
 }
 
 func newGetHostClusterOkButNotReady(message string) cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, probtime, fakeToolchainClusterReason, message, nil)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, fakeToolchainClusterReason, message, &updatetime)
 }
 
 func newGetHostClusterOkWithClusterOfflineCondition() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterOffline, corev1.ConditionFalse, probtime, fakeToolchainClusterReason, fakeToolchainClusterMsg, nil)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterOffline, corev1.ConditionFalse, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime)
 }
 
 func newGetHostClusterLastProbeTimeExceeded() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, probtime1, fakeToolchainClusterReason, fakeToolchainClusterMsg, nil)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime1)
 }
 
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status and lastProbeTime.
 // If ok == false, then the function returns nil for the cluster.
-<<<<<<< HEAD
-func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string) cluster.GetHostClusterFunc {
-=======
-func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClusterConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string, lastUpdatedTime *metav1.Time) cluster.GetHostClusterFunc {
->>>>>>> master
+func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ConditionType, status corev1.ConditionStatus, reason, message string, lastUpdatedTime *metav1.Time) cluster.GetHostClusterFunc {
 	if !ok {
 		return func() (*cluster.CachedToolchainCluster, bool) {
 			return nil, false
@@ -216,11 +211,10 @@ func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClu
 				OwnerClusterName:  test.MemberClusterName,
 			},
 			ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-				Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
+				Conditions: []toolchainv1alpha1.Condition{{
 					Type:            conditionType,
 					Reason:          reason,
 					Status:          status,
-					LastProbeTime:   lastProbeTime,
 					LastUpdatedTime: lastUpdatedTime,
 				}},
 			},

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -197,7 +197,7 @@ func newGetHostClusterLastProbeTimeExceeded() cluster.GetHostClusterFunc {
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster
 // that is returned by the function then contains the given client and the given status and lastProbeTime.
 // If ok == false, then the function returns nil for the cluster.
-func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClusterConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string) cluster.GetHostClusterFunc {
+func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ConditionType, status corev1.ConditionStatus, lastProbeTime metav1.Time, reason, message string) cluster.GetHostClusterFunc {
 	if !ok {
 		return func() (*cluster.CachedToolchainCluster, bool) {
 			return nil, false
@@ -210,11 +210,11 @@ func NewFakeGetHostCluster(ok bool, conditionType toolchainv1alpha1.ToolchainClu
 				OwnerClusterName:  test.MemberClusterName,
 			},
 			ClusterStatus: &toolchainv1alpha1.ToolchainClusterStatus{
-				Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
-					Type:          conditionType,
-					Reason:        reason,
-					Status:        status,
-					LastProbeTime: lastProbeTime,
+				Conditions: []toolchainv1alpha1.Condition{{
+					Type:               conditionType,
+					Reason:             reason,
+					Status:             status,
+					LastTransitionTime: lastProbeTime,
 				}},
 			},
 		}

--- a/pkg/status/toolchaincluster_test.go
+++ b/pkg/status/toolchaincluster_test.go
@@ -176,15 +176,15 @@ func TestGetToolchainClusterConditions(t *testing.T) {
 }
 
 func newGetHostClusterReady() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, fakeToolchainClusterReason, "", &updatetime)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ConditionReady, corev1.ConditionTrue, fakeToolchainClusterReason, "", &updatetime)
 }
 
 func newGetHostClusterNotOk() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(false, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime)
+	return NewFakeGetHostCluster(false, toolchainv1alpha1.ConditionReady, corev1.ConditionFalse, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime)
 }
 
 func newGetHostClusterOkButNotReady(message string) cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse, fakeToolchainClusterReason, message, &updatetime)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ConditionReady, corev1.ConditionFalse, fakeToolchainClusterReason, message, &updatetime)
 }
 
 func newGetHostClusterOkWithClusterOfflineCondition() cluster.GetHostClusterFunc {
@@ -192,7 +192,7 @@ func newGetHostClusterOkWithClusterOfflineCondition() cluster.GetHostClusterFunc
 }
 
 func newGetHostClusterLastProbeTimeExceeded() cluster.GetHostClusterFunc {
-	return NewFakeGetHostCluster(true, toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime1)
+	return NewFakeGetHostCluster(true, toolchainv1alpha1.ConditionReady, corev1.ConditionTrue, fakeToolchainClusterReason, fakeToolchainClusterMsg, &updatetime1)
 }
 
 // NewGetHostCluster returns cluster.GetHostClusterFunc function. The cluster.CachedToolchainCluster

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -50,9 +50,9 @@ func NewToolchainClusterWithEndpoint(name, tcNs, secName, apiEndpoint string, st
 	}, secret
 }
 
-func NewClusterStatus(conType toolchainv1alpha1.ToolchainClusterConditionType, conStatus corev1.ConditionStatus) toolchainv1alpha1.ToolchainClusterStatus {
+func NewClusterStatus(conType toolchainv1alpha1.ConditionType, conStatus corev1.ConditionStatus) toolchainv1alpha1.ToolchainClusterStatus {
 	return toolchainv1alpha1.ToolchainClusterStatus{
-		Conditions: []toolchainv1alpha1.ToolchainClusterCondition{{
+		Conditions: []toolchainv1alpha1.Condition{{
 			Type:   conType,
 			Status: conStatus,
 		}},

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -23,7 +23,7 @@ type FunctionToVerify func(toolchainCluster *toolchainv1alpha1.ToolchainCluster,
 func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 
 	t.Run("add member ToolchainCluster with namespace label set", func(t *testing.T) {
 		for _, withCA := range []bool{true, false} {
@@ -77,7 +77,7 @@ func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify
 func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionFalse)
 	t.Run("add host ToolchainCluster with namespace label set", func(t *testing.T) {
 		for _, withCA := range []bool{true, false} {
 			toolchainCluster, sec := test.NewToolchainCluster("east", test.MemberOperatorNs, "secret", status, Labels("host-ns", test.NameMember))
@@ -134,7 +134,7 @@ func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) 
 func AddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster, _ := test.NewToolchainCluster("east", test.MemberOperatorNs, "secret", status, Labels("", test.NameHost))
 	cl := test.NewFakeClient(t, toolchainCluster)
 	service := newToolchainClusterService(t, cl, false)
@@ -152,7 +152,7 @@ func AddToolchainClusterFailsBecauseOfMissingSecret(t *testing.T, functionToVeri
 func AddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster, _ := test.NewToolchainCluster("east", test.MemberOperatorNs, "secret", status,
 		Labels(test.MemberOperatorNs, test.NameHost))
 	secret := &corev1.Secret{
@@ -176,10 +176,10 @@ func AddToolchainClusterFailsBecauseOfEmptySecret(t *testing.T, functionToVerify
 func UpdateToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster1, sec1 := test.NewToolchainCluster("east", test.HostOperatorNs, "secret1", statusTrue,
 		Labels(test.HostOperatorNs, test.NameMember))
-	statusFalse := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionFalse)
+	statusFalse := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionFalse)
 	toolchainCluster2, sec2 := test.NewToolchainCluster("east", test.HostOperatorNs, "secret2", statusFalse,
 		Labels(test.HostOperatorNs, test.NameMember))
 	cl := test.NewFakeClient(t, toolchainCluster2, sec1, sec2)
@@ -207,7 +207,7 @@ func UpdateToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 func DeleteToolchainCluster(t *testing.T, functionToVerify FunctionToVerify) {
 	// given
 	defer gock.Off()
-	status := test.NewClusterStatus(toolchainv1alpha1.ToolchainClusterReady, corev1.ConditionTrue)
+	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	toolchainCluster, sec := test.NewToolchainCluster("east", test.MemberOperatorNs, "sec", status,
 		Labels(test.MemberOperatorNs, test.NameHost))
 	cl := test.NewFakeClient(t, sec)


### PR DESCRIPTION
This is to replace the special ToolchainClusterCondition with the standard toolchain Condition.

This is  Related to Change in 
- API - https://github.com/codeready-toolchain/api/pull/416
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1017
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/560
- Toolchain-E2E - https://github.com/codeready-toolchain/toolchain-e2e/pull/955
- KSCTL - https://github.com/kubesaw/ksctl/pull/38

Only change is updating the dependency of API and toolchain-common
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/424
- Sandbox-SRE - https://github.com/codeready-toolchain/sandbox-sre/pull/1706

