### PR TITLE
KUBESAW-100: Refactoring toolchaincluster controller

### DIFF
--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -19,8 +19,8 @@ const (
 	clusterReachableMsg    = "cluster is reachable"
 )
 
-// getClusterHealthStatus gets the kubernetes cluster health status by requesting "/healthz"
-func getClusterHealthStatus(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) []v1alpha1.Condition {
+// GetClusterHealthStatus gets the kubernetes cluster health status by requesting "/healthz"
+func GetClusterHealthStatus(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) []v1alpha1.Condition {
 	lgr := log.FromContext(ctx)
 	conditions := []v1alpha1.Condition{}
 	body, err := remoteClusterClientset.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do(ctx).Raw()

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -9,10 +9,8 @@ import (
 )
 
 const (
-	healthzOk              = "/healthz responded with ok"
-	healthzNotOk           = "/healthz responded without ok"
-	clusterNotReachableMsg = "cluster is not reachable"
-	clusterReachableMsg    = "cluster is reachable"
+	healthzOk    = "/healthz responded with ok"
+	healthzNotOk = "/healthz responded without ok"
 )
 
 // getClusterHealth gets the kubernetes cluster health status by requesting "/healthz"

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -15,8 +15,8 @@ const (
 	clusterReachableMsg    = "cluster is reachable"
 )
 
-// GetClusterHealth gets the kubernetes cluster health status by requesting "/healthz"
-func GetClusterHealth(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) (bool, error) {
+// getClusterHealth gets the kubernetes cluster health status by requesting "/healthz"
+func getClusterHealthStatus(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) (bool, error) {
 
 	lgr := log.FromContext(ctx)
 	body, err := remoteClusterClientset.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do(ctx).Raw()

--- a/controllers/toolchaincluster/healthchecker.go
+++ b/controllers/toolchaincluster/healthchecker.go
@@ -23,11 +23,7 @@ func getClusterHealthStatus(ctx context.Context, remoteClusterClientset *kubecli
 	if err != nil {
 		lgr.Error(err, "Failed to do cluster health check for a ToolchainCluster")
 		return false, err
-	} else {
-		if !strings.EqualFold(string(body), "ok") {
-			return false, nil
-		} else {
-			return true, nil
-		}
 	}
+	return strings.EqualFold(string(body), "ok"), nil
+
 }

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -97,7 +97,7 @@ func TestClusterHealthChecks(t *testing.T) {
 			require.NoError(t, err)
 
 			//when
-			hcond := getClusterHealthStatus(context.TODO(), cacheclient)
+			hcond := GetClusterHealthStatus(context.TODO(), cacheclient)
 
 			//then
 			assert.Len(t, tc.clusterconditions, len(hcond))

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -5,22 +5,21 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
+	kubeclientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var logger = logf.Log.WithName("toolchaincluster_healthcheck")
 
 func TestClusterHealthChecks(t *testing.T) {
 
 	// given
 	defer gock.Off()
-	//tcNs := "test-namespace"
+	tcNs := "test-namespace"
 	gock.New("http://cluster.com").
 		Get("healthz").
 		Persist().
@@ -43,89 +42,86 @@ func TestClusterHealthChecks(t *testing.T) {
 		status            toolchainv1alpha1.ToolchainClusterStatus
 	}{
 		//ToolchainCluster.status doesn't contain any conditions
-		"UnstableNoCondition": {
-			tctype:            "unstable",
-			apiendpoint:       "http://unstable.com",
-			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
-			status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		},
+		// "UnstableNoCondition": {
+		// 	tctype:            "unstable",
+		// 	apiendpoint:       "http://unstable.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
+		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		// },
 		"StableNoCondition": {
 			tctype:            "stable",
 			apiendpoint:       "http://cluster.com",
 			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
-		"NotFoundNoCondition": {
-			tctype:            "not-found",
-			apiendpoint:       "http://not-found.com",
-			clusterconditions: []toolchainv1alpha1.Condition{offline()},
-			status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		},
+		// "NotFoundNoCondition": {
+		// 	tctype:            "not-found",
+		// 	apiendpoint:       "http://not-found.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
+		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		// },
 		//ToolchainCluster.status already contains conditions
-		"UnstableContainsCondition": {
-			tctype:            "unstable",
-			apiendpoint:       "http://unstable.com",
-			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
-			status:            withStatus(healthy()),
-		},
-		"StableContainsCondition": {
-			tctype:            "stable",
-			apiendpoint:       "http://cluster.com",
-			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
-			status:            withStatus(offline()),
-		},
-		"NotFoundContainsCondition": {
-			tctype:            "not-found",
-			apiendpoint:       "http://not-found.com",
-			clusterconditions: []toolchainv1alpha1.Condition{offline()},
-			status:            withStatus(healthy()),
-		},
-		//if the connection cannot be established at beginning, then it should be offline
-		"OfflineConnectionNotEstablished": {
-			tctype:            "failing",
-			apiendpoint:       "http://failing.com",
-			clusterconditions: []toolchainv1alpha1.Condition{offline()},
-			status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		},
-		//if no zones nor region is retrieved, then keep the current
-		"NoZoneKeepCurrent": {
-			tctype:            "stable",
-			apiendpoint:       "http://cluster.com",
-			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
-			status:            withStatus(offline()),
-		},
+		// "UnstableContainsCondition": {
+		// 	tctype:            "unstable",
+		// 	apiendpoint:       "http://unstable.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
+		// 	status:            withStatus(healthy()),
+		// },
+		// "StableContainsCondition": {
+		// 	tctype:            "stable",
+		// 	apiendpoint:       "http://cluster.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{healthy()},
+		// 	status:            withStatus(offline()),
+		// },
+		// "NotFoundContainsCondition": {
+		// 	tctype:            "not-found",
+		// 	apiendpoint:       "http://not-found.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
+		// 	status:            withStatus(healthy()),
+		// },
+		// //if the connection cannot be established at beginning, then it should be offline
+		// "OfflineConnectionNotEstablished": {
+		// 	tctype:            "failing",
+		// 	apiendpoint:       "http://failing.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
+		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		// },
+		// //if no zones nor region is retrieved, then keep the current
+		// "NoZoneKeepCurrent": {
+		// 	tctype:            "stable",
+		// 	apiendpoint:       "http://cluster.com",
+		// 	clusterconditions: []toolchainv1alpha1.Condition{healthy()},
+		// 	status:            withStatus(offline()),
+		// },
 	}
-	for k, _ := range tests {
+	for k, tc := range tests {
 		t.Run(k, func(t *testing.T) {
-			// tctype, sec := newToolchainCluster(tc.tctype, tcNs, tc.apiendpoint, tc.status)
-			// cl := test.NewFakeClient(t, tctype, sec)
-			// reset := setupCachedClusters(t, cl, tctype)
-			// defer reset()
-			// cachedtc, found := cluster.GetCachedToolchainCluster(tctype.Name)
-			// require.True(t, found)
-			// cacheclient, err := kubeclientset.NewForConfig(cachedtc.RestConfig)
-			// require.NoError(t, err)
-			// healthChecker := &HealthChecker{
-			// 	localClusterClient:     cl,
-			// 	remoteClusterClient:    cachedtc.Client,
-			// 	remoteClusterClientset: cacheclient,
-			// 	logger:                 logger,
-			// }
-			// when
-			//err = healthChecker.updateIndividualClusterStatus(context.TODO(), tctype)
+			tctype, sec := newToolchainCluster(tc.tctype, tcNs, tc.apiendpoint, tc.status)
+			cl := test.NewFakeClient(t, tctype, sec)
+			reset := setupCachedClusters(t, cl, tctype)
+			defer reset()
+			cachedtc, found := cluster.GetCachedToolchainCluster(tctype.Name)
+			require.True(t, found)
+			cacheclient, err := kubeclientset.NewForConfig(cachedtc.RestConfig)
+			require.NoError(t, err)
 
+			//when
+			hcond := getClusterHealthStatus(context.TODO(), cacheclient)
+			//fmt.Printf("hcond %+v", hcond)
 			//then
-			// require.NoError(t, err)
-			// assertClusterStatus(t, cl, tc.tctype, tc.clusterconditions...)
+			require.NoError(t, err)
+			//fmt.Printf("tc cond %+v", tc.clusterconditions)
+			//assertClusterStatus(t, cl, tc.tctype, hcond...)
+			assert.Equal(t, hcond[0].Status, tc.clusterconditions[0].Status)
 		})
 	}
 }
 
-func withStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1alpha1.ToolchainClusterStatus {
-	return toolchainv1alpha1.ToolchainClusterStatus{
-		Conditions: conditions,
-	}
-}
+//	func withStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1alpha1.ToolchainClusterStatus {
+//		return toolchainv1alpha1.ToolchainClusterStatus{
+//			Conditions: conditions,
+//		}
+//	}
 func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...toolchainv1alpha1.Condition) {
 	tc := &toolchainv1alpha1.ToolchainCluster{}
 	err := cl.Get(context.TODO(), test.NamespacedName("test-namespace", clusterName), tc)

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -34,49 +34,49 @@ func TestClusterHealthChecks(t *testing.T) {
 		Reply(404)
 
 	tests := map[string]struct {
-		tctype      string
-		apiendpoint string
-		healthcheck bool
-		errh        error
+		tcType      string
+		apiEndPoint string
+		healthCheck bool
+		err         error
 	}{
 		"HealthOkay": {
-			tctype:      "stable",
-			apiendpoint: "http://cluster.com",
-			healthcheck: true,
+			tcType:      "stable",
+			apiEndPoint: "http://cluster.com",
+			healthCheck: true,
 		},
 		"HealthNotOkayButNoError": {
-			tctype:      "unstable",
-			apiendpoint: "http://unstable.com",
-			healthcheck: false,
+			tcType:      "unstable",
+			apiEndPoint: "http://unstable.com",
+			healthCheck: false,
 		},
 		"ErrorWhileDoingHealth": {
-			tctype:      "Notfound",
-			apiendpoint: "http://not-found.com",
-			healthcheck: false,
-			errh:        fmt.Errorf("the server could not find the requested resource"),
+			tcType:      "Notfound",
+			apiEndPoint: "http://not-found.com",
+			healthCheck: false,
+			err:         fmt.Errorf("the server could not find the requested resource"),
 		},
 	}
 	for k, tc := range tests {
 		t.Run(k, func(t *testing.T) {
 			//given
-			tctype, sec := newToolchainCluster(tc.tctype, tcNs, tc.apiendpoint, toolchainv1alpha1.ToolchainClusterStatus{})
-			cl := test.NewFakeClient(t, tctype, sec)
-			reset := setupCachedClusters(t, cl, tctype)
+			tcType, sec := newToolchainCluster(tc.tcType, tcNs, tc.apiEndPoint, toolchainv1alpha1.ToolchainClusterStatus{})
+			cl := test.NewFakeClient(t, tcType, sec)
+			reset := setupCachedClusters(t, cl, tcType)
 			defer reset()
-			cachedtc, found := cluster.GetCachedToolchainCluster(tctype.Name)
+			cachedTC, found := cluster.GetCachedToolchainCluster(tcType.Name)
 			require.True(t, found)
-			cacheclient, err := kubeclientset.NewForConfig(cachedtc.RestConfig)
+			cacheClient, err := kubeclientset.NewForConfig(cachedTC.RestConfig)
 			require.NoError(t, err)
 
 			//when
-			healthcheck, errh := getClusterHealthStatus(context.TODO(), cacheclient)
+			healthCheck, err := getClusterHealthStatus(context.TODO(), cacheClient)
 
 			//then
-			require.Equal(t, tc.healthcheck, healthcheck)
-			if tc.errh != nil {
-				require.EqualError(t, errh, tc.errh.Error())
+			require.Equal(t, tc.healthCheck, healthCheck)
+			if tc.err != nil {
+				require.EqualError(t, err, tc.err.Error())
 			} else {
-				require.NoError(t, errh)
+				require.NoError(t, err)
 			}
 
 		})

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -42,13 +42,11 @@ func TestClusterHealthChecks(t *testing.T) {
 			tctype:      "stable",
 			apiendpoint: "http://cluster.com",
 			healthcheck: true,
-			errh:        nil,
 		},
 		"HealthNotOkayButNoError": {
 			tctype:      "unstable",
 			apiendpoint: "http://unstable.com",
 			healthcheck: false,
-			errh:        nil,
 		},
 		"ErrorWhileDoingHealth": {
 			tctype:      "Notfound",
@@ -76,7 +74,7 @@ func TestClusterHealthChecks(t *testing.T) {
 			if tc.tctype == "Notfound" {
 				require.Error(t, errh)
 			} else {
-				require.Equal(t, tc.errh, errh)
+				require.NoError(t, errh)
 			}
 
 		})

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	corev1 "k8s.io/api/core/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 )
 
@@ -88,34 +87,4 @@ func TestClusterHealthChecks(t *testing.T) {
 		require.Equal(t, false, health)
 
 	})
-}
-
-func healthy() toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{
-		Type:    toolchainv1alpha1.ConditionReady,
-		Status:  corev1.ConditionTrue,
-		Reason:  "ClusterReady",
-		Message: "/healthz responded with ok",
-	}
-}
-func unhealthy() toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ConditionReady,
-		Status:  corev1.ConditionFalse,
-		Reason:  "ClusterNotReady",
-		Message: "/healthz responded without ok",
-	}
-}
-func offline() toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterOffline,
-		Status:  corev1.ConditionTrue,
-		Reason:  "ClusterNotReachable",
-		Message: "cluster is not reachable",
-	}
-}
-func notOffline() toolchainv1alpha1.Condition {
-	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterOffline,
-		Status:  corev1.ConditionFalse,
-		Reason:  "ClusterReachable",
-		Message: "cluster is reachable",
-	}
 }

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -5,13 +5,11 @@ import (
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
-	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
-	kubeclientset "k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -22,7 +20,7 @@ func TestClusterHealthChecks(t *testing.T) {
 
 	// given
 	defer gock.Off()
-	tcNs := "test-namespace"
+	//tcNs := "test-namespace"
 	gock.New("http://cluster.com").
 		Get("healthz").
 		Persist().
@@ -97,28 +95,28 @@ func TestClusterHealthChecks(t *testing.T) {
 			status:            withStatus(offline()),
 		},
 	}
-	for k, tc := range tests {
+	for k, _ := range tests {
 		t.Run(k, func(t *testing.T) {
-			tctype, sec := newToolchainCluster(tc.tctype, tcNs, tc.apiendpoint, tc.status)
-			cl := test.NewFakeClient(t, tctype, sec)
-			reset := setupCachedClusters(t, cl, tctype)
-			defer reset()
-			cachedtc, found := cluster.GetCachedToolchainCluster(tctype.Name)
-			require.True(t, found)
-			cacheclient, err := kubeclientset.NewForConfig(cachedtc.RestConfig)
-			require.NoError(t, err)
-			healthChecker := &HealthChecker{
-				localClusterClient:     cl,
-				remoteClusterClient:    cachedtc.Client,
-				remoteClusterClientset: cacheclient,
-				logger:                 logger,
-			}
+			// tctype, sec := newToolchainCluster(tc.tctype, tcNs, tc.apiendpoint, tc.status)
+			// cl := test.NewFakeClient(t, tctype, sec)
+			// reset := setupCachedClusters(t, cl, tctype)
+			// defer reset()
+			// cachedtc, found := cluster.GetCachedToolchainCluster(tctype.Name)
+			// require.True(t, found)
+			// cacheclient, err := kubeclientset.NewForConfig(cachedtc.RestConfig)
+			// require.NoError(t, err)
+			// healthChecker := &HealthChecker{
+			// 	localClusterClient:     cl,
+			// 	remoteClusterClient:    cachedtc.Client,
+			// 	remoteClusterClientset: cacheclient,
+			// 	logger:                 logger,
+			// }
 			// when
-			err = healthChecker.updateIndividualClusterStatus(context.TODO(), tctype)
+			//err = healthChecker.updateIndividualClusterStatus(context.TODO(), tctype)
 
 			//then
-			require.NoError(t, err)
-			assertClusterStatus(t, cl, tc.tctype, tc.clusterconditions...)
+			// require.NoError(t, err)
+			// assertClusterStatus(t, cl, tc.tctype, tc.clusterconditions...)
 		})
 	}
 }

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -42,57 +42,57 @@ func TestClusterHealthChecks(t *testing.T) {
 		status            toolchainv1alpha1.ToolchainClusterStatus
 	}{
 		//ToolchainCluster.status doesn't contain any conditions
-		// "UnstableNoCondition": {
-		// 	tctype:            "unstable",
-		// 	apiendpoint:       "http://unstable.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
-		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		// },
+		"UnstableNoCondition": {
+			tctype:            "unstable",
+			apiendpoint:       "http://unstable.com",
+			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
+			status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		},
 		"StableNoCondition": {
 			tctype:            "stable",
 			apiendpoint:       "http://cluster.com",
 			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
 			status:            toolchainv1alpha1.ToolchainClusterStatus{},
 		},
-		// "NotFoundNoCondition": {
-		// 	tctype:            "not-found",
-		// 	apiendpoint:       "http://not-found.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
-		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		// },
+		"NotFoundNoCondition": {
+			tctype:            "not-found",
+			apiendpoint:       "http://not-found.com",
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
+			status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		},
 		//ToolchainCluster.status already contains conditions
-		// "UnstableContainsCondition": {
-		// 	tctype:            "unstable",
-		// 	apiendpoint:       "http://unstable.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
-		// 	status:            withStatus(healthy()),
-		// },
-		// "StableContainsCondition": {
-		// 	tctype:            "stable",
-		// 	apiendpoint:       "http://cluster.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{healthy()},
-		// 	status:            withStatus(offline()),
-		// },
-		// "NotFoundContainsCondition": {
-		// 	tctype:            "not-found",
-		// 	apiendpoint:       "http://not-found.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
-		// 	status:            withStatus(healthy()),
-		// },
-		// //if the connection cannot be established at beginning, then it should be offline
-		// "OfflineConnectionNotEstablished": {
-		// 	tctype:            "failing",
-		// 	apiendpoint:       "http://failing.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{offline()},
-		// 	status:            toolchainv1alpha1.ToolchainClusterStatus{},
-		// },
-		// //if no zones nor region is retrieved, then keep the current
-		// "NoZoneKeepCurrent": {
-		// 	tctype:            "stable",
-		// 	apiendpoint:       "http://cluster.com",
-		// 	clusterconditions: []toolchainv1alpha1.Condition{healthy()},
-		// 	status:            withStatus(offline()),
-		// },
+		"UnstableContainsCondition": {
+			tctype:            "unstable",
+			apiendpoint:       "http://unstable.com",
+			clusterconditions: []toolchainv1alpha1.Condition{unhealthy(), notOffline()},
+			status:            withStatus(healthy()),
+		},
+		"StableContainsCondition": {
+			tctype:            "stable",
+			apiendpoint:       "http://cluster.com",
+			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
+			status:            withStatus(offline()),
+		},
+		"NotFoundContainsCondition": {
+			tctype:            "not-found",
+			apiendpoint:       "http://not-found.com",
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
+			status:            withStatus(healthy()),
+		},
+		//if the connection cannot be established at beginning, then it should be offline
+		"OfflineConnectionNotEstablished": {
+			tctype:            "failing",
+			apiendpoint:       "http://failing.com",
+			clusterconditions: []toolchainv1alpha1.Condition{offline()},
+			status:            toolchainv1alpha1.ToolchainClusterStatus{},
+		},
+		//if no zones nor region is retrieved, then keep the current
+		"NoZoneKeepCurrent": {
+			tctype:            "stable",
+			apiendpoint:       "http://cluster.com",
+			clusterconditions: []toolchainv1alpha1.Condition{healthy()},
+			status:            withStatus(offline()),
+		},
 	}
 	for k, tc := range tests {
 		t.Run(k, func(t *testing.T) {
@@ -117,11 +117,11 @@ func TestClusterHealthChecks(t *testing.T) {
 	}
 }
 
-//	func withStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1alpha1.ToolchainClusterStatus {
-//		return toolchainv1alpha1.ToolchainClusterStatus{
-//			Conditions: conditions,
-//		}
-//	}
+func withStatus(conditions ...toolchainv1alpha1.Condition) toolchainv1alpha1.ToolchainClusterStatus {
+	return toolchainv1alpha1.ToolchainClusterStatus{
+		Conditions: conditions,
+	}
+}
 func assertClusterStatus(t *testing.T, cl client.Client, clusterName string, clusterConds ...toolchainv1alpha1.Condition) {
 	tc := &toolchainv1alpha1.ToolchainCluster{}
 	err := cl.Get(context.TODO(), test.NamespacedName("test-namespace", clusterName), tc)

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -107,12 +107,22 @@ func TestClusterHealthChecks(t *testing.T) {
 
 			//when
 			hcond := getClusterHealthStatus(context.TODO(), cacheclient)
-			//fmt.Printf("hcond %+v", hcond)
+
 			//then
-			require.NoError(t, err)
-			//fmt.Printf("tc cond %+v", tc.clusterconditions)
-			//assertClusterStatus(t, cl, tc.tctype, hcond...)
-			assert.Equal(t, hcond[0].Status, tc.clusterconditions[0].Status)
+			assert.Len(t, tc.clusterconditions, len(hcond))
+		SetConditions:
+			for _, hc := range hcond {
+				for _, tco := range tc.clusterconditions {
+					if hc.Type == tco.Type {
+						assert.Equal(t, tco.Status, hc.Status)
+						assert.Equal(t, tco.Reason, hc.Reason)
+						assert.Equal(t, tco.Message, hc.Message)
+						continue SetConditions
+					}
+				}
+				assert.Failf(t, "condition not found", "the list of conditions %v doesn't contain the expected condition %v", tc.clusterconditions, hc)
+			}
+
 		})
 	}
 }

--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -2,6 +2,7 @@ package toolchaincluster
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -52,6 +53,7 @@ func TestClusterHealthChecks(t *testing.T) {
 			tctype:      "Notfound",
 			apiendpoint: "http://not-found.com",
 			healthcheck: false,
+			errh:        fmt.Errorf("the server could not find the requested resource"),
 		},
 	}
 	for k, tc := range tests {
@@ -71,8 +73,8 @@ func TestClusterHealthChecks(t *testing.T) {
 
 			//then
 			require.Equal(t, tc.healthcheck, healthcheck)
-			if tc.tctype == "Notfound" {
-				require.Error(t, errh)
+			if tc.errh != nil {
+				require.EqualError(t, errh, tc.errh.Error())
 			} else {
 				require.NoError(t, errh)
 			}

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -57,7 +57,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	cachedCluster, ok := cluster.GetCachedToolchainCluster(toolchainCluster.Name)
 	if !ok {
 		err := fmt.Errorf("cluster %s not found in cache", toolchainCluster.Name)
-		r.updateStatus(ctx, toolchainCluster, clusterOfflineCondition())
+		if err := r.updateStatus(ctx, toolchainCluster, clusterOfflineCondition()); err != nil {
+			reqLogger.Error(err, "unable to update cluster status of ToolchainCluster")
+		}
 		return reconcile.Result{}, err
 	}
 
@@ -65,7 +67,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	clientSet, err := kubeclientset.NewForConfig(cachedCluster.RestConfig)
 	if err != nil {
 		reqLogger.Error(err, "cannot create ClientSet for the ToolchainCluster")
-		r.updateStatus(ctx, toolchainCluster, clusterNotReadyCondition())
+		if err := r.updateStatus(ctx, toolchainCluster, clusterNotReadyCondition()); err != nil {
+			reqLogger.Error(err, "unable to update cluster status of ToolchainCluster")
+		}
 		return reconcile.Result{}, err
 	}
 

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -73,7 +73,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
-	//Not testing as this as this is being tested in cluster package
 	clientSet, err := kubeclientset.NewForConfig(cachedCluster.RestConfig)
 	if err != nil {
 		reqLogger.Error(err, "cannot create ClientSet for the ToolchainCluster")
@@ -84,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// execute healthcheck
-	healthcheckResult := r.GetClusterHealthCondition(ctx, clientSet)
+	healthcheckResult := r.getClusterHealthCondition(ctx, clientSet)
 
 	// update the status of the individual cluster.
 	if err := r.updateStatus(ctx, toolchainCluster, healthcheckResult...); err != nil {
@@ -106,7 +105,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolcha
 	return nil
 }
 
-func (r *Reconciler) GetClusterHealthCondition(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) []v1alpha1.Condition {
+func (r *Reconciler) getClusterHealthCondition(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) []v1alpha1.Condition {
 	conditions := []v1alpha1.Condition{}
 
 	healthcheck, errhealth := r.getClusterHealth(ctx, remoteClusterClientset)
@@ -126,7 +125,7 @@ func (r *Reconciler) getClusterHealth(ctx context.Context, remoteClusterClientse
 	if r.CheckHealth != nil {
 		return r.CheckHealth(ctx, remoteClusterClientset)
 	}
-	return GetClusterHealth(ctx, remoteClusterClientset)
+	return getClusterHealthStatus(ctx, remoteClusterClientset)
 }
 
 func clusterReadyCondition() toolchainv1alpha1.Condition {

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -64,6 +64,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
+	//Not testing as this as this is being tested in cluster package
 	clientSet, err := kubeclientset.NewForConfig(cachedCluster.RestConfig)
 	if err != nil {
 		reqLogger.Error(err, "cannot create ClientSet for the ToolchainCluster")

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -91,8 +91,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	return reconcile.Result{RequeueAfter: r.RequeAfter}, nil
 }
 
-func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolchainv1alpha1.ToolchainCluster, currentconditions ...toolchainv1alpha1.Condition) error {
-	toolchainCluster.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(toolchainCluster.Status.Conditions, currentconditions...)
+func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolchainv1alpha1.ToolchainCluster, currentConditions ...toolchainv1alpha1.Condition) error {
+	toolchainCluster.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(toolchainCluster.Status.Conditions, currentConditions...)
 	if err := r.Client.Status().Update(ctx, toolchainCluster); err != nil {
 		return fmt.Errorf("failed to update the status of cluster - %s "+err.Error(), toolchainCluster.Name)
 	}
@@ -101,15 +101,15 @@ func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolcha
 
 func (r *Reconciler) getClusterHealthCondition(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) v1alpha1.Condition {
 
-	ishealthy, err := r.getClusterHealth(ctx, remoteClusterClientset)
+	isHealthy, err := r.getClusterHealth(ctx, remoteClusterClientset)
 	if err != nil {
 		return clusterOfflineCondition(err.Error())
-	} else {
-		if !ishealthy {
-			return clusterNotReadyCondition()
-		}
-		return clusterReadyCondition()
 	}
+	if !isHealthy {
+		return clusterNotReadyCondition()
+	}
+	return clusterReadyCondition()
+
 }
 
 func (r *Reconciler) getClusterHealth(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) (bool, error) {

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -81,10 +81,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	// execute healthcheck
-	healthcheckResult := r.getClusterHealthCondition(ctx, clientSet)
+	healthCheckResult := r.getClusterHealthCondition(ctx, clientSet)
 
 	// update the status of the individual cluster.
-	if err := r.updateStatus(ctx, toolchainCluster, healthcheckResult); err != nil {
+	if err := r.updateStatus(ctx, toolchainCluster, healthCheckResult); err != nil {
 		reqLogger.Error(err, "unable to update cluster status of ToolchainCluster")
 		return reconcile.Result{}, err
 	}

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -100,7 +100,6 @@ func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolcha
 }
 
 func (r *Reconciler) getClusterHealthCondition(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) v1alpha1.Condition {
-
 	isHealthy, err := r.getClusterHealth(ctx, remoteClusterClientset)
 	if err != nil {
 		return clusterOfflineCondition(err.Error())
@@ -118,6 +117,7 @@ func (r *Reconciler) getClusterHealth(ctx context.Context, remoteClusterClientse
 	}
 	return getClusterHealthStatus(ctx, remoteClusterClientset)
 }
+
 func clusterOfflineCondition(errMsg string) toolchainv1alpha1.Condition {
 	return toolchainv1alpha1.Condition{
 		Type:    toolchainv1alpha1.ConditionReady,

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -94,7 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolchainv1alpha1.ToolchainCluster, currentConditions ...toolchainv1alpha1.Condition) error {
 	toolchainCluster.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(toolchainCluster.Status.Conditions, currentConditions...)
 	if err := r.Client.Status().Update(ctx, toolchainCluster); err != nil {
-		return fmt.Errorf("failed to update the status of cluster - %s "+err.Error(), toolchainCluster.Name)
+		return fmt.Errorf("failed to update the status of cluster - %s: %w", toolchainCluster.Name, err)
 	}
 	return nil
 }

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -106,19 +106,16 @@ func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolcha
 }
 
 func (r *Reconciler) getClusterHealthCondition(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) []v1alpha1.Condition {
-	conditions := []v1alpha1.Condition{}
 
 	healthcheck, errhealth := r.getClusterHealth(ctx, remoteClusterClientset)
 	if errhealth != nil {
-		conditions = append(conditions, clusterOfflineCondition())
-	} else {
-		if !healthcheck {
-			conditions = append(conditions, clusterNotReadyCondition(), clusterNotOfflineCondition())
-		} else {
-			conditions = append(conditions, clusterReadyCondition())
-		}
+		return []v1alpha1.Condition{clusterOfflineCondition()}
 	}
-	return conditions
+	if !healthcheck {
+		return []v1alpha1.Condition{clusterNotReadyCondition(), clusterNotOfflineCondition()}
+	}
+	return []v1alpha1.Condition{clusterReadyCondition()}
+
 }
 
 func (r *Reconciler) getClusterHealth(ctx context.Context, remoteClusterClientset *kubeclientset.Clientset) (bool, error) {

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -61,7 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	cachedCluster, ok := cluster.GetCachedToolchainCluster(toolchainCluster.Name)
 	if !ok {
 		err := fmt.Errorf("cluster %s not found in cache", toolchainCluster.Name)
-		if err := r.updateStatus(ctx, toolchainCluster, clusterNotReadyCondition()); err != nil {
+		if err := r.updateStatus(ctx, toolchainCluster, clusterOfflineCondition(err.Error())); err != nil {
 			reqLogger.Error(err, "unable to update cluster status of ToolchainCluster")
 		}
 		return reconcile.Result{}, err
@@ -74,7 +74,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	clientSet, err := kubeclientset.NewForConfig(cachedCluster.RestConfig)
 	if err != nil {
 		reqLogger.Error(err, "cannot create ClientSet for the ToolchainCluster")
-		if err := r.updateStatus(ctx, toolchainCluster, clusterNotReadyCondition()); err != nil {
+		if err := r.updateStatus(ctx, toolchainCluster, clusterOfflineCondition(err.Error())); err != nil {
 			reqLogger.Error(err, "unable to update cluster status of ToolchainCluster")
 		}
 		return reconcile.Result{}, err

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -94,11 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, toolchainCluster *toolchainv1alpha1.ToolchainCluster, currentconditions ...toolchainv1alpha1.Condition) error {
-	resultconditions, updated := condition.AddOrUpdateStatusConditions(toolchainCluster.Status.Conditions, currentconditions...)
-	if !updated {
-		return nil
-	}
-	toolchainCluster.Status.Conditions = resultconditions
+	toolchainCluster.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(toolchainCluster.Status.Conditions, currentconditions...)
 	if err := r.Client.Status().Update(ctx, toolchainCluster); err != nil {
 		return errors.Wrapf(err, "Failed to update the status of cluster %s", toolchainCluster.Name)
 	}

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -332,3 +332,20 @@ ExpConditions:
 		assert.Failf(t, "condition not found", "the list of conditions %v doesn't contain the expected condition %v", tc.Status.Conditions, expCond)
 	}
 }
+
+func healthy() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{
+		Type:    toolchainv1alpha1.ConditionReady,
+		Status:  corev1.ConditionTrue,
+		Reason:  "ClusterReady",
+		Message: "/healthz responded with ok",
+	}
+}
+
+func offline() toolchainv1alpha1.Condition {
+	return toolchainv1alpha1.Condition{Type: toolchainv1alpha1.ToolchainClusterOffline,
+		Status:  corev1.ConditionTrue,
+		Reason:  "ClusterNotReachable",
+		Message: "cluster is not reachable",
+	}
+}

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -86,11 +86,11 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("reconcile successful and requeued", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", withStatus(healthy()))
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
-		stable.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(stable.Status.Conditions, clusterReadyCondition())
+
 		defer reset()
 		controller, req := prepareReconcile(stable, cl, requeAfter)
 
@@ -105,11 +105,10 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("Checking the run check health default ", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", withStatus(healthy()))
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
-		stable.Status.Conditions = condition.AddOrUpdateStatusConditionsWithLastUpdatedTimestamp(stable.Status.Conditions, clusterReadyCondition())
 		defer reset()
 		controller, req := prepareCheckHealthDefaultReconcile(stable, cl, requeAfter)
 

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -198,7 +198,7 @@ func TestClusterControllerChecks(t *testing.T) {
 		tc := &toolchainv1alpha1.ToolchainCluster{}
 		err = cl.Get(context.TODO(), test.NamespacedName("test-namespace", stable.Name), tc)
 		require.NoError(t, err)
-		assert.Equal(t, stable.Status, tc.Status)
+		assert.Equal(t, stable.Status.Conditions[0].LastTransitionTime, tc.Status.Conditions[0].LastTransitionTime)
 	})
 
 	t.Run("migrates connection settings to kubeconfig in secret", func(t *testing.T) {
@@ -237,7 +237,7 @@ func TestClusterControllerChecks(t *testing.T) {
 }
 
 func TestGetClusterHealth(t *testing.T) {
-	t.Run("Checkhealth deafualt", func(t *testing.T) {
+	t.Run("Check health defualt", func(t *testing.T) {
 		// given
 		stable, sec := newToolchainCluster("stable", "test-namespace", "http://cluster.com", withStatus(healthy()))
 

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -62,7 +62,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.Equal(t, reconcile.Result{Requeue: false, RequeueAfter: 0}, recresult)
+		require.Equal(t, reconcile.Result{Requeue: false, RequeueAfter: 0}, recResult)
 	})
 
 	t.Run("Error while getting ToolchainCluster", func(t *testing.T) {
@@ -101,8 +101,8 @@ func TestClusterControllerChecks(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
-		require.Equal(t, reconcile.Result{RequeueAfter: requeAfter}, recresult)
-		assertClusterStatus(t, cl, "stable", healthy())
+		require.Equal(t, reconcile.Result{RequeueAfter: requeAfter}, recResult)
+		assertClusterStatus(t, cl, "stable", clusterReadyCondition())
 	})
 
 	t.Run("toolchain cluster cache not found", func(t *testing.T) {

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -237,7 +237,7 @@ func TestClusterControllerChecks(t *testing.T) {
 }
 
 func TestGetClusterHealth(t *testing.T) {
-	t.Run("Check health defualt", func(t *testing.T) {
+	t.Run("Check health default", func(t *testing.T) {
 		// given
 		stable, sec := newToolchainCluster("stable", "test-namespace", "http://cluster.com", withStatus(healthy()))
 


### PR DESCRIPTION
This PR is to refactor the ToolchainCluster controller .

this is related to this [discussion](https://github.com/codeready-toolchain/toolchain-common/pull/386#discussion_r1571030991) and [this ](https://redhat-internal.slack.com/archives/C06MJ2DVBU4/p1713430967057339?thread_ts=1713362133.858979&cid=C06MJ2DVBU4) . 

Related PR where only change is updating the dependency But paired E2e has changes as Offline condition is dropped
- Host-operator - https://github.com/codeready-toolchain/host-operator/pull/1049
   - Paired e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1005
- Member-operator - https://github.com/codeready-toolchain/member-operator/pull/579
  - Paired e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1006
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/437
  - Paired-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1000
- Sandbox-SRE - https://github.com/codeready-toolchain/sandbox-sre/pull/1830
- KSCTL - https://github.com/kubesaw/ksctl/pull/42