### PR TITLE
Remove the migration step to kubeconfig

### DIFF
--- a/controllers/toolchaincluster/healthchecker_test.go
+++ b/controllers/toolchaincluster/healthchecker_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
 	"github.com/stretchr/testify/require"
@@ -58,7 +57,7 @@ func TestClusterHealthChecks(t *testing.T) {
 	for k, tc := range tests {
 		t.Run(k, func(t *testing.T) {
 			// given
-			tcType, sec := newToolchainCluster(t, tc.tcType, tcNs, tc.apiEndPoint, toolchainv1alpha1.ToolchainClusterStatus{}, false)
+			tcType, sec := newToolchainCluster(t, tc.tcType, tcNs, tc.apiEndPoint)
 			cl := test.NewFakeClient(t, tcType, sec)
 			reset := setupCachedClusters(t, cl, tcType)
 			defer reset()

--- a/controllers/toolchaincluster/toolchaincluster_controller.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller.go
@@ -12,7 +12,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubeclientset "k8s.io/client-go/kubernetes"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -143,29 +142,5 @@ func clusterNotReadyCondition() toolchainv1alpha1.Condition {
 		Status:  corev1.ConditionFalse,
 		Reason:  toolchainv1alpha1.ToolchainClusterClusterNotReadyReason,
 		Message: healthzNotOk,
-	}
-}
-
-func composeKubeConfigFromData(token []byte, apiEndpoint, operatorNamespace string, insecureTls bool) clientcmdapi.Config {
-	return clientcmdapi.Config{
-		Contexts: map[string]*clientcmdapi.Context{
-			"ctx": {
-				Cluster:   "cluster",
-				Namespace: operatorNamespace,
-				AuthInfo:  "auth",
-			},
-		},
-		CurrentContext: "ctx",
-		Clusters: map[string]*clientcmdapi.Cluster{
-			"cluster": {
-				Server:                apiEndpoint,
-				InsecureSkipTLSVerify: insecureTls,
-			},
-		},
-		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"auth": {
-				Token: string(token),
-			},
-		},
 	}
 }

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -45,7 +45,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("ToolchainCluster not found", func(t *testing.T) {
 		// given
-		NotFound, sec := newToolchainCluster(t, "notfound", tcNs, "http://not-found.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		NotFound, sec := newToolchainCluster(t, "notfound", tcNs, "http://not-found.com")
 
 		cl := test.NewFakeClient(t, sec)
 		reset := setupCachedClusters(t, cl, NotFound)
@@ -62,7 +62,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("Error while getting ToolchainCluster", func(t *testing.T) {
 		// given
-		tc, sec := newToolchainCluster(t, "tc", tcNs, "http://tc.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		tc, sec := newToolchainCluster(t, "tc", tcNs, "http://tc.com")
 
 		cl := test.NewFakeClient(t, sec)
 		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
@@ -83,7 +83,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("reconcile successful and requeued", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com")
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -102,7 +102,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("toolchain cluster cache not found", func(t *testing.T) {
 		// given
-		unstable, _ := newToolchainCluster(t, "unstable", tcNs, "http://unstable.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		unstable, _ := newToolchainCluster(t, "unstable", tcNs, "http://unstable.com")
 
 		cl := test.NewFakeClient(t, unstable)
 		controller, req := prepareReconcile(unstable, cl, requeAfter)
@@ -117,7 +117,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("error while updating a toolchain cluster status on cache not found", func(t *testing.T) {
 		// given
-		stable, _ := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		stable, _ := newToolchainCluster(t, "stable", tcNs, "https://cluster.com")
 
 		cl := test.NewFakeClient(t, stable)
 		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
@@ -137,7 +137,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("error while updating a toolchain cluster status when health-check failed", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com")
 		expectedErr := fmt.Errorf("my test error")
 		cl := test.NewFakeClient(t, stable, sec)
 		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
@@ -163,7 +163,7 @@ func TestClusterControllerChecks(t *testing.T) {
 func TestGetClusterHealth(t *testing.T) {
 	t.Run("Check health default", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com")
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -184,7 +184,7 @@ func TestGetClusterHealth(t *testing.T) {
 	})
 	t.Run("get health condition when health obtained is false ", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
+		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com")
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -238,8 +238,8 @@ func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolcha
 	}
 }
 
-func newToolchainCluster(t *testing.T, name, tcNs string, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus, insecureTls bool) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
-	toolchainCluster, secret := test.NewToolchainClusterWithEndpoint(t, name, tcNs, "test-namespace", "secret", apiEndpoint, status, insecureTls)
+func newToolchainCluster(t *testing.T, name, tcNs string, apiEndpoint string) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
+	toolchainCluster, secret := test.NewToolchainClusterWithEndpoint(t, name, tcNs, "test-namespace", "secret", apiEndpoint, toolchainv1alpha1.ToolchainClusterStatus{}, false)
 	return toolchainCluster, secret
 }
 

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -9,7 +9,6 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
@@ -203,19 +202,6 @@ func TestGetClusterHealth(t *testing.T) {
 		require.Equal(t, reconcile.Result{RequeueAfter: requeAfter}, recResult)
 		assertClusterStatus(t, cl, "stable", clusterNotReadyCondition())
 	})
-}
-
-func TestComposeKubeConfig(t *testing.T) {
-	// when
-	kubeConfig := composeKubeConfigFromData([]byte("token"), "http://over.the.rainbow", "the-namespace", false)
-
-	// then
-	context := kubeConfig.Contexts[kubeConfig.CurrentContext]
-
-	assert.Equal(t, "token", kubeConfig.AuthInfos[context.AuthInfo].Token)
-	assert.Equal(t, "http://over.the.rainbow", kubeConfig.Clusters[context.Cluster].Server)
-	assert.Equal(t, "the-namespace", context.Namespace)
-	assert.False(t, kubeConfig.Clusters[context.Cluster].InsecureSkipTLSVerify)
 }
 
 func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolchainv1alpha1.ToolchainCluster) func() {

--- a/controllers/toolchaincluster/toolchaincluster_controller_test.go
+++ b/controllers/toolchaincluster/toolchaincluster_controller_test.go
@@ -9,17 +9,13 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
 	"github.com/codeready-toolchain/toolchain-common/pkg/test"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
-	"gotest.tools/assert/cmp"
 	corev1 "k8s.io/api/core/v1"
 	kubeclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -32,24 +28,24 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	defer gock.Off()
 	tcNs := "test-namespace"
-	gock.New("http://cluster.com").
+	gock.New("https://cluster.com").
 		Get("healthz").
 		Persist().
 		Reply(200).
 		BodyString("ok")
-	gock.New("http://unstable.com").
+	gock.New("https://unstable.com").
 		Get("healthz").
 		Persist().
 		Reply(200).
 		BodyString("unstable")
-	gock.New("http://not-found.com").
+	gock.New("https://not-found.com").
 		Get("healthz").
 		Persist().
 		Reply(404)
 
 	t.Run("ToolchainCluster not found", func(t *testing.T) {
 		// given
-		NotFound, sec := newToolchainCluster("notfound", tcNs, "http://not-found.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		NotFound, sec := newToolchainCluster(t, "notfound", tcNs, "http://not-found.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, sec)
 		reset := setupCachedClusters(t, cl, NotFound)
@@ -66,7 +62,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("Error while getting ToolchainCluster", func(t *testing.T) {
 		// given
-		tc, sec := newToolchainCluster("tc", tcNs, "http://tc.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		tc, sec := newToolchainCluster(t, "tc", tcNs, "http://tc.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, sec)
 		cl.MockGet = func(ctx context.Context, key runtimeclient.ObjectKey, obj runtimeclient.Object, opts ...runtimeclient.GetOption) error {
@@ -87,7 +83,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("reconcile successful and requeued", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -106,7 +102,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("toolchain cluster cache not found", func(t *testing.T) {
 		// given
-		unstable, _ := newToolchainCluster("unstable", tcNs, "http://unstable.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		unstable, _ := newToolchainCluster(t, "unstable", tcNs, "http://unstable.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, unstable)
 		controller, req := prepareReconcile(unstable, cl, requeAfter)
@@ -121,7 +117,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("error while updating a toolchain cluster status on cache not found", func(t *testing.T) {
 		// given
-		stable, _ := newToolchainCluster("stable", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, _ := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, stable)
 		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
@@ -141,7 +137,7 @@ func TestClusterControllerChecks(t *testing.T) {
 
 	t.Run("error while updating a toolchain cluster status when health-check failed", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster(t, "stable", tcNs, "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 		expectedErr := fmt.Errorf("my test error")
 		cl := test.NewFakeClient(t, stable, sec)
 		cl.MockStatusUpdate = func(ctx context.Context, obj runtimeclient.Object, opts ...runtimeclient.UpdateOption) error {
@@ -162,46 +158,12 @@ func TestClusterControllerChecks(t *testing.T) {
 		require.Equal(t, reconcile.Result{}, recResult)
 		assertClusterStatus(t, cl, "stable")
 	})
-
-	t.Run("migrates connection settings to kubeconfig in secret", func(t *testing.T) {
-		// given
-		tc, secret := newToolchainCluster("tc", tcNs, "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
-		cl := test.NewFakeClient(t, tc, secret)
-		reset := setupCachedClusters(t, cl, tc)
-		defer reset()
-
-		controller, req := prepareReconcile(tc, cl, requeAfter)
-		expectedKubeConfig := composeKubeConfigFromData([]byte("mycooltoken"), "http://cluster.com", "test-namespace", true)
-
-		// when
-		_, err := controller.Reconcile(context.TODO(), req)
-		secretAfterReconcile := &corev1.Secret{}
-		require.NoError(t, cl.Get(context.TODO(), runtimeclient.ObjectKeyFromObject(secret), secretAfterReconcile))
-		actualKubeConfig, loadErr := clientcmd.Load(secretAfterReconcile.Data["kubeconfig"])
-
-		// then
-		require.NoError(t, err)
-		require.NoError(t, loadErr)
-		assert.Contains(t, secretAfterReconcile.Data, "kubeconfig")
-
-		// we need to use this more complex equals, because we don't initialize the Extension fields (i.e. they're nil)
-		// while they're initialized and empty after deserialization, which causes the "normal" deep equals to fail.
-		result := cmp.DeepEqual(expectedKubeConfig, *actualKubeConfig,
-			cmpopts.IgnoreFields(clientcmdapi.Config{}, "Extensions"),
-			cmpopts.IgnoreFields(clientcmdapi.Preferences{}, "Extensions"),
-			cmpopts.IgnoreFields(clientcmdapi.Cluster{}, "Extensions"),
-			cmpopts.IgnoreFields(clientcmdapi.AuthInfo{}, "Extensions"),
-			cmpopts.IgnoreFields(clientcmdapi.Context{}, "Extensions"),
-		)()
-
-		assert.True(t, result.Success())
-	})
 }
 
 func TestGetClusterHealth(t *testing.T) {
 	t.Run("Check health default", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", "test-namespace", "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -222,7 +184,7 @@ func TestGetClusterHealth(t *testing.T) {
 	})
 	t.Run("get health condition when health obtained is false ", func(t *testing.T) {
 		// given
-		stable, sec := newToolchainCluster("stable", "test-namespace", "http://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{})
+		stable, sec := newToolchainCluster(t, "stable", "test-namespace", "https://cluster.com", toolchainv1alpha1.ToolchainClusterStatus{}, false)
 
 		cl := test.NewFakeClient(t, stable, sec)
 		reset := setupCachedClusters(t, cl, stable)
@@ -242,6 +204,7 @@ func TestGetClusterHealth(t *testing.T) {
 		assertClusterStatus(t, cl, "stable", clusterNotReadyCondition())
 	})
 }
+
 func TestComposeKubeConfig(t *testing.T) {
 	// when
 	kubeConfig := composeKubeConfigFromData([]byte("token"), "http://over.the.rainbow", "the-namespace", false)
@@ -275,8 +238,8 @@ func setupCachedClusters(t *testing.T, cl *test.FakeClient, clusters ...*toolcha
 	}
 }
 
-func newToolchainCluster(name, tcNs string, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
-	toolchainCluster, secret := test.NewToolchainClusterWithEndpoint(name, tcNs, "secret", apiEndpoint, status, map[string]string{"namespace": "test-namespace"})
+func newToolchainCluster(t *testing.T, name, tcNs string, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus, insecureTls bool) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
+	toolchainCluster, secret := test.NewToolchainClusterWithEndpoint(t, name, tcNs, "test-namespace", "secret", apiEndpoint, status, insecureTls)
 	return toolchainCluster, secret
 }
 

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -19,16 +19,10 @@ import (
 )
 
 const (
-	labelNamespace        = "namespace"
 	labelOwnerClusterName = "ownerClusterName"
 	LabelType             = "type"
 	// labelClusterRolePrefix is the prefix that defines the cluster role as label key
 	labelClusterRolePrefix = "cluster-role"
-
-	// These are not used
-	// toolchainAPIQPS   = 20.0
-	// toolchainAPIBurst = 30
-	// toolchainTokenKey = "token"
 )
 
 // ToolchainClusterService manages cached cluster kube clients and related ToolchainCluster CRDs

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -174,48 +174,7 @@ func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.Tool
 		return nil, errors.Wrapf(err, "unable to get secret %s for cluster %s", name, toolchainCluster.Name)
 	}
 
-	if _, ok := secret.Data["kubeconfig"]; ok {
-		return loadConfigFromKubeConfig(toolchainCluster, secret, timeout)
-	} else {
-		return loadConfigFromLegacyToolchainCluster(toolchainCluster, secret, timeout)
-	}
-}
-
-func loadConfigFromLegacyToolchainCluster(toolchainCluster *toolchainv1alpha1.ToolchainCluster, secret *v1.Secret, timeout time.Duration) (*Config, error) {
-	clusterName := toolchainCluster.Name
-
-	apiEndpoint := toolchainCluster.Spec.APIEndpoint
-	if apiEndpoint == "" {
-		return nil, errors.Errorf("the api endpoint of cluster %s is empty", clusterName)
-	}
-
-	token, tokenFound := secret.Data[toolchainTokenKey]
-	if !tokenFound || len(token) == 0 {
-		return nil, errors.Errorf("the secret for cluster %s is missing a non-empty value for %q", clusterName, toolchainTokenKey)
-	}
-
-	restConfig, err := clientcmd.BuildConfigFromFlags(apiEndpoint, "")
-	if err != nil {
-		return nil, err
-	}
-
-	if len(toolchainCluster.Spec.DisabledTLSValidations) == 1 &&
-		toolchainCluster.Spec.DisabledTLSValidations[0] == toolchainv1alpha1.TLSAll {
-		restConfig.Insecure = true
-	}
-	restConfig.BearerToken = string(token)
-	restConfig.QPS = toolchainAPIQPS
-	restConfig.Burst = toolchainAPIBurst
-	restConfig.Timeout = timeout
-
-	return &Config{
-		Name:              clusterName,
-		APIEndpoint:       apiEndpoint,
-		RestConfig:        restConfig,
-		OperatorNamespace: toolchainCluster.Labels[labelNamespace],
-		OwnerClusterName:  toolchainCluster.Labels[labelOwnerClusterName],
-		Labels:            toolchainCluster.Labels,
-	}, nil
+	return loadConfigFromKubeConfig(toolchainCluster, secret, timeout)
 }
 
 func loadConfigFromKubeConfig(toolchainCluster *toolchainv1alpha1.ToolchainCluster, secret *v1.Secret, timeout time.Duration) (*Config, error) {

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -25,9 +25,10 @@ const (
 	// labelClusterRolePrefix is the prefix that defines the cluster role as label key
 	labelClusterRolePrefix = "cluster-role"
 
-	toolchainAPIQPS   = 20.0
-	toolchainAPIBurst = 30
-	toolchainTokenKey = "token"
+	// These are not used
+	// toolchainAPIQPS   = 20.0
+	// toolchainAPIBurst = 30
+	// toolchainTokenKey = "token"
 )
 
 // ToolchainClusterService manages cached cluster kube clients and related ToolchainCluster CRDs

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -75,8 +75,8 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
 
-	m1, sec1 := test.NewToolchainClusterWithEndpoint(t, "east", test.HostOperatorNs, test.MemberOperatorNs, "secret1", "http://m1.com", status, false)
-	m2, sec2 := test.NewToolchainClusterWithEndpoint(t, "west", test.HostOperatorNs, test.MemberOperatorNs, "secret2", "http://m2.com", status, false)
+	m1, sec1 := test.NewToolchainClusterWithEndpoint(t, "east", test.HostOperatorNs, test.MemberOperatorNs, "secret1", "https://m1.com", status, false)
+	m2, sec2 := test.NewToolchainClusterWithEndpoint(t, "west", test.HostOperatorNs, test.MemberOperatorNs, "secret2", "https://m2.com", status, false)
 	host, secHost := test.NewToolchainCluster(t, "host", test.MemberOperatorNs, test.HostOperatorNs, "secretHost", status, false)
 	noise, secNoise := test.NewToolchainCluster(t, "noise", "noise-namespace", "secretNoise", test.MemberOperatorNs, status, false)
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -93,13 +93,13 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		verify.AssertClusterConfigThat(t, clusterConfigs[0]).
 			HasName("east").
 			HasOperatorNamespace("toolchain-member-operator").
-			HasAPIEndpoint("http://m1.com").
-			RestConfigHasHost("http://m1.com")
+			HasAPIEndpoint("https://m1.com").
+			RestConfigHasHost("https://m1.com")
 		verify.AssertClusterConfigThat(t, clusterConfigs[1]).
 			HasName("west").
 			HasOperatorNamespace("toolchain-member-operator").
-			HasAPIEndpoint("http://m2.com").
-			RestConfigHasHost("http://m2.com")
+			HasAPIEndpoint("https://m2.com").
+			RestConfigHasHost("https://m2.com")
 	})
 
 	t.Run("list host", func(t *testing.T) {

--- a/pkg/cluster/service_test.go
+++ b/pkg/cluster/service_test.go
@@ -75,10 +75,10 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
 
-	m1, sec1 := test.NewToolchainClusterWithEndpoint("east", test.HostOperatorNs, "secret1", "http://m1.com", status, map[string]string{"ownerClusterName": "m1ClusterName", "namespace": test.MemberOperatorNs, cluster.RoleLabel(cluster.Tenant): ""})
-	m2, sec2 := test.NewToolchainClusterWithEndpoint("west", test.HostOperatorNs, "secret2", "http://m2.com", status, map[string]string{"ownerClusterName": "m2ClusterName", "namespace": test.MemberOperatorNs, cluster.RoleLabel(cluster.Tenant): ""})
-	host, secHost := test.NewToolchainCluster("host", test.MemberOperatorNs, "secretHost", status, verify.Labels(test.HostOperatorNs, "hostClusterName"))
-	noise, secNoise := test.NewToolchainCluster("noise", "noise-namespace", "secretNoise", status, verify.Labels(test.MemberOperatorNs, "noiseClusterName"))
+	m1, sec1 := test.NewToolchainClusterWithEndpoint(t, "east", test.HostOperatorNs, test.MemberOperatorNs, "secret1", "http://m1.com", status, false)
+	m2, sec2 := test.NewToolchainClusterWithEndpoint(t, "west", test.HostOperatorNs, test.MemberOperatorNs, "secret2", "http://m2.com", status, false)
+	host, secHost := test.NewToolchainCluster(t, "host", test.MemberOperatorNs, test.HostOperatorNs, "secretHost", status, false)
+	noise, secNoise := test.NewToolchainCluster(t, "noise", "noise-namespace", "secretNoise", test.MemberOperatorNs, status, false)
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
 
 	cl := test.NewFakeClient(t, m1, m2, host, noise, sec1, sec2, secHost, secNoise)
@@ -93,16 +93,12 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		verify.AssertClusterConfigThat(t, clusterConfigs[0]).
 			HasName("east").
 			HasOperatorNamespace("toolchain-member-operator").
-			HasOwnerClusterName("m1ClusterName").
 			HasAPIEndpoint("http://m1.com").
-			ContainsLabel(cluster.RoleLabel(cluster.Tenant)). // the value is not used only the key matters
 			RestConfigHasHost("http://m1.com")
 		verify.AssertClusterConfigThat(t, clusterConfigs[1]).
 			HasName("west").
 			HasOperatorNamespace("toolchain-member-operator").
-			HasOwnerClusterName("m2ClusterName").
 			HasAPIEndpoint("http://m2.com").
-			ContainsLabel(cluster.RoleLabel(cluster.Tenant)). // the value is not used only the key matters
 			RestConfigHasHost("http://m2.com")
 	})
 
@@ -118,9 +114,8 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 		verify.AssertClusterConfigThat(t, clusterConfigs[0]).
 			HasName("host").
 			HasOperatorNamespace("toolchain-host-operator").
-			HasOwnerClusterName("hostClusterName").
-			HasAPIEndpoint("http://cluster.com").
-			RestConfigHasHost("http://cluster.com")
+			HasAPIEndpoint("https://cluster.com").
+			RestConfigHasHost("https://cluster.com")
 	})
 
 	t.Run("list members when there is none present", func(t *testing.T) {
@@ -167,24 +162,7 @@ func TestListToolchainClusterConfigs(t *testing.T) {
 }
 
 func TestNewClusterConfig(t *testing.T) {
-	legacyTc := func() *toolchainv1alpha1.ToolchainCluster {
-		return &toolchainv1alpha1.ToolchainCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "tc",
-				Namespace: "ns",
-				Labels: map[string]string{
-					"namespace": "operatorns",
-				},
-			},
-			Spec: toolchainv1alpha1.ToolchainClusterSpec{
-				APIEndpoint: "https://over.the.rainbow",
-				SecretRef: toolchainv1alpha1.LocalSecretReference{
-					Name: "secret",
-				},
-			},
-		}
-	}
-	newFormTc := func() *toolchainv1alpha1.ToolchainCluster {
+	tc := func() *toolchainv1alpha1.ToolchainCluster {
 		return &toolchainv1alpha1.ToolchainCluster{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "tc",
@@ -198,17 +176,6 @@ func TestNewClusterConfig(t *testing.T) {
 		}
 	}
 
-	legacySecret := func() *corev1.Secret {
-		return &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "secret",
-				Namespace: "ns",
-			},
-			Data: map[string][]byte{
-				"token": []byte("token"),
-			},
-		}
-	}
 	kubeconfigSecret := func(t *testing.T) *corev1.Secret {
 		t.Helper()
 		kubeconfig := clientcmdapi.Config{
@@ -245,40 +212,9 @@ func TestNewClusterConfig(t *testing.T) {
 		}
 	}
 
-	t.Run("using legacy fields in ToolchainCluster and token in secret", func(t *testing.T) {
-		tc := legacyTc()
-		secret := legacySecret()
-
-		cl := test.NewFakeClient(t, tc, secret)
-
-		cfg, err := cluster.NewClusterConfig(cl, tc, 1*time.Second)
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://over.the.rainbow", cfg.APIEndpoint)
-		assert.Equal(t, "operatorns", cfg.OperatorNamespace)
-		assert.Equal(t, "token", cfg.RestConfig.BearerToken)
-	})
-
 	t.Run("using kubeconfig in secret", func(t *testing.T) {
-		tc := newFormTc()
+		tc := tc()
 		secret := kubeconfigSecret(t)
-
-		cl := test.NewFakeClient(t, tc, secret)
-
-		cfg, err := cluster.NewClusterConfig(cl, tc, 1*time.Second)
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://over.the.rainbow", cfg.APIEndpoint)
-		assert.Equal(t, "operatorns", cfg.OperatorNamespace)
-		assert.Equal(t, "token", cfg.RestConfig.BearerToken)
-	})
-
-	t.Run("uses kubeconfig in precedence over legacy fields", func(t *testing.T) {
-		tc := newFormTc()
-		// Combine the kubeconfig and the token in the same secret.
-		// We should see auth from the kubeconfig used...
-		secret := kubeconfigSecret(t)
-		secret.Data["token"] = []byte("not-the-token-we-want")
 
 		cl := test.NewFakeClient(t, tc, secret)
 

--- a/pkg/cluster/service_whitebox_test.go
+++ b/pkg/cluster/service_whitebox_test.go
@@ -20,7 +20,7 @@ func TestRefreshCacheInService(t *testing.T) {
 	// given
 	defer gock.Off()
 	status := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
-	toolchainCluster, sec := test.NewToolchainCluster("east", test.HostOperatorNs, "secret", status, map[string]string{"ownerClusterName": test.NameMember, "namespace": test.MemberOperatorNs})
+	toolchainCluster, sec := test.NewToolchainCluster(t, "east", test.HostOperatorNs, test.MemberOperatorNs, "secret", status, false)
 	s := scheme.Scheme
 	err := toolchainv1alpha1.AddToScheme(s)
 	require.NoError(t, err)
@@ -75,8 +75,7 @@ func TestUpdateClientBasedOnRestConfig(t *testing.T) {
 	// given
 	defer gock.Off()
 	statusTrue := test.NewClusterStatus(toolchainv1alpha1.ConditionReady, corev1.ConditionTrue)
-	toolchainCluster1, sec1 := test.NewToolchainCluster("east", test.HostOperatorNs, "secret1", statusTrue,
-		map[string]string{"namespace": test.HostOperatorNs})
+	toolchainCluster1, sec1 := test.NewToolchainCluster(t, "east", test.HostOperatorNs, test.HostOperatorNs, "secret1", statusTrue, false)
 
 	t.Run("don't update when RestConfig is the same", func(t *testing.T) {
 		// given
@@ -136,6 +135,5 @@ func newToolchainClusterService(cl client.Client, timeout time.Duration, tcNs st
 
 func assertMemberCluster(t *testing.T, cachedCluster *CachedToolchainCluster, status toolchainv1alpha1.ToolchainClusterStatus) {
 	assert.Equal(t, status, *cachedCluster.ClusterStatus)
-	assert.Equal(t, test.NameMember, cachedCluster.OwnerClusterName)
-	assert.Equal(t, "http://cluster.com", cachedCluster.APIEndpoint)
+	assert.Equal(t, "https://cluster.com", cachedCluster.APIEndpoint)
 }

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -1,10 +1,15 @@
 package test
 
 import (
+	"testing"
+
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 const (
@@ -12,16 +17,21 @@ const (
 	NameMember = "east"
 )
 
-func NewToolchainCluster(name, tcNs, secName string, status toolchainv1alpha1.ToolchainClusterStatus, labels map[string]string) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
-	return NewToolchainClusterWithEndpoint(name, tcNs, secName, "http://cluster.com", status, labels)
+func NewToolchainCluster(t *testing.T, name, tcNs, operatorNs, secName string, status toolchainv1alpha1.ToolchainClusterStatus, insecure bool) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
+	t.Helper()
+	return NewToolchainClusterWithEndpoint(t, name, tcNs, operatorNs, secName, "https://cluster.com", status, insecure)
 }
 
-func NewToolchainClusterWithEndpoint(name, tcNs, secName, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus, labels map[string]string) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
+func NewToolchainClusterWithEndpoint(t *testing.T, name, tcNs, operatorNs, secName, apiEndpoint string, status toolchainv1alpha1.ToolchainClusterStatus, insecureTls bool) (*toolchainv1alpha1.ToolchainCluster, *corev1.Secret) {
+	t.Helper()
 	gock.New(apiEndpoint).
 		Get("api").
 		Persist().
 		Reply(200).
 		BodyString("{}")
+
+	kubeConfig := createKubeConfigContent(t, createKubeConfig(apiEndpoint, operatorNs, "mycooltoken", insecureTls))
+
 	secret := &corev1.Secret{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      secName,
@@ -29,7 +39,7 @@ func NewToolchainClusterWithEndpoint(name, tcNs, secName, apiEndpoint string, st
 		},
 		Type: corev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			"token": []byte("mycooltoken"),
+			"kubeconfig": kubeConfig,
 		},
 	}
 
@@ -45,7 +55,6 @@ func NewToolchainClusterWithEndpoint(name, tcNs, secName, apiEndpoint string, st
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,
 			Namespace: tcNs,
-			Labels:    labels,
 		},
 		Status: status,
 	}, secret
@@ -58,4 +67,34 @@ func NewClusterStatus(conType toolchainv1alpha1.ConditionType, conStatus corev1.
 			Status: conStatus,
 		}},
 	}
+}
+
+func createKubeConfig(apiEndpoint, namespace, token string, insecureTls bool) *clientcmdapi.Config {
+	return &clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cluster": {
+				Server:                apiEndpoint,
+				InsecureSkipTLSVerify: insecureTls,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"auth": {
+				Token: token,
+			},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			"ctx": {
+				AuthInfo:  "auth",
+				Cluster:   "cluster",
+				Namespace: namespace,
+			},
+		},
+		CurrentContext: "ctx",
+	}
+}
+
+func createKubeConfigContent(t *testing.T, kubeConfig *clientcmdapi.Config) []byte {
+	data, err := clientcmd.Write(*kubeConfig)
+	require.NoError(t, err)
+	return data
 }

--- a/pkg/test/verify/cluster.go
+++ b/pkg/test/verify/cluster.go
@@ -37,10 +37,7 @@ func AddToolchainClusterAsMember(t *testing.T, functionToVerify FunctionToVerify
 	cachedToolchainCluster, ok := cluster.GetCachedToolchainCluster("east")
 	require.True(t, ok)
 	assert.Equal(t, "member-ns", cachedToolchainCluster.OperatorNamespace)
-	// check that toolchain cluster role label tenant was set only on member cluster type
 	require.NoError(t, cl.Get(context.TODO(), client.ObjectKeyFromObject(toolchainCluster), toolchainCluster))
-	_, found := toolchainCluster.Labels[cluster.RoleLabel(cluster.Tenant)]
-	require.True(t, found)
 	assert.Equal(t, status, *cachedToolchainCluster.ClusterStatus)
 	assert.Equal(t, "https://cluster.com", cachedToolchainCluster.APIEndpoint)
 }
@@ -65,11 +62,7 @@ func AddToolchainClusterAsHost(t *testing.T, functionToVerify FunctionToVerify) 
 
 	assert.Equal(t, "host-ns", cachedToolchainCluster.OperatorNamespace)
 
-	// check that toolchain cluster role label tenant is not set on host cluster
 	require.NoError(t, cl.Get(context.TODO(), client.ObjectKeyFromObject(toolchainCluster), toolchainCluster))
-	expectedToolChainClusterRoleLabel := cluster.RoleLabel(cluster.Tenant)
-	_, found := toolchainCluster.Labels[expectedToolChainClusterRoleLabel]
-	require.False(t, found)
 	assert.Equal(t, status, *cachedToolchainCluster.ClusterStatus)
 	assert.Equal(t, "https://cluster.com", cachedToolchainCluster.APIEndpoint)
 }


### PR DESCRIPTION
Remove the migration step to kubeconfig and update the tests to not test for the legacy fields in ToolchainCluster.

This a follow-up of https://github.com/codeready-toolchain/toolchain-common/pull/412 that updates the testsuite to not rely on the legacy fields that defined the connection settings for the clusters.

This is safe to do, because all of our clusters have already been upgraded and have the kubeconfigs generated in the connection secrets.

Related PRs:
- toolchain-common: https://github.com/codeready-toolchain/toolchain-common/pull/412
- host-operator: https://github.com/codeready-toolchain/host-operator/pull/1058
- toolchain-e2e: https://github.com/codeready-toolchain/toolchain-e2e/pull/1012