### PR TITLE
remove webConsolePlugin from ToolchainClusterConfig (phase 2)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-common
 go 1.20
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a
+	github.com/codeready-toolchain/api v0.0.0-20240801160201-ed4387f19137
 	github.com/go-logr/logr v1.2.3
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/lestrrat-go/jwx v1.2.29
@@ -23,8 +23,6 @@ require (
 	k8s.io/client-go v0.25.0
 	sigs.k8s.io/controller-runtime v0.13.0
 )
-
-replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 
+replace github.com/codeready-toolchain/api => github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e
+
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a h1:La7GOCysmkU+4vnN8lDzXFJwJiA1LWZ9YkX/yQXYnpw=
-github.com/codeready-toolchain/api v0.0.0-20240717145630-bb67a632867a/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -582,6 +580,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e h1:6rYzVUcLeuVHmFjd7BU/Oe1SMsPrwdQgak2EYMz+oxM=
+github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
+github.com/codeready-toolchain/api v0.0.0-20240801160201-ed4387f19137 h1:axAZH/Ku+QHu2eQjlx/a7dctWRgj0T3K4gfnq1fzKFo=
+github.com/codeready-toolchain/api v0.0.0-20240801160201-ed4387f19137/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -580,8 +582,6 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
-github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e h1:6rYzVUcLeuVHmFjd7BU/Oe1SMsPrwdQgak2EYMz+oxM=
-github.com/xcoulon/api v0.0.0-20240725145329-0fc7541fe19e/go.mod h1:ie9p4LenCCS0LsnbWp6/xwpFDdCWYE0KWzUO6Sk1g0E=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/configuration/memberoperatorconfig/configuration.go
+++ b/pkg/configuration/memberoperatorconfig/configuration.go
@@ -115,10 +115,6 @@ func (c *Configuration) Webhook() WebhookConfig {
 	}
 }
 
-func (c *Configuration) WebConsolePlugin() WebConsolePluginConfig {
-	return WebConsolePluginConfig{c.cfg.WebConsolePlugin}
-}
-
 type AuthConfig struct {
 	auth toolchainv1alpha1.AuthConfig
 }
@@ -251,20 +247,4 @@ func (a WebhookConfig) VMSSHKey() string {
 	}
 	vmAccessKey := commonconfig.GetString(a.w.Secret.VirtualMachineAccessKey, "")
 	return a.webhookSecret(vmAccessKey)
-}
-
-type WebConsolePluginConfig struct {
-	w toolchainv1alpha1.WebConsolePlugin
-}
-
-func (a WebConsolePluginConfig) Deploy() bool {
-	return commonconfig.GetBool(a.w.Deploy, false)
-}
-
-func (a WebConsolePluginConfig) PendoKey() string {
-	return commonconfig.GetString(a.w.PendoKey, "")
-}
-
-func (a WebConsolePluginConfig) PendoHost() string {
-	return commonconfig.GetString(a.w.PendoHost, "cdn.pendo.io")
 }

--- a/pkg/configuration/memberoperatorconfig/configuration_test.go
+++ b/pkg/configuration/memberoperatorconfig/configuration_test.go
@@ -273,30 +273,3 @@ func TestWebhook(t *testing.T) {
 		assert.Equal(t, "ssh-rsa abc-123", memberOperatorCfg.Webhook().VMSSHKey())
 	})
 }
-
-func TestWebConsolePlugin(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		cfg := commonconfig.NewMemberOperatorConfigWithReset(t)
-		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-		assert.False(t, memberOperatorCfg.WebConsolePlugin().Deploy())
-	})
-	t.Run("non-default", func(t *testing.T) {
-		cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.WebConsolePlugin().Deploy(true))
-		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-		assert.True(t, memberOperatorCfg.WebConsolePlugin().Deploy())
-	})
-	t.Run("with PendoKey set", func(t *testing.T) {
-		cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.WebConsolePlugin().PendoKey("XXXX"))
-		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-		assert.Equal(t, "XXXX", memberOperatorCfg.WebConsolePlugin().PendoKey())
-	})
-	t.Run("with PendoHost set", func(t *testing.T) {
-		cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.WebConsolePlugin().PendoHost("abc.pendo.io"))
-		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-		assert.Equal(t, "abc.pendo.io", memberOperatorCfg.WebConsolePlugin().PendoHost())
-	})
-}

--- a/pkg/test/config/memberoperatorconfig.go
+++ b/pkg/test/config/memberoperatorconfig.go
@@ -277,42 +277,6 @@ func (o WebhookOption) VMSSHKey(value string) WebhookOption {
 	return o
 }
 
-type WebConsolePluginOption struct {
-	*MemberOperatorConfigOptionImpl
-}
-
-func WebConsolePlugin() *WebConsolePluginOption {
-	o := &WebConsolePluginOption{
-		&MemberOperatorConfigOptionImpl{},
-	}
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.WebConsolePlugin = toolchainv1alpha1.WebConsolePlugin{}
-	})
-
-	return o
-}
-
-func (o WebConsolePluginOption) Deploy(value bool) WebConsolePluginOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.WebConsolePlugin.Deploy = &value
-	})
-	return o
-}
-
-func (o WebConsolePluginOption) PendoKey(value string) WebConsolePluginOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.WebConsolePlugin.PendoKey = &value
-	})
-	return o
-}
-
-func (o WebConsolePluginOption) PendoHost(value string) WebConsolePluginOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.WebConsolePlugin.PendoHost = &value
-	})
-	return o
-}
-
 func NewMemberOperatorConfigObj(options ...MemberOperatorConfigOption) *toolchainv1alpha1.MemberOperatorConfig {
 	memberOperatorConfig := &toolchainv1alpha1.MemberOperatorConfig{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Pendo has been decommisioned, we don't need this plugin anymore

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
