### PR TITLE
Add User Tier context to Notification Builder

### DIFF
--- a/pkg/test/tier/usertier.go
+++ b/pkg/test/tier/usertier.go
@@ -1,0 +1,36 @@
+package tier
+
+import (
+	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/codeready-toolchain/toolchain-common/pkg/test"
+	"github.com/google/uuid"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func WithDeactivationTimeoutDays(days int) Modifier {
+	return func(userSignup *toolchainv1alpha1.UserTier) {
+		userSignup.Spec.DeactivationTimeoutDays = days
+	}
+}
+
+func WithName(name string) Modifier {
+	return func(userSignup *toolchainv1alpha1.UserTier) {
+		userSignup.Name = name
+	}
+}
+
+type Modifier func(tier *toolchainv1alpha1.UserTier)
+
+func NewUserTier(modifiers ...Modifier) *toolchainv1alpha1.UserTier {
+	t := &toolchainv1alpha1.UserTier{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              uuid.NewString(),
+			Namespace:         test.HostOperatorNs,
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+	for _, modify := range modifiers {
+		modify(t)
+	}
+	return t
+}


### PR DESCRIPTION
So we can use the deactivation timeout days in the user-provisioned email templates from the corresponding user tier.

Part of https://issues.redhat.com/browse/SANDBOX-741