### PR TITLE
add .gitleaks.toml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,5 +2,5 @@
   description = "Global Allowlist"
 
   paths = [
-    '''pkg/test/auth/tokenmanager.go''',
+    '''^pkg/test/auth/tokenmanager.go$''',
   ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,0 @@
-[allowlist]
-  description = "Global Allowlist"
-
-  paths = [
-    '''^pkg/test/auth/tokenmanager.go$''',
-  ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  paths = [
+    '''pkg/test/auth/tokenmanager.go''',
+  ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,6 @@
+[allowlist]
+  description = "Global Allowlist"
+
+  paths = [
+    '''^pkg/test/auth/tokenmanager.go$''',
+  ]

--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -21,11 +21,6 @@ const (
 	e2ePrivateKID = "d5693c31-7016-46a4-bbe4-867e6d6a3b3a"
 )
 
-var (
-	e2eTestPrivateKey *rsa.PrivateKey
-	e2ePKOnce         sync.Once
-)
-
 // WebKeySet represents a JWK Set object.
 type WebKeySet struct {
 	Keys []jwk.Key `json:"keys"`
@@ -306,6 +301,11 @@ func GetE2ETestPublicKey() []*PublicKey {
 
 	return publicKeys
 }
+
+var (
+	e2eTestPrivateKey *rsa.PrivateKey
+	e2ePKOnce         sync.Once
+)
 
 // getE2ETestPrivateKey returns the e2e private key from the PEM.
 func getE2ETestPrivateKey() *rsa.PrivateKey {

--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -3,14 +3,11 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"sync"
 	"time"
 
 	uuid "github.com/gofrs/uuid"
@@ -20,36 +17,7 @@ import (
 )
 
 const (
-	bitSize = 2048
-	//nolint:gosec
-	e2ePrivatePEM = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEApnQLIhfCVZPJKt5D5SCRUhJ/N5aCsRNlnowqMFzhUF7DF5kb
-YWoE8YWF6YcLuyfh/NChAVkixd4zOvyOtVuOjFao/1/2HmKlGxeJ4JhlF1PBXMZV
-L53aInEaP4A8J5kAghN74P+Uz1ax1/eF8FjV711ETZDiwYUYXvbPaIdb8WvCU7tG
-A5v63My+6PrrDia1xgOevOicV/qxKWdb3stFQ52x/hJKHuMbyGTjSJ6tXdnJZ3ND
-j04OBLI0Z1uNShHcGPqp9foAX02dGEJvmBorDg7O1egVNGRYEK7DJ8Y0T50EXGpr
-gJaSYjYMTL6u2Ds9vLzjircigD+F2ltJdbhSsQIDAQABAoIBADBsB6UWVlFA2b+f
-ww6Pp9bBTMLmBQTwSJqT2d4R1vXja0udHar8BY4hMrCZuZ7rXkGGi5/xxzzag/q/
-59/4T4Kh3y3TQ6zZM4CrG0/75USg99o+VB+zAvcMAf/BFT7LsqskceAlWavrY3cZ
-KZyeqzWj4y/RWzXCuzE9CV82KVgUcccKofwK6ZauwXDke2xRruaOMeJ4mP62xgNp
-hVy0W/La5sqrq24EzJ/0hEMJYg+Z0udOzLofl5NqAoPrazgdZg1oVxbGY0sSUEax
-kA/nIlUskiNTgCYrRAeWrI1p6L0LtKMQ+KMs5ek5lI3k2K6EViHXO5kelOKeIas0
-hVo0tfECgYEA2NeYtkPIZDzGonu60/52FpJyLzoW9mxc8UBa9/p/CgMC/UzdyxbL
-ys4Tw/BuXxwPx0shAI/txlfqd3Dl9z3HF+e84VOIph3VqYFh9cBkZQI9z55pP5kt
-o8UW1SWUA799QTIZRhdFrPspaPISiWXgGAiHfaOy6SMM/ghTU22+Dm0CgYEAxIME
-lycBt7dsfvbb41OsVeH61mYeC7ZB6FNLhF7X2CqH9ybhMGqUnYvN+/EHMElWR/ky
-xe68Hcsvq3sSmEv1SHjAk6WottjpdwwCXvDKWu3LEjR6o3i2VRTCL1jJD9OlcJnk
-tSdI2gp/rTQrcm/ANY9KcmYfAyq/xe7DkOkUWtUCgYEAuAUXKy6Q5EgThhacsYXU
-L0mur1eL3yqNIYus559kqllt8wqFevFolz6V1YW4FOzakxW19yUt81Huv9hGwLBj
-wmy+hTZ/1AGjrksHmCfiyznAvO5BgWB8M+xxeQd/+kJKiMZ8XlgnoCoxtUch5gpX
-x+2NFlmS3nkJcJgeJsIONW0CgYAPW7YGIjROKXW/TofM8oMriyfRjdWXUL1B7RCf
-3dG8wUYzGMTMxeerkHuezy2ipnip014WfhwRsAmfu1SutnELIvTaFT5kW/uTJEsj
-JGqMRL10RMm48Pw/Fgo/LQ85v27UqBJp3hIhiGSGIueqX/WDuhk1a6nM05B9ZbW/
-I5hFqQKBgEktcozzuQL0EcyTJ+wFPSoma4qdAqbYf4sUWC9ebrzVd2/plhVRren7
-nmblwgPUKfdPKPe9ckWQOaHAIpNsq5Baxjq2wxFWZOvxH2qWmVmljEeoiTRdTHoF
-sMnQfhExyZp/T6uc3rgP0yyOFzSbZrnXpzZ9CZtfqbsfjGKwEbq7
------END RSA PRIVATE KEY-----
-`
+	bitSize       = 2048
 	e2ePrivateKID = "d5693c31-7016-46a4-bbe4-867e6d6a3b3a"
 )
 
@@ -334,23 +302,24 @@ func GetE2ETestPublicKey() []*PublicKey {
 	return publicKeys
 }
 
+var (
+	e2eTestPrivateKey *rsa.PrivateKey
+	e2ePKOnce         sync.Once
+)
+
 // getE2ETestPrivateKey returns the e2e private key from the PEM.
 func getE2ETestPrivateKey() *rsa.PrivateKey {
-	r := strings.NewReader(e2ePrivatePEM)
-	pemBytes, err := io.ReadAll(r)
-	if err != nil {
-		return nil
-	}
+	e2ePKOnce.Do(func() {
+		pk, err := rsa.GenerateKey(rand.Reader, bitSize)
+		if err != nil {
+			return
+		}
 
-	block, _ := pem.Decode(pemBytes)
-	if block == nil {
-		return nil
-	}
+		if err := pk.Validate(); err != nil {
+			return
+		}
 
-	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-	if err != nil {
-		return nil
-	}
-
-	return privateKey
+		e2eTestPrivateKey = pk
+	})
+	return e2eTestPrivateKey
 }

--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -3,11 +3,14 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
-	"sync"
+	"strings"
 	"time"
 
 	uuid "github.com/gofrs/uuid"
@@ -17,7 +20,36 @@ import (
 )
 
 const (
-	bitSize       = 2048
+	bitSize = 2048
+	//nolint:gosec
+	e2ePrivatePEM = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEApnQLIhfCVZPJKt5D5SCRUhJ/N5aCsRNlnowqMFzhUF7DF5kb
+YWoE8YWF6YcLuyfh/NChAVkixd4zOvyOtVuOjFao/1/2HmKlGxeJ4JhlF1PBXMZV
+L53aInEaP4A8J5kAghN74P+Uz1ax1/eF8FjV711ETZDiwYUYXvbPaIdb8WvCU7tG
+A5v63My+6PrrDia1xgOevOicV/qxKWdb3stFQ52x/hJKHuMbyGTjSJ6tXdnJZ3ND
+j04OBLI0Z1uNShHcGPqp9foAX02dGEJvmBorDg7O1egVNGRYEK7DJ8Y0T50EXGpr
+gJaSYjYMTL6u2Ds9vLzjircigD+F2ltJdbhSsQIDAQABAoIBADBsB6UWVlFA2b+f
+ww6Pp9bBTMLmBQTwSJqT2d4R1vXja0udHar8BY4hMrCZuZ7rXkGGi5/xxzzag/q/
+59/4T4Kh3y3TQ6zZM4CrG0/75USg99o+VB+zAvcMAf/BFT7LsqskceAlWavrY3cZ
+KZyeqzWj4y/RWzXCuzE9CV82KVgUcccKofwK6ZauwXDke2xRruaOMeJ4mP62xgNp
+hVy0W/La5sqrq24EzJ/0hEMJYg+Z0udOzLofl5NqAoPrazgdZg1oVxbGY0sSUEax
+kA/nIlUskiNTgCYrRAeWrI1p6L0LtKMQ+KMs5ek5lI3k2K6EViHXO5kelOKeIas0
+hVo0tfECgYEA2NeYtkPIZDzGonu60/52FpJyLzoW9mxc8UBa9/p/CgMC/UzdyxbL
+ys4Tw/BuXxwPx0shAI/txlfqd3Dl9z3HF+e84VOIph3VqYFh9cBkZQI9z55pP5kt
+o8UW1SWUA799QTIZRhdFrPspaPISiWXgGAiHfaOy6SMM/ghTU22+Dm0CgYEAxIME
+lycBt7dsfvbb41OsVeH61mYeC7ZB6FNLhF7X2CqH9ybhMGqUnYvN+/EHMElWR/ky
+xe68Hcsvq3sSmEv1SHjAk6WottjpdwwCXvDKWu3LEjR6o3i2VRTCL1jJD9OlcJnk
+tSdI2gp/rTQrcm/ANY9KcmYfAyq/xe7DkOkUWtUCgYEAuAUXKy6Q5EgThhacsYXU
+L0mur1eL3yqNIYus559kqllt8wqFevFolz6V1YW4FOzakxW19yUt81Huv9hGwLBj
+wmy+hTZ/1AGjrksHmCfiyznAvO5BgWB8M+xxeQd/+kJKiMZ8XlgnoCoxtUch5gpX
+x+2NFlmS3nkJcJgeJsIONW0CgYAPW7YGIjROKXW/TofM8oMriyfRjdWXUL1B7RCf
+3dG8wUYzGMTMxeerkHuezy2ipnip014WfhwRsAmfu1SutnELIvTaFT5kW/uTJEsj
+JGqMRL10RMm48Pw/Fgo/LQ85v27UqBJp3hIhiGSGIueqX/WDuhk1a6nM05B9ZbW/
+I5hFqQKBgEktcozzuQL0EcyTJ+wFPSoma4qdAqbYf4sUWC9ebrzVd2/plhVRren7
+nmblwgPUKfdPKPe9ckWQOaHAIpNsq5Baxjq2wxFWZOvxH2qWmVmljEeoiTRdTHoF
+sMnQfhExyZp/T6uc3rgP0yyOFzSbZrnXpzZ9CZtfqbsfjGKwEbq7
+-----END RSA PRIVATE KEY-----
+`
 	e2ePrivateKID = "d5693c31-7016-46a4-bbe4-867e6d6a3b3a"
 )
 
@@ -302,24 +334,23 @@ func GetE2ETestPublicKey() []*PublicKey {
 	return publicKeys
 }
 
-var (
-	e2eTestPrivateKey *rsa.PrivateKey
-	e2ePKOnce         sync.Once
-)
-
 // getE2ETestPrivateKey returns the e2e private key from the PEM.
 func getE2ETestPrivateKey() *rsa.PrivateKey {
-	e2ePKOnce.Do(func() {
-		pk, err := rsa.GenerateKey(rand.Reader, bitSize)
-		if err != nil {
-			return
-		}
+	r := strings.NewReader(e2ePrivatePEM)
+	pemBytes, err := io.ReadAll(r)
+	if err != nil {
+		return nil
+	}
 
-		if err := pk.Validate(); err != nil {
-			return
-		}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil
+	}
 
-		e2eTestPrivateKey = pk
-	})
-	return e2eTestPrivateKey
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil
+	}
+
+	return privateKey
 }

--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -21,6 +21,11 @@ const (
 	e2ePrivateKID = "d5693c31-7016-46a4-bbe4-867e6d6a3b3a"
 )
 
+var (
+	e2eTestPrivateKey *rsa.PrivateKey
+	e2ePKOnce         sync.Once
+)
+
 // WebKeySet represents a JWK Set object.
 type WebKeySet struct {
 	Keys []jwk.Key `json:"keys"`
@@ -301,11 +306,6 @@ func GetE2ETestPublicKey() []*PublicKey {
 
 	return publicKeys
 }
-
-var (
-	e2eTestPrivateKey *rsa.PrivateKey
-	e2ePKOnce         sync.Once
-)
 
 // getE2ETestPrivateKey returns the e2e private key from the PEM.
 func getE2ETestPrivateKey() *rsa.PrivateKey {


### PR DESCRIPTION
This PR excludes the file `pkg/test/auth/tokenmanager.go` from the GitLeaks checks. It is actually containing a certificate that prevents the git hook to complete successfully.

Signed-off-by: Francesco Ilario <filario@redhat.com>
