### PR TITLE
KUBESAW-124: Makefile target for dependency validations

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -19,7 +19,7 @@ vendor:
 
 .PHONY: verify-dependencies
 ## Runs commands to verify after the updated dependecies of toolchain-common/API(go mod replace), if the repo needs any changes to be made
-verify-dependencies: tidy vet test lint-go-code
+verify-dependencies: tidy vet build test lint-go-code
 
 .PHONY: tidy
 tidy: 

--- a/make/go.mk
+++ b/make/go.mk
@@ -16,3 +16,15 @@ build: $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 .PHONY: vendor
 vendor:
 	$(Q)go mod vendor
+
+.PHONY: verify-dependencies
+## Runs commands to verify after the updated dependecies of toolchain-common/API(go mod replace), if the repo needs any changes to be made
+verify-dependencies: tidy vet test lint-go-code
+
+.PHONY: tidy
+tidy: 
+	go mod tidy
+
+.PHONY: vet
+vet:
+	go vet ./...


### PR DESCRIPTION
This is to create makefile target for dependency validations in each repository so that this can be used to verify if there are any compilation issues after updating the dependencies of toolchain-common/api

Similar PRs

- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1052
- Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/581
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/440
- Toolchain-E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1002
- KSTCL - https://github.com/kubesaw/ksctl/pull/43