### PR TITLE
KUBESAW-192: Introduce a make command for pre-requisite of verify-replace script

### DIFF
--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -7,9 +7,11 @@ declare -a REPOS=("${GH_BASE_URL_KS}ksctl" "${GH_BASE_URL_CRT}host-operator" "${
 C_PATH=${PWD}
 ERRORLIST=()
 
+
 echo Initiating verify-replace on dependent repos
 for repo in "${REPOS[@]}"
 do
+    result=0
     echo =========================================================================================
     echo  
     echo                        "$(basename ${repo})"
@@ -20,7 +22,10 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
-    make pre-verify || ERRORLIST+="($(basename ${repo}))"
+    make pre-verify || ERRORLIST+="($(basename ${repo}))" result=${$?}
+    if [ ${result} -ne 0 ]; then
+        continue
+    fi
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/toolchain-common=${C_PATH}
     make verify-dependencies || ERRORLIST+="($(basename ${repo}))"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -22,8 +22,8 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
-    make pre-verify || ERRORLIST+="($(basename ${repo}))" result=${$?}
-    if [ ${result} -ne 0 ]; then
+    if ! make pre-verify; then
+        ERRORLIST+="($(basename ${repo}))"
         continue
     fi
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -20,9 +20,7 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
-    if [ $(basename ${repo}) == "host-operator" ]; then
-        make generate
-    fi
+    make pre-verify
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/toolchain-common=${C_PATH}
     make verify-dependencies || ERRORLIST+="($(basename ${repo}))"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -20,7 +20,7 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
-    make pre-verify
+    make pre-verify || ERRORLIST+="($(basename ${repo}))"
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/toolchain-common=${C_PATH}
     make verify-dependencies || ERRORLIST+="($(basename ${repo}))"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -20,6 +20,9 @@ do
     git clone --depth=1 ${repo} ${repo_path}
     echo "Repo cloned successfully"
     cd ${repo_path}
+    if [ $(basename ${repo}) == "host-operator" ]; then
+        make generate
+    fi
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/toolchain-common=${C_PATH}
     make verify-dependencies || ERRORLIST+="($(basename ${repo}))"

--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -7,11 +7,9 @@ declare -a REPOS=("${GH_BASE_URL_KS}ksctl" "${GH_BASE_URL_CRT}host-operator" "${
 C_PATH=${PWD}
 ERRORLIST=()
 
-
 echo Initiating verify-replace on dependent repos
 for repo in "${REPOS[@]}"
 do
-    result=0
     echo =========================================================================================
     echo  
     echo                        "$(basename ${repo})"


### PR DESCRIPTION
Introduce a make command for pre-requisite of verify-replace script as host-operator and member operator require tiers and assets to be ready before any changes to go mod

Related PRs:
Host Operator - https://github.com/codeready-toolchain/host-operator/pull/1091
Member Operator - https://github.com/codeready-toolchain/member-operator/pull/599 
Toolchain-e2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1049 
Registration service - https://github.com/codeready-toolchain/registration-service/pull/465
Ksctl - https://github.com/kubesaw/ksctl/pull/81