### PR TITLE
Don't use fields of ToolchainCluster spec

### DIFF
--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -49,7 +49,6 @@ func NewToolchainClusterWithEndpoint(t *testing.T, name, tcNs, operatorNs, secNa
 				Name: secName,
 			},
 			APIEndpoint:            apiEndpoint,
-			CABundle:               "",
 			DisabledTLSValidations: []toolchainv1alpha1.TLSValidation{toolchainv1alpha1.TLSAll},
 		},
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -48,8 +48,7 @@ func NewToolchainClusterWithEndpoint(t *testing.T, name, tcNs, operatorNs, secNa
 			SecretRef: toolchainv1alpha1.LocalSecretReference{
 				Name: secName,
 			},
-			APIEndpoint:            apiEndpoint,
-			DisabledTLSValidations: []toolchainv1alpha1.TLSValidation{toolchainv1alpha1.TLSAll},
+			APIEndpoint: apiEndpoint,
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,

--- a/pkg/test/cluster.go
+++ b/pkg/test/cluster.go
@@ -48,7 +48,6 @@ func NewToolchainClusterWithEndpoint(t *testing.T, name, tcNs, operatorNs, secNa
 			SecretRef: toolchainv1alpha1.LocalSecretReference{
 				Name: secName,
 			},
-			APIEndpoint: apiEndpoint,
 		},
 		ObjectMeta: v1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
This PR prepares `toolchain-common` for removal of most fields from the `ToolchainCluster` spec. The only field that will eventually remain is the secret reference. All the rest of the fields have either been moved to the status of the `ToolchainCluster` already or are part of the kubeconfig that is stored in the referenced secret.

NOTE: that this PR does NOT update the dependency to the API. That is to avoid breakage during the relatively long time it will take to update all the components with the necessary changes. Once we merge this PR, I will create a number of additional PRs in the rest of the components that will use the new version of `toolchain-common` and make necessary updates in the components to not use the outdated fields of `ToolchainCluster`. Only once those PRs are merged, we can go ahead and merge the PR to remove the fields from the API, followed by another set of PRs to update `toolchain-common` and subsequenlty all the other components to that new version.

Doing it this way will ensure that any changes that happen in `api` and/or `toolchain-common` in the meantime will not be affected by the breaking change.