### PR TITLE
Store kubeconfig in ToolchainCluster secret

### DIFF
--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -7,9 +7,13 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -51,6 +55,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return reconcile.Result{}, err
 	}
 
+	if err = r.migrateSecretToKubeConfig(ctx, toolchainCluster); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	cachedCluster, ok := cluster.GetCachedToolchainCluster(toolchainCluster.Name)
 	if !ok {
 		err := fmt.Errorf("cluster %s not found in cache", toolchainCluster.Name)
@@ -79,4 +87,67 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 	}
 
 	return reconcile.Result{RequeueAfter: r.RequeAfter}, nil
+}
+
+func (r *Reconciler) migrateSecretToKubeConfig(ctx context.Context, tc *toolchainv1alpha1.ToolchainCluster) error {
+	if len(tc.Spec.SecretRef.Name) == 0 {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: tc.Spec.SecretRef.Name, Namespace: tc.Namespace}, secret); err != nil {
+		return err
+	}
+
+	token := secret.Data["token"]
+	apiEndpoint := tc.Spec.APIEndpoint
+	operatorNamespace := tc.Labels["namespace"]
+	caCertificate := tc.Spec.CABundle
+
+	kubeConfig := composeKubeConfigFromData(token, apiEndpoint, operatorNamespace, caCertificate)
+
+	data, err := clientcmd.Write(kubeConfig)
+	if err != nil {
+		return err
+	}
+
+	origKubeConfigData := secret.Data["kubeconfig"]
+	secret.Data["kubeconfig"] = data
+
+	if !slices.Equal(origKubeConfigData, data) {
+		if err = r.Client.Update(ctx, secret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func composeKubeConfigFromData(token []byte, apiEndpoint, operatorNamespace, caCertificate string) clientcmdapi.Config {
+	var caCertificateBytes []byte
+	if len(caCertificate) > 0 {
+		caCertificateBytes = []byte(caCertificate)
+	}
+
+	return clientcmdapi.Config{
+		Contexts: map[string]*clientcmdapi.Context{
+			"ctx": {
+				Cluster:   "cluster",
+				Namespace: operatorNamespace,
+				AuthInfo:  "auth",
+			},
+		},
+		CurrentContext: "ctx",
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {
+				Server:                   apiEndpoint,
+				CertificateAuthorityData: caCertificateBytes,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"auth": {
+				Token: string(token),
+			},
+		},
+	}
 }

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -9,12 +9,17 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
+	"gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -119,6 +124,53 @@ func TestClusterControllerChecks(t *testing.T) {
 		require.NoError(t, err)
 		assertClusterStatus(t, cl, "stable", offline())
 	})
+
+	t.Run("migrates connection settings to kubeconfig in secret", func(t *testing.T) {
+		// given
+		tc, secret := newToolchainCluster("tc", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		cl := test.NewFakeClient(t, tc, secret)
+		reset := setupCachedClusters(t, cl, tc)
+		defer reset()
+
+		controller, req := prepareReconcile(tc, cl, requeAfter)
+		expectedKubeConfig := composeKubeConfigFromData([]byte("mycooltoken"), "http://cluster.com", "test-namespace", "")
+
+		// when
+		_, err := controller.Reconcile(context.TODO(), req)
+		secretAfterReconcile := &corev1.Secret{}
+		require.NoError(t, cl.Get(context.TODO(), client.ObjectKeyFromObject(secret), secretAfterReconcile))
+		actualKubeConfig, loadErr := clientcmd.Load(secretAfterReconcile.Data["kubeconfig"])
+
+		// then
+		require.NoError(t, err)
+		require.NoError(t, loadErr)
+		assert.Contains(t, secretAfterReconcile.Data, "kubeconfig")
+
+		// we need to use this more complex equals, because we don't initialize the Extension fields (i.e. they're nil)
+		// while they're initialized and empty after deserialization, which causes the "normal" deep equals to fail.
+		result := cmp.DeepEqual(expectedKubeConfig, *actualKubeConfig,
+			cmpopts.IgnoreFields(clientcmdapi.Config{}, "Extensions"),
+			cmpopts.IgnoreFields(clientcmdapi.Preferences{}, "Extensions"),
+			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "Extensions"),
+			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Extensions"),
+			cmpopts.IgnoreFields(clientcmdapi.Context{}, "Extensions"),
+		)()
+
+		assert.True(t, result.Success())
+	})
+}
+
+func TestComposeKubeConfig(t *testing.T) {
+	// when
+	kubeConfig := composeKubeConfigFromData([]byte("token"), "http://over.the.rainbow", "the-namespace", "secure-certificate")
+
+	// then
+	context := kubeConfig.Contexts[kubeConfig.CurrentContext]
+
+	assert.Equal(t, "token", kubeConfig.AuthInfos[context.AuthInfo].Token)
+	assert.Equal(t, "http://over.the.rainbow", kubeConfig.Clusters[context.Cluster].Server)
+	assert.Equal(t, "the-namespace", context.Namespace)
+	assert.Equal(t, []byte("secure-certificate"), kubeConfig.Clusters[context.Cluster].CertificateAuthorityData)
 }
 
 func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolchainv1alpha1.ToolchainCluster) func() {

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -133,7 +133,7 @@ func TestClusterControllerChecks(t *testing.T) {
 		defer reset()
 
 		controller, req := prepareReconcile(tc, cl, requeAfter)
-		expectedKubeConfig := composeKubeConfigFromData([]byte("mycooltoken"), "http://cluster.com", "test-namespace", "")
+		expectedKubeConfig := composeKubeConfigFromData([]byte("mycooltoken"), "http://cluster.com", "test-namespace", true)
 
 		// when
 		_, err := controller.Reconcile(context.TODO(), req)
@@ -162,7 +162,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 func TestComposeKubeConfig(t *testing.T) {
 	// when
-	kubeConfig := composeKubeConfigFromData([]byte("token"), "http://over.the.rainbow", "the-namespace", "secure-certificate")
+	kubeConfig := composeKubeConfigFromData([]byte("token"), "http://over.the.rainbow", "the-namespace", false)
 
 	// then
 	context := kubeConfig.Contexts[kubeConfig.CurrentContext]
@@ -170,7 +170,7 @@ func TestComposeKubeConfig(t *testing.T) {
 	assert.Equal(t, "token", kubeConfig.AuthInfos[context.AuthInfo].Token)
 	assert.Equal(t, "http://over.the.rainbow", kubeConfig.Clusters[context.Cluster].Server)
 	assert.Equal(t, "the-namespace", context.Namespace)
-	assert.Equal(t, []byte("secure-certificate"), kubeConfig.Clusters[context.Cluster].CertificateAuthorityData)
+	assert.False(t, kubeConfig.Clusters[context.Cluster].InsecureSkipTLSVerify)
 }
 
 func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolchainv1alpha1.ToolchainCluster) func() {


### PR DESCRIPTION
This introduces a temporary migration step that converts the connection details spread across the ToolchainCluster and its associated secret into the "kubeconfig" field in the secret data that contains the serialized kubeconfig file with the details all included.

Associated PRs:
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/997
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1042