### PR TITLE
SANDBOX-677 use go-version-file

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,13 +14,13 @@ jobs:
     name: GolangCI Lint
     runs-on: ubuntu-20.04
     steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
-        
-    - name: Checkout code
-      uses: actions/checkout@v4
+        go-version-file: go.mod
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/test-with-coverage.yml
+++ b/.github/workflows/test-with-coverage.yml
@@ -15,17 +15,17 @@ jobs:
     name: Test with Coverage
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.20.x
-    
     - name: Checkout code
       uses: actions/checkout@v4
       with:
         ref: ${{github.event.pull_request.head.ref}}
         repository: ${{github.event.pull_request.head.repo.full_name}}
         fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
     
     - name: Test
       run: |


### PR DESCRIPTION
uses go-version-file instead of go-version. One less place to change when making updates.
Changes order in github action to first checkout code and then install go.

related PRs:
https://github.com/codeready-toolchain/api/pull/434