### PR TITLE
SANDBOX-674: add NewBannedUser and IsAlreadyBanned funcs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/migueleliasweb/go-github-mock v0.0.18
 	golang.org/x/oauth2 v0.7.0
 	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/kubectl v0.24.0
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 )
 
@@ -107,8 +108,10 @@ require (
 	k8s.io/component-base v0.25.0 // indirect
 	k8s.io/klog/v2 v2.70.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 // indirect
-	k8s.io/kubectl v0.24.0 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+// temporary
+replace github.com/codeready-toolchain/api => github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-common
 go 1.20
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb
+	github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a
 	github.com/go-logr/logr v1.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -112,6 +112,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-// temporary
-replace github.com/codeready-toolchain/api => github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a h1:La7GOCysmkU+4vnN8lDzXFJwJiA1LWZ9YkX/yQXYnpw=
+github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -519,8 +521,6 @@ github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e h1:nrCMu0XtzQVMD0gKN5cNaYgE0cAYBcF407lj6JDCz6c=
-github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb h1:Wc9CMsv0ODZv9dM5qF3OI0mFDO95YNIXV/8oRvoz8aE=
-github.com/codeready-toolchain/api v0.0.0-20240708122235-0af5a9a178bb/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -521,6 +519,8 @@ github.com/redhat-cop/operator-utils v1.3.3-0.20220121120056-862ef22b8cdf/go.mod
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e h1:nrCMu0XtzQVMD0gKN5cNaYgE0cAYBcF407lj6JDCz6c=
+github.com/rsoaresd/api v0.0.0-20240717091444-c6440c0ad84e/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/banneduser/banneduser.go
+++ b/pkg/banneduser/banneduser.go
@@ -1,0 +1,59 @@
+package banneduser
+
+import (
+	"context"
+	"fmt"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const bannedByLabel = toolchainv1alpha1.LabelKeyPrefix + "banned-by"
+
+// NewBannedUser creates a BannedUser resource
+func NewBannedUser(userSignup *toolchainv1alpha1.UserSignup, bannedBy string) (*toolchainv1alpha1.BannedUser, error) {
+	var emailHashLbl, phoneHashLbl string
+	var exists bool
+
+	if emailHashLbl, exists = userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]; !exists {
+		return nil, fmt.Errorf("the UserSignup %s doesn't have the label '%s' set", userSignup.Name, toolchainv1alpha1.UserSignupUserEmailHashLabelKey) // nolint:loggercheck
+	}
+
+	bannedUser := &toolchainv1alpha1.BannedUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: userSignup.Namespace,
+			Name:      fmt.Sprintf("banneduser-%s", emailHashLbl),
+			Labels: map[string]string{
+				toolchainv1alpha1.BannedUserEmailHashLabelKey: emailHashLbl,
+				bannedByLabel: bannedBy,
+			},
+		},
+		Spec: toolchainv1alpha1.BannedUserSpec{
+			Email: userSignup.Spec.IdentityClaims.Email,
+		},
+	}
+
+	if phoneHashLbl, exists = userSignup.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey]; exists {
+		bannedUser.Labels[toolchainv1alpha1.BannedUserPhoneNumberHashLabelKey] = phoneHashLbl
+	}
+	return bannedUser, nil
+}
+
+// IsAlreadyBanned checks if the user was already banned
+func IsAlreadyBanned(ctx context.Context, bannedUser *toolchainv1alpha1.BannedUser, hostClient client.Client, hostNamespace string) (bool, error) {
+	emailHashLabelMatch := client.MatchingLabels(map[string]string{
+		toolchainv1alpha1.BannedUserEmailHashLabelKey: bannedUser.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey],
+	})
+	bannedUsers := &toolchainv1alpha1.BannedUserList{}
+
+	if err := hostClient.List(ctx, bannedUsers, emailHashLabelMatch, client.InNamespace(hostNamespace)); err != nil {
+		return false, err
+	}
+
+	if len(bannedUsers.Items) > 0 {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/pkg/banneduser/banneduser.go
+++ b/pkg/banneduser/banneduser.go
@@ -41,9 +41,9 @@ func NewBannedUser(userSignup *toolchainv1alpha1.UserSignup, bannedBy string) (*
 }
 
 // IsAlreadyBanned checks if the user was already banned
-func IsAlreadyBanned(ctx context.Context, bannedUser *toolchainv1alpha1.BannedUser, hostClient client.Client, hostNamespace string) (bool, error) {
+func IsAlreadyBanned(ctx context.Context, userEmailHash string, hostClient client.Client, hostNamespace string) (bool, error) {
 	emailHashLabelMatch := client.MatchingLabels(map[string]string{
-		toolchainv1alpha1.BannedUserEmailHashLabelKey: bannedUser.Labels[toolchainv1alpha1.BannedUserEmailHashLabelKey],
+		toolchainv1alpha1.BannedUserEmailHashLabelKey: userEmailHash,
 	})
 	bannedUsers := &toolchainv1alpha1.BannedUserList{}
 

--- a/pkg/banneduser/banneduser.go
+++ b/pkg/banneduser/banneduser.go
@@ -9,9 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const bannedByLabel = toolchainv1alpha1.LabelKeyPrefix + "banned-by"
-
-// NewBannedUser creates a BannedUser resource
+// NewBannedUser creates a bannedUser resource
 func NewBannedUser(userSignup *toolchainv1alpha1.UserSignup, bannedBy string) (*toolchainv1alpha1.BannedUser, error) {
 	var emailHashLbl, phoneHashLbl string
 	var exists bool
@@ -26,7 +24,7 @@ func NewBannedUser(userSignup *toolchainv1alpha1.UserSignup, bannedBy string) (*
 			Name:      fmt.Sprintf("banneduser-%s", emailHashLbl),
 			Labels: map[string]string{
 				toolchainv1alpha1.BannedUserEmailHashLabelKey: emailHashLbl,
-				bannedByLabel: bannedBy,
+				toolchainv1alpha1.BannedByLabelKey:            bannedBy,
 			},
 		},
 		Spec: toolchainv1alpha1.BannedUserSpec{

--- a/pkg/banneduser/banneduser.go
+++ b/pkg/banneduser/banneduser.go
@@ -47,13 +47,12 @@ func IsAlreadyBanned(ctx context.Context, bannedUser *toolchainv1alpha1.BannedUs
 	})
 	bannedUsers := &toolchainv1alpha1.BannedUserList{}
 
+	fmt.Println("list", hostClient.List(ctx, bannedUsers, emailHashLabelMatch, client.InNamespace(hostNamespace)))
 	if err := hostClient.List(ctx, bannedUsers, emailHashLabelMatch, client.InNamespace(hostNamespace)); err != nil {
 		return false, err
 	}
 
-	if len(bannedUsers.Items) > 0 {
-		return true, nil
-	}
+	fmt.Println("bannedUsers", bannedUsers)
 
-	return false, nil
+	return len(bannedUsers.Items) > 0, nil
 }

--- a/pkg/banneduser/banneduser.go
+++ b/pkg/banneduser/banneduser.go
@@ -47,12 +47,9 @@ func IsAlreadyBanned(ctx context.Context, bannedUser *toolchainv1alpha1.BannedUs
 	})
 	bannedUsers := &toolchainv1alpha1.BannedUserList{}
 
-	fmt.Println("list", hostClient.List(ctx, bannedUsers, emailHashLabelMatch, client.InNamespace(hostNamespace)))
 	if err := hostClient.List(ctx, bannedUsers, emailHashLabelMatch, client.InNamespace(hostNamespace)); err != nil {
 		return false, err
 	}
-
-	fmt.Println("bannedUsers", bannedUsers)
 
 	return len(bannedUsers.Items) > 0, nil
 }

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -3,6 +3,7 @@ package banneduser
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -102,8 +103,8 @@ func TestNewBannedUser(t *testing.T) {
 				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
 				assert.Equal(t, tt.expectedBannedUser.Spec.Email, got.Spec.Email)
 
-				if tt.expectedBannedUser != nil && !compareMaps(tt.expectedBannedUser.Labels, got.Labels) {
-					t.Errorf("compareMaps(%v, %v) = false, expected = true", tt.expectedBannedUser.Labels, got.Labels)
+				if tt.expectedBannedUser != nil {
+					assert.True(t, reflect.DeepEqual(tt.expectedBannedUser.Labels, got.Labels))
 				}
 			}
 		})
@@ -167,22 +168,4 @@ func TestIsAlreadyBanned(t *testing.T) {
 			}
 		})
 	}
-}
-
-func compareMaps(map1, map2 map[string]string) bool {
-	if len(map1) != len(map2) {
-		return false
-	}
-
-	for key, value1 := range map1 {
-		value2, ok := map2[key]
-		if !ok {
-			return false
-		}
-		if value1 != value2 {
-			return false
-		}
-	}
-
-	return true
 }

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -1,0 +1,124 @@
+package banneduser
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	commonsignup "github.com/codeready-toolchain/toolchain-common/pkg/test/usersignup"
+	"github.com/stretchr/testify/require"
+	"gotest.tools/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNewBannedUser(t *testing.T) {
+	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"))
+	userSignup1UserEmailHashLabelKey := userSignup1.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]
+
+	userSignup2 := commonsignup.NewUserSignup(commonsignup.WithName("bob"))
+	userSignup2.Labels = map[string]string{}
+
+	tests := []struct {
+		name               string
+		userSignup         *toolchainv1alpha1.UserSignup
+		bannedBy           string
+		wantError          bool
+		wantErrorMsg       string
+		expectedBannedUser *toolchainv1alpha1.BannedUser
+	}{
+		{
+			name:         "userSignup with email hash label",
+			userSignup:   userSignup1,
+			bannedBy:     "admin",
+			wantError:    false,
+			wantErrorMsg: "",
+			expectedBannedUser: &toolchainv1alpha1.BannedUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: userSignup1.Namespace,
+					Name:      fmt.Sprintf("banneduser-%s", userSignup1UserEmailHashLabelKey),
+					Labels: map[string]string{
+						toolchainv1alpha1.BannedUserEmailHashLabelKey: userSignup1UserEmailHashLabelKey,
+						bannedByLabel: "admin",
+					},
+				},
+				Spec: toolchainv1alpha1.BannedUserSpec{
+					Email: userSignup1.Spec.IdentityClaims.Email,
+				},
+			},
+		},
+		{
+			name:               "userSignup without email hash label",
+			userSignup:         userSignup2,
+			bannedBy:           "admin",
+			wantError:          true,
+			wantErrorMsg:       fmt.Sprintf("the UserSignup %s doesn't have the label '%s' set", userSignup2.Name, toolchainv1alpha1.UserSignupUserEmailHashLabelKey),
+			expectedBannedUser: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := NewBannedUser(test.userSignup, test.bannedBy)
+
+			if test.wantError {
+				require.Error(t, err)
+				assert.Equal(t, test.wantErrorMsg, err.Error())
+				require.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+
+				assert.Equal(t, test.expectedBannedUser.ObjectMeta.Namespace, got.ObjectMeta.Namespace)
+				assert.Equal(t, test.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
+				assert.Equal(t, test.expectedBannedUser.Spec.Email, got.Spec.Email)
+				reflect.DeepEqual(test.expectedBannedUser.ObjectMeta.Labels, got.ObjectMeta.Labels)
+			}
+		})
+	}
+}
+
+func TestIsAlreadyBanned(t *testing.T) {
+	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"))
+	userSignup2 := commonsignup.NewUserSignup(commonsignup.WithName("bob"), commonsignup.WithEmail("bob@example.com"))
+	bannedUser1, err := NewBannedUser(userSignup1, "admin")
+	require.NoError(t, err)
+	bannedUser2, err := NewBannedUser(userSignup2, "admin")
+	require.NoError(t, err)
+
+	mockT := test.NewMockT()
+	fakeClient := test.NewFakeClient(mockT, bannedUser1)
+	ctx := context.TODO()
+
+	tests := []struct {
+		name       string
+		toBan      *toolchainv1alpha1.BannedUser
+		wantResult bool
+		wantErr    bool
+	}{
+		{
+			name:       "user is already banned",
+			toBan:      bannedUser1,
+			wantResult: true,
+		},
+		{
+			name:       "user is not banned",
+			toBan:      bannedUser2,
+			wantResult: false,
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotResult, err := IsAlreadyBanned(ctx, tt.toBan, fakeClient, test.HostOperatorNs)
+
+			fmt.Println("gotResult", gotResult)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantResult, gotResult)
+		})
+	}
+}

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -47,7 +47,7 @@ func TestNewBannedUser(t *testing.T) {
 					Name:      fmt.Sprintf("banneduser-%s", userSignup1UserEmailHash),
 					Labels: map[string]string{
 						toolchainv1alpha1.BannedUserEmailHashLabelKey: userSignup1UserEmailHash,
-						bannedByLabel: "admin",
+						toolchainv1alpha1.BannedByLabelKey:            "admin",
 					},
 				},
 				Spec: toolchainv1alpha1.BannedUserSpec{
@@ -74,8 +74,8 @@ func TestNewBannedUser(t *testing.T) {
 					Namespace: userSignup3.Namespace,
 					Name:      fmt.Sprintf("banneduser-%s", userSignup3EmailHash),
 					Labels: map[string]string{
-						toolchainv1alpha1.BannedUserEmailHashLabelKey: userSignup3EmailHash,
-						bannedByLabel: "admin",
+						toolchainv1alpha1.BannedUserEmailHashLabelKey:     userSignup3EmailHash,
+						toolchainv1alpha1.BannedByLabelKey:                "admin",
 						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: userSignup3PhoneHash,
 					},
 				},

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -3,7 +3,6 @@ package banneduser
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -12,14 +11,21 @@ import (
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestNewBannedUser(t *testing.T) {
-	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"))
+	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"), commonsignup.WithEmail("jonhy@example.com"))
 	userSignup1UserEmailHashLabelKey := userSignup1.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]
 
-	userSignup2 := commonsignup.NewUserSignup(commonsignup.WithName("bob"))
+	userSignup2 := commonsignup.NewUserSignup(commonsignup.WithName("bob"), commonsignup.WithEmail("bob@example.com"))
 	userSignup2.Labels = map[string]string{}
+
+	userSignup3 := commonsignup.NewUserSignup(commonsignup.WithName("oliver"), commonsignup.WithEmail("oliver@example.com"))
+	userSignup3PhoneHashLabelKey := "fd276563a8232d16620da8ec85d0575f"
+	userSignup3.Labels[toolchainv1alpha1.UserSignupUserPhoneHashLabelKey] = userSignup3PhoneHashLabelKey
+	userSignup3UserEmailHashLabelKey := userSignup3.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey]
 
 	tests := []struct {
 		name               string
@@ -50,12 +56,33 @@ func TestNewBannedUser(t *testing.T) {
 			},
 		},
 		{
-			name:               "userSignup without email hash label",
+			name:               "userSignup without email hash label and phone has label",
 			userSignup:         userSignup2,
 			bannedBy:           "admin",
 			wantError:          true,
 			wantErrorMsg:       fmt.Sprintf("the UserSignup %s doesn't have the label '%s' set", userSignup2.Name, toolchainv1alpha1.UserSignupUserEmailHashLabelKey),
 			expectedBannedUser: nil,
+		},
+		{
+			name:         "userSignup with email hash label and phone hash label",
+			userSignup:   userSignup3,
+			bannedBy:     "admin",
+			wantError:    false,
+			wantErrorMsg: "",
+			expectedBannedUser: &toolchainv1alpha1.BannedUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: userSignup3.Namespace,
+					Name:      fmt.Sprintf("banneduser-%s", userSignup3UserEmailHashLabelKey),
+					Labels: map[string]string{
+						toolchainv1alpha1.BannedUserEmailHashLabelKey: userSignup3UserEmailHashLabelKey,
+						bannedByLabel: "admin",
+						toolchainv1alpha1.UserSignupUserPhoneHashLabelKey: userSignup3PhoneHashLabelKey,
+					},
+				},
+				Spec: toolchainv1alpha1.BannedUserSpec{
+					Email: userSignup3.Spec.IdentityClaims.Email,
+				},
+			},
 		},
 	}
 
@@ -74,18 +101,24 @@ func TestNewBannedUser(t *testing.T) {
 				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Namespace, got.ObjectMeta.Namespace)
 				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
 				assert.Equal(t, tt.expectedBannedUser.Spec.Email, got.Spec.Email)
-				reflect.DeepEqual(tt.expectedBannedUser.ObjectMeta.Labels, got.ObjectMeta.Labels)
+
+				if tt.expectedBannedUser != nil && !compareMaps(tt.expectedBannedUser.Labels, got.Labels) {
+					t.Errorf("compareMaps(%v, %v) = false, expected = true", tt.expectedBannedUser.Labels, got.Labels)
+				}
 			}
 		})
 	}
 }
 
 func TestIsAlreadyBanned(t *testing.T) {
-	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"))
+	userSignup1 := commonsignup.NewUserSignup(commonsignup.WithName("johny"), commonsignup.WithEmail("johny@example.com"))
 	userSignup2 := commonsignup.NewUserSignup(commonsignup.WithName("bob"), commonsignup.WithEmail("bob@example.com"))
+	userSignup3 := commonsignup.NewUserSignup(commonsignup.WithName("oliver"), commonsignup.WithEmail("oliver@example.com"))
 	bannedUser1, err := NewBannedUser(userSignup1, "admin")
 	require.NoError(t, err)
 	bannedUser2, err := NewBannedUser(userSignup2, "admin")
+	require.NoError(t, err)
+	bannedUser3, err := NewBannedUser(userSignup3, "admin")
 	require.NoError(t, err)
 
 	mockT := test.NewMockT()
@@ -97,24 +130,34 @@ func TestIsAlreadyBanned(t *testing.T) {
 		toBan      *toolchainv1alpha1.BannedUser
 		wantResult bool
 		wantError  bool
+		fakeClient *test.FakeClient
 	}{
 		{
 			name:       "user is already banned",
 			toBan:      bannedUser1,
 			wantResult: true,
 			wantError:  false,
+			fakeClient: fakeClient,
 		},
 		{
 			name:       "user is not banned",
 			toBan:      bannedUser2,
 			wantResult: false,
 			wantError:  false,
+			fakeClient: fakeClient,
+		},
+		{
+			name:       "cannot list banned users because the client does have type v1alpha1.BannedUserList registered in the scheme",
+			toBan:      bannedUser3,
+			wantResult: false,
+			wantError:  true,
+			fakeClient: &test.FakeClient{Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).Build(), T: t},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotResult, err := IsAlreadyBanned(ctx, tt.toBan, fakeClient, test.HostOperatorNs)
+			gotResult, err := IsAlreadyBanned(ctx, tt.toBan, tt.fakeClient, test.HostOperatorNs)
 
 			if tt.wantError {
 				require.Error(t, err)
@@ -124,4 +167,22 @@ func TestIsAlreadyBanned(t *testing.T) {
 			}
 		})
 	}
+}
+
+func compareMaps(map1, map2 map[string]string) bool {
+	if len(map1) != len(map2) {
+		return false
+	}
+
+	for key, value1 := range map1 {
+		value2, ok := map2[key]
+		if !ok {
+			return false
+		}
+		if value1 != value2 {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -56,7 +56,7 @@ func TestNewBannedUser(t *testing.T) {
 			},
 		},
 		{
-			name:               "userSignup without email hash label and phone has label",
+			name:               "userSignup without email hash label and phone hash label",
 			userSignup:         userSignup2,
 			bannedBy:           "admin",
 			wantError:          true,

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -59,22 +59,22 @@ func TestNewBannedUser(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := NewBannedUser(test.userSignup, test.bannedBy)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewBannedUser(tt.userSignup, tt.bannedBy)
 
-			if test.wantError {
+			if tt.wantError {
 				require.Error(t, err)
-				assert.Equal(t, test.wantErrorMsg, err.Error())
+				assert.Equal(t, tt.wantErrorMsg, err.Error())
 				require.Nil(t, got)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, got)
 
-				assert.Equal(t, test.expectedBannedUser.ObjectMeta.Namespace, got.ObjectMeta.Namespace)
-				assert.Equal(t, test.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
-				assert.Equal(t, test.expectedBannedUser.Spec.Email, got.Spec.Email)
-				reflect.DeepEqual(test.expectedBannedUser.ObjectMeta.Labels, got.ObjectMeta.Labels)
+				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Namespace, got.ObjectMeta.Namespace)
+				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
+				assert.Equal(t, tt.expectedBannedUser.Spec.Email, got.Spec.Email)
+				reflect.DeepEqual(tt.expectedBannedUser.ObjectMeta.Labels, got.ObjectMeta.Labels)
 			}
 		})
 	}
@@ -96,18 +96,19 @@ func TestIsAlreadyBanned(t *testing.T) {
 		name       string
 		toBan      *toolchainv1alpha1.BannedUser
 		wantResult bool
-		wantErr    bool
+		wantError  bool
 	}{
 		{
 			name:       "user is already banned",
 			toBan:      bannedUser1,
 			wantResult: true,
+			wantError:  false,
 		},
 		{
 			name:       "user is not banned",
 			toBan:      bannedUser2,
 			wantResult: false,
-			wantErr:    false,
+			wantError:  false,
 		},
 	}
 
@@ -115,10 +116,12 @@ func TestIsAlreadyBanned(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotResult, err := IsAlreadyBanned(ctx, tt.toBan, fakeClient, test.HostOperatorNs)
 
-			fmt.Println("gotResult", gotResult)
-
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantResult, gotResult)
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantResult, gotResult)
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description
- add NewBannedUser and IsAlreadyBanned funcs to avoid duplicate this work across the repos

## Issue ticket number and link
[SANDBOX-674](https://issues.redhat.com/browse/SANDBOX-674)

Associated PRs:
- api: https://github.com/codeready-toolchain/api/pull/436
- workload-analyzer: https://github.com/codeready-toolchain/workload-analyzer/pull/12