### PR TITLE
add GetCRTConfiguration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/configuration/memberoperatorconfig/configuration.go
+++ b/pkg/configuration/memberoperatorconfig/configuration.go
@@ -24,7 +24,6 @@ type Configuration struct {
 // then retrieves the latest config using the provided client and updates the cache
 func GetConfiguration(cl client.Client) (Configuration, error) {
 	config, secrets, err := commonconfig.GetConfig(cl, &toolchainv1alpha1.MemberOperatorConfig{})
-	fmt.Println("aqui vai err", err)
 	if err != nil {
 		// return default config
 		logger.Error(err, "failed to retrieve Configuration")

--- a/pkg/configuration/memberoperatorconfig/configuration.go
+++ b/pkg/configuration/memberoperatorconfig/configuration.go
@@ -8,6 +8,7 @@ import (
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -23,6 +24,7 @@ type Configuration struct {
 // then retrieves the latest config using the provided client and updates the cache
 func GetConfiguration(cl client.Client) (Configuration, error) {
 	config, secrets, err := commonconfig.GetConfig(cl, &toolchainv1alpha1.MemberOperatorConfig{})
+	fmt.Println("aqui vai err", err)
 	if err != nil {
 		// return default config
 		logger.Error(err, "failed to retrieve Configuration")
@@ -267,4 +269,18 @@ func (a WebConsolePluginConfig) PendoKey() string {
 
 func (a WebConsolePluginConfig) PendoHost() string {
 	return commonconfig.GetString(a.w.PendoHost, "cdn.pendo.io")
+}
+
+// GetCRTConfiguration creates the client used for configuration and
+// returns the loaded CRT configuration
+func GetCRTConfiguration(config *rest.Config, scheme *runtime.Scheme) (Configuration, error) {
+	// create client that will be used for retrieving the member operator config maps
+	cl, err := client.New(config, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return Configuration{}, err
+	}
+
+	return GetConfiguration(cl)
 }

--- a/pkg/configuration/memberoperatorconfig/configuration_test.go
+++ b/pkg/configuration/memberoperatorconfig/configuration_test.go
@@ -6,8 +6,13 @@ import (
 
 	commonconfig "github.com/codeready-toolchain/toolchain-common/pkg/configuration"
 	testconfig "github.com/codeready-toolchain/toolchain-common/pkg/test/config"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuth(t *testing.T) {
@@ -299,4 +304,23 @@ func TestWebConsolePlugin(t *testing.T) {
 
 		assert.Equal(t, "abc.pendo.io", memberOperatorCfg.WebConsolePlugin().PendoHost())
 	})
+}
+
+func TestGetCRTConfiguration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	mockGetter := new(MockConfigGetter)
+	mockGetter.On("GetCRTConfiguration", mock.Anything, mock.Anything).Return(Configuration{cfg: &toolchainv1alpha1.MemberOperatorConfigSpec{}}, nil)
+
+	t.Run("succeeds", func(t *testing.T) {
+		crtConfig, err := mockGetter.GetCRTConfiguration(&rest.Config{}, scheme)
+		require.NoError(t, err)
+		assert.NotEmpty(t, crtConfig)
+	})
+
+	t.Run("fails", func(t *testing.T) {
+		crtConfig, err := GetCRTConfiguration(&rest.Config{}, scheme)
+		require.Error(t, err)
+		assert.Empty(t, crtConfig)
+	})
+
 }

--- a/pkg/configuration/memberoperatorconfig/mock.go
+++ b/pkg/configuration/memberoperatorconfig/mock.go
@@ -1,16 +1,16 @@
 package memberoperatorconfig
 
 import (
-    "github.com/stretchr/testify/mock"
-    "k8s.io/apimachinery/pkg/runtime"
-    "k8s.io/client-go/rest"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 )
 
 type MockConfigGetter struct {
-    mock.Mock
+	mock.Mock
 }
 
 func (m *MockConfigGetter) GetCRTConfiguration(config *rest.Config, scheme *runtime.Scheme) (Configuration, error) {
-    args := m.Called(config, scheme)
-    return args.Get(0).(Configuration), args.Error(1)
+	args := m.Called(config, scheme)
+	return args.Get(0).(Configuration), args.Error(1)
 }

--- a/pkg/configuration/memberoperatorconfig/mock.go
+++ b/pkg/configuration/memberoperatorconfig/mock.go
@@ -1,0 +1,16 @@
+package memberoperatorconfig
+
+import (
+    "github.com/stretchr/testify/mock"
+    "k8s.io/apimachinery/pkg/runtime"
+    "k8s.io/client-go/rest"
+)
+
+type MockConfigGetter struct {
+    mock.Mock
+}
+
+func (m *MockConfigGetter) GetCRTConfiguration(config *rest.Config, scheme *runtime.Scheme) (Configuration, error) {
+    args := m.Called(config, scheme)
+    return args.Get(0).(Configuration), args.Error(1)
+}


### PR DESCRIPTION
# Description
- add `GetCRTConfiguration` func to avoid duplicate this work across the repos. Currently, it is present on [member-operator](https://github.com/codeready-toolchain/member-operator/blob/1a2fc46b5262e08a54abdc16db7009dd91fbec7e/main.go#L357-L369) and we will need in workload-analyzer

## Issue ticket number and link
[SANDBOX-674](https://issues.redhat.com/browse/SANDBOX-674)

Associated PRs:
- api: https://github.com/codeready-toolchain/api/pull/436
- workload-analyzer: https://github.com/codeready-toolchain/workload-analyzer/pull/12