### PR TITLE
Add utility functions to support tests on SpaceProvisionerConfig.Status.ConsumedCapacity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/codeready-toolchain/toolchain-common
 go 1.20
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf
+	github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80
 	github.com/go-logr/logr v1.2.4
 	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/lestrrat-go/jwx v1.2.29

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
-github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf h1:tOHKd4PT6gnV8lLh3kmqqK9YONvL6oFKHpi0kGzfsvw=
-github.com/codeready-toolchain/api v0.0.0-20241114213029-44333bf24bcf/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
+github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80 h1:OpZkP3OGAdrDHOb1TtHVnLSVuevEiQhOH//plnpVL/c=
+github.com/codeready-toolchain/api v0.0.0-20241119094246-f6581d52dc80/go.mod h1:DUq1ffy9Mbersdgji48i/cm9Y+6NMwAdAQJNlfOrPRo=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig.go
+++ b/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig.go
@@ -11,13 +11,15 @@ import (
 type CreateOption func(*toolchainv1alpha1.SpaceProvisionerConfig)
 
 func NewSpaceProvisionerConfig(name string, namespace string, opts ...CreateOption) *toolchainv1alpha1.SpaceProvisionerConfig {
-	spc := &toolchainv1alpha1.SpaceProvisionerConfig{
+	return ModifySpaceProvisionerConfig(&toolchainv1alpha1.SpaceProvisionerConfig{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-	}
+	}, opts...)
+}
 
+func ModifySpaceProvisionerConfig(spc *toolchainv1alpha1.SpaceProvisionerConfig, opts ...CreateOption) *toolchainv1alpha1.SpaceProvisionerConfig {
 	for _, apply := range opts {
 		apply(spc)
 	}
@@ -74,5 +76,26 @@ func MaxNumberOfSpaces(number uint) CreateOption {
 func MaxMemoryUtilizationPercent(number uint) CreateOption {
 	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
 		spc.Spec.CapacityThresholds.MaxMemoryUtilizationPercent = number
+	}
+}
+
+func WithConsumedSpaceCount(value int) CreateOption {
+	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
+		if spc.Status.ConsumedCapacity == nil {
+			spc.Status.ConsumedCapacity = &toolchainv1alpha1.ConsumedCapacity{}
+		}
+		spc.Status.ConsumedCapacity.SpaceCount = value
+	}
+}
+
+func WithConsumedMemoryUsagePercentInNode(role string, usage int) CreateOption {
+	return func(spc *toolchainv1alpha1.SpaceProvisionerConfig) {
+		if spc.Status.ConsumedCapacity == nil {
+			spc.Status.ConsumedCapacity = &toolchainv1alpha1.ConsumedCapacity{}
+		}
+		if spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole == nil {
+			spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole = map[string]int{}
+		}
+		spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole[role] = usage
 	}
 }

--- a/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig_assertions.go
+++ b/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig_assertions.go
@@ -8,81 +8,132 @@ import (
 )
 
 type (
-	ready              struct{}
-	notReady           struct{}
-	notReadyWithReason struct {
-		expectedReason string
+	readyWithStatusAndReason struct {
+		expectedStatus corev1.ConditionStatus
+		expectedReason *string
 	}
+
+	consumedSpaceCount struct {
+		expectedSpaceCount int
+	}
+
+	consumedMemoryUsage struct {
+		expectedMemoryUsage map[string]int
+	}
+
+	unknownConsumedCapacity struct{}
 )
 
 var (
-	_ assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig]           = (*ready)(nil)
-	_ assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig]           = (*notReady)(nil)
-	_ assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig]           = (*notReadyWithReason)(nil)
-	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*ready)(nil)
-	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*notReady)(nil)
-	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*notReadyWithReason)(nil)
+	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*readyWithStatusAndReason)(nil)
+	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*consumedSpaceCount)(nil)
+	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*consumedMemoryUsage)(nil)
+	_ assertions.PredicateMatchFixer[*toolchainv1alpha1.SpaceProvisionerConfig] = (*unknownConsumedCapacity)(nil)
 )
 
-func (*ready) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
-	return condition.IsTrueWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionerConfigValidReason)
+func (r *readyWithStatusAndReason) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
+	cond, found := condition.FindConditionByType(spc.Status.Conditions, toolchainv1alpha1.ConditionReady)
+	if !found {
+		return false
+	}
+
+	if cond.Status != r.expectedStatus {
+		return false
+	}
+
+	if r.expectedReason != nil && cond.Reason != *r.expectedReason {
+		return false
+	}
+
+	return true
 }
 
-func (*ready) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
-	spc.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spc.Status.Conditions, toolchainv1alpha1.Condition{
-		Type:   toolchainv1alpha1.ConditionReady,
-		Status: corev1.ConditionTrue,
-		Reason: toolchainv1alpha1.SpaceProvisionerConfigValidReason,
-	})
+func (r *readyWithStatusAndReason) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
+	cnd, found := condition.FindConditionByType(spc.Status.Conditions, toolchainv1alpha1.ConditionReady)
+	cnd.Type = toolchainv1alpha1.ConditionReady
+	cnd.Status = r.expectedStatus
+	if r.expectedReason != nil {
+		cnd.Reason = *r.expectedReason
+	}
+	if !found {
+		spc.Status.Conditions = condition.AddStatusConditions(spc.Status.Conditions, cnd)
+	} else {
+		spc.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spc.Status.Conditions, cnd)
+	}
+	return spc
+}
+
+func (p *consumedSpaceCount) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
+	if spc.Status.ConsumedCapacity == nil {
+		return false
+	}
+	return p.expectedSpaceCount == spc.Status.ConsumedCapacity.SpaceCount
+}
+
+func (p *consumedSpaceCount) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
+	if spc.Status.ConsumedCapacity == nil {
+		spc.Status.ConsumedCapacity = &toolchainv1alpha1.ConsumedCapacity{}
+	}
+	spc.Status.ConsumedCapacity.SpaceCount = p.expectedSpaceCount
+	return spc
+}
+
+func (p *consumedMemoryUsage) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
+	if spc.Status.ConsumedCapacity == nil {
+		return false
+	}
+	if len(spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole) != len(p.expectedMemoryUsage) {
+		return false
+	}
+	for k, v := range spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole {
+		if p.expectedMemoryUsage[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *consumedMemoryUsage) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
+	if spc.Status.ConsumedCapacity == nil {
+		spc.Status.ConsumedCapacity = &toolchainv1alpha1.ConsumedCapacity{}
+	}
+	spc.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole = p.expectedMemoryUsage
+	return spc
+}
+
+func (p *unknownConsumedCapacity) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
+	return spc.Status.ConsumedCapacity == nil
+}
+
+func (p *unknownConsumedCapacity) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
+	spc.Status.ConsumedCapacity = nil
 	return spc
 }
 
 func Ready() assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
-	return &ready{}
-}
-
-func (*notReady) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
-	return condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady)
-}
-
-func (*notReady) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
-	cnd, found := condition.FindConditionByType(spc.Status.Conditions, toolchainv1alpha1.ConditionReady)
-	if !found {
-		spc.Status.Conditions = condition.AddStatusConditions(spc.Status.Conditions, toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionFalse,
-		})
-	} else {
-		cnd.Status = corev1.ConditionFalse
-		spc.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spc.Status.Conditions, cnd)
-	}
-	return spc
+	return &readyWithStatusAndReason{expectedStatus: corev1.ConditionTrue}
 }
 
 func NotReady() assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
-	return &notReady{}
-}
-
-func (p *notReadyWithReason) Matches(spc *toolchainv1alpha1.SpaceProvisionerConfig) bool {
-	return condition.IsFalseWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, p.expectedReason)
-}
-
-func (p *notReadyWithReason) FixToMatch(spc *toolchainv1alpha1.SpaceProvisionerConfig) *toolchainv1alpha1.SpaceProvisionerConfig {
-	cnd, found := condition.FindConditionByType(spc.Status.Conditions, toolchainv1alpha1.ConditionReady)
-	if !found {
-		spc.Status.Conditions = condition.AddStatusConditions(spc.Status.Conditions, toolchainv1alpha1.Condition{
-			Type:   toolchainv1alpha1.ConditionReady,
-			Status: corev1.ConditionFalse,
-			Reason: p.expectedReason,
-		})
-	} else {
-		cnd.Status = corev1.ConditionFalse
-		cnd.Reason = p.expectedReason
-		spc.Status.Conditions, _ = condition.AddOrUpdateStatusConditions(spc.Status.Conditions, cnd)
-	}
-	return spc
+	return &readyWithStatusAndReason{expectedStatus: corev1.ConditionFalse}
 }
 
 func NotReadyWithReason(reason string) assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
-	return &notReadyWithReason{expectedReason: reason}
+	return &readyWithStatusAndReason{expectedStatus: corev1.ConditionFalse, expectedReason: &reason}
+}
+
+func ReadyStatusAndReason(status corev1.ConditionStatus, reason string) assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
+	return &readyWithStatusAndReason{expectedStatus: status, expectedReason: &reason}
+}
+
+func ConsumedSpaceCount(value int) assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
+	return &consumedSpaceCount{expectedSpaceCount: value}
+}
+
+func ConsumedMemoryUsage(values map[string]int) assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
+	return &consumedMemoryUsage{expectedMemoryUsage: values}
+}
+
+func UnknownConsumedCapacity() assertions.Predicate[*toolchainv1alpha1.SpaceProvisionerConfig] {
+	return &unknownConsumedCapacity{}
 }

--- a/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig_assertions_test.go
+++ b/pkg/test/spaceprovisionerconfig/spaceprovisionerconfig_assertions_test.go
@@ -9,158 +9,265 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestReadyPredicate(t *testing.T) {
-	t.Run("matching", func(t *testing.T) {
+func TestReadyWithStatusAndReasonPredicate(t *testing.T) {
+	test := func(status corev1.ConditionStatus, reason string, t *testing.T) {
+		t.Run("matching: status="+string(status)+", reason='"+reason+"'", func(t *testing.T) {
+			// given
+			pred := &readyWithStatusAndReason{expectedStatus: status}
+			spc := NewSpaceProvisionerConfig("spc", "default", WithReadyCondition(status, reason))
+
+			// when & then
+			assert.True(t, pred.Matches(spc))
+		})
+
+		t.Run("fixer with no conditions: status="+string(status)+", reason='"+reason+"'", func(t *testing.T) {
+			// given
+			pred := &readyWithStatusAndReason{expectedStatus: status}
+			spc := NewSpaceProvisionerConfig("spc", "default")
+
+			// when
+			spc = pred.FixToMatch(spc)
+
+			// then
+			assert.Equal(t, 1, condition.Count(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, status, ""))
+		})
+		t.Run("fixer with different conditions: status="+string(status)+", reason='"+reason+"'", func(t *testing.T) {
+			// given
+			pred := &readyWithStatusAndReason{expectedStatus: status}
+			spc := NewSpaceProvisionerConfig("spc", "default")
+			spc.Status.Conditions = []toolchainv1alpha1.Condition{
+				{
+					Type:   toolchainv1alpha1.ConditionType("made up"),
+					Status: corev1.ConditionTrue,
+				},
+			}
+
+			// when
+			spc = pred.FixToMatch(spc)
+
+			// then
+			assert.Equal(t, 1, condition.Count(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, status, ""))
+			assert.Len(t, spc.Status.Conditions, 2)
+		})
+		t.Run("fixer with wrong condition: status="+string(status)+", reason='"+reason+"'", func(t *testing.T) {
+			// given
+			anotherStatus := corev1.ConditionTrue
+			if anotherStatus == status {
+				anotherStatus = corev1.ConditionFalse
+			}
+			if anotherStatus == status {
+				anotherStatus = corev1.ConditionUnknown
+			}
+			pred := &readyWithStatusAndReason{expectedStatus: status}
+			expectedReason := "because"
+			spc := NewSpaceProvisionerConfig("spc", "default", WithReadyCondition(anotherStatus, expectedReason))
+
+			// when
+			spc = pred.FixToMatch(spc)
+
+			// then
+			assert.Equal(t, 1, condition.Count(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, status, expectedReason))
+		})
+	}
+
+	for _, status := range []corev1.ConditionStatus{corev1.ConditionTrue, corev1.ConditionFalse, corev1.ConditionUnknown} {
+		t.Run("no reason specified", func(t *testing.T) {
+			test(status, "", t)
+		})
+		t.Run("with reason", func(t *testing.T) {
+			test(status, "the reason", t)
+		})
+	}
+}
+
+func TestConsumedSpaceCountPredicate(t *testing.T) {
+	t.Run("matches", func(t *testing.T) {
 		// given
-		pred := &ready{}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionValid())
+		pred := &consumedSpaceCount{expectedSpaceCount: 5}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(5))
 
 		// when & then
 		assert.True(t, pred.Matches(spc))
 	})
-
-	t.Run("fixer with no conditions", func(t *testing.T) {
+	t.Run("doesn't match", func(t *testing.T) {
 		// given
-		pred := &ready{}
+		pred := &consumedSpaceCount{expectedSpaceCount: 5}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(4))
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match if nil consumed capacity", func(t *testing.T) {
+		// given
+		pred := &consumedSpaceCount{expectedSpaceCount: 5}
+		spc := NewSpaceProvisionerConfig("spc", "default")
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("fixes wrong value", func(t *testing.T) {
+		// given
+		pred := &consumedSpaceCount{expectedSpaceCount: 5}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(4))
+
+		// when
+		fixed := pred.FixToMatch(spc.DeepCopy())
+
+		// then
+		assert.NotNil(t, fixed.Status.ConsumedCapacity)
+		assert.Equal(t, 5, fixed.Status.ConsumedCapacity.SpaceCount)
+	})
+	t.Run("fixes if there's no consumed capacity", func(t *testing.T) {
+		// given
+		pred := &consumedSpaceCount{expectedSpaceCount: 5}
 		spc := NewSpaceProvisionerConfig("spc", "default")
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsTrue(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
-	})
-	t.Run("fixer with different conditions", func(t *testing.T) {
-		// given
-		pred := &ready{}
-		spc := NewSpaceProvisionerConfig("spc", "default")
-		spc.Status.Conditions = []toolchainv1alpha1.Condition{
-			{
-				Type:   toolchainv1alpha1.ConditionType("made up"),
-				Status: corev1.ConditionTrue,
-			},
-		}
-
-		// when
-		spc = pred.FixToMatch(spc)
-
-		// then
-		assert.True(t, condition.IsTrue(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
-		assert.Len(t, spc.Status.Conditions, 2)
-	})
-	t.Run("fixer with wrong condition", func(t *testing.T) {
-		// given
-		pred := &ready{}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionInvalid("because"))
-
-		// when
-		spc = pred.FixToMatch(spc)
-
-		// then
-		assert.True(t, condition.IsTrueWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, toolchainv1alpha1.SpaceProvisionerConfigValidReason))
+		assert.NotNil(t, fixed.Status.ConsumedCapacity)
+		assert.Equal(t, 5, fixed.Status.ConsumedCapacity.SpaceCount)
 	})
 }
 
-func TestNotReadyPredicate(t *testing.T) {
-	t.Run("matching", func(t *testing.T) {
+func TestConsumedMemoryUsagePredicate(t *testing.T) {
+	t.Run("matches", func(t *testing.T) {
 		// given
-		pred := &notReady{}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionInvalid("any reason"))
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedMemoryUsagePercentInNode("worker", 5), WithConsumedMemoryUsagePercentInNode("master", 20))
 
 		// when & then
 		assert.True(t, pred.Matches(spc))
 	})
-
-	t.Run("fixer with no conditions", func(t *testing.T) {
+	t.Run("doesn't match if expecting more keys", func(t *testing.T) {
 		// given
-		pred := &notReady{}
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedMemoryUsagePercentInNode("worker", 5))
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match if more keys present", func(t *testing.T) {
+		// given
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5}}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedMemoryUsagePercentInNode("worker", 5), WithConsumedMemoryUsagePercentInNode("master", 20))
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match if value differs", func(t *testing.T) {
+		// given
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedMemoryUsagePercentInNode("worker", 5), WithConsumedMemoryUsagePercentInNode("master", 21))
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match if nil consumed capacity", func(t *testing.T) {
+		// given
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default")
+
+		// when & then
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("fixes no consumed capacity", func(t *testing.T) {
+		// given
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
 		spc := NewSpaceProvisionerConfig("spc", "default")
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+		assert.NotNil(t, fixed.Status.ConsumedCapacity)
+		assert.Len(t, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole, 2)
+		assert.Equal(t, 5, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["worker"])
+		assert.Equal(t, 20, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["master"])
 	})
-	t.Run("fixer with different conditions", func(t *testing.T) {
+	t.Run("fixes different values", func(t *testing.T) {
 		// given
-		pred := &notReady{}
-		spc := NewSpaceProvisionerConfig("spc", "default")
-		spc.Status.Conditions = []toolchainv1alpha1.Condition{
-			{
-				Type:   toolchainv1alpha1.ConditionType("made up"),
-				Status: corev1.ConditionTrue,
-			},
-		}
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default",
+			WithConsumedMemoryUsagePercentInNode("worker", 6),
+			WithConsumedMemoryUsagePercentInNode("master", 21),
+		)
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
-		assert.Len(t, spc.Status.Conditions, 2)
+		assert.NotNil(t, fixed.Status.ConsumedCapacity)
+		assert.Len(t, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole, 2)
+		assert.Equal(t, 5, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["worker"])
+		assert.Equal(t, 20, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["master"])
 	})
-	t.Run("fixer with wrong condition", func(t *testing.T) {
+	t.Run("fixes different keys", func(t *testing.T) {
 		// given
-		pred := &notReady{}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionValid())
+		pred := &consumedMemoryUsage{expectedMemoryUsage: map[string]int{"worker": 5, "master": 20}}
+		spc := NewSpaceProvisionerConfig("spc", "default",
+			WithConsumedMemoryUsagePercentInNode("master", 21),
+			WithConsumedMemoryUsagePercentInNode("disaster", 80),
+		)
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsFalse(spc.Status.Conditions, toolchainv1alpha1.ConditionReady))
+		assert.NotNil(t, fixed.Status.ConsumedCapacity)
+		assert.Len(t, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole, 2)
+		assert.Equal(t, 5, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["worker"])
+		assert.Equal(t, 20, fixed.Status.ConsumedCapacity.MemoryUsagePercentPerNodeRole["master"])
 	})
 }
 
-func TestNotReadyWithReasonPredicate(t *testing.T) {
-	t.Run("matching", func(t *testing.T) {
-		// given
-		pred := &notReadyWithReason{expectedReason: "the right reason"}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionInvalid("the right reason"))
+func TestUnknownConsumedCapacityPredicate(t *testing.T) {
+	t.Run("matches", func(t *testing.T) {
+		pred := &unknownConsumedCapacity{}
+		spc := NewSpaceProvisionerConfig("spc", "default")
 
-		// when & then
 		assert.True(t, pred.Matches(spc))
 	})
+	t.Run("doesn't match with space count", func(t *testing.T) {
+		pred := &unknownConsumedCapacity{}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(5))
 
-	t.Run("fixer with no conditions", func(t *testing.T) {
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match with memory usage", func(t *testing.T) {
+		pred := &unknownConsumedCapacity{}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedMemoryUsagePercentInNode("master", 5))
+
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("doesn't match with full consumed capacity", func(t *testing.T) {
+		pred := &unknownConsumedCapacity{}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(5), WithConsumedMemoryUsagePercentInNode("workter", 5))
+
+		assert.False(t, pred.Matches(spc))
+	})
+	t.Run("fixer does nothing on matching SPC", func(t *testing.T) {
 		// given
-		pred := &notReadyWithReason{expectedReason: "the right reason"}
+		pred := &unknownConsumedCapacity{}
 		spc := NewSpaceProvisionerConfig("spc", "default")
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsFalseWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, "the right reason"))
+		assert.Equal(t, spc, fixed)
 	})
-	t.Run("fixer with different conditions", func(t *testing.T) {
+	t.Run("fixes non-matching", func(t *testing.T) {
 		// given
-		pred := &notReadyWithReason{expectedReason: "the right reason"}
-		spc := NewSpaceProvisionerConfig("spc", "default")
-		spc.Status.Conditions = []toolchainv1alpha1.Condition{
-			{
-				Type:   toolchainv1alpha1.ConditionType("made up"),
-				Status: corev1.ConditionTrue,
-			},
-		}
+		pred := &unknownConsumedCapacity{}
+		spc := NewSpaceProvisionerConfig("spc", "default", WithConsumedSpaceCount(5))
 
 		// when
-		spc = pred.FixToMatch(spc)
+		fixed := pred.FixToMatch(spc.DeepCopy())
 
 		// then
-		assert.True(t, condition.IsFalseWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, "the right reason"))
-		assert.Len(t, spc.Status.Conditions, 2)
-	})
-	t.Run("fixer with wrong condition", func(t *testing.T) {
-		// given
-		pred := &notReadyWithReason{expectedReason: "the right reason"}
-		spc := NewSpaceProvisionerConfig("spc", "default", WithReadyConditionInvalid("the wrong reason"))
-
-		// when
-		spc = pred.FixToMatch(spc)
-
-		// then
-		assert.True(t, condition.IsFalseWithReason(spc.Status.Conditions, toolchainv1alpha1.ConditionReady, "the right reason"))
+		assert.NotEqual(t, spc, fixed)
+		assert.Nil(t, fixed.Status.ConsumedCapacity)
 	})
 }


### PR DESCRIPTION
This just adds a couple of utility functions and predicates to be used by the tests on the new `SpaceProvisionerConfig.Status.ConsumedCapacity`. The functions will be used in code in the host operator and e2e tests in the upcoming PRs.