### PR TITLE
Use LabelsAndGenerationPredicate for ToolchainClusterCache controller

### DIFF
--- a/controllers/toolchainclustercache/toolchaincluster_cache_controller.go
+++ b/controllers/toolchainclustercache/toolchaincluster_cache_controller.go
@@ -6,6 +6,7 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
+	commonpredicates "github.com/codeready-toolchain/toolchain-common/pkg/predicate"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -31,7 +32,7 @@ func NewReconciler(mgr manager.Manager, namespace string, timeout time.Duration)
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&toolchainv1alpha1.ToolchainCluster{}, builder.WithPredicates(namespacePredicate{namespace: r.namespace})).
+		For(&toolchainv1alpha1.ToolchainCluster{}, builder.WithPredicates(namespacePredicate{namespace: r.namespace}, commonpredicates.LabelsAndGenerationPredicate{})).
 		Complete(r)
 }
 


### PR DESCRIPTION
Use LabelsAndGenerationPredicate for ToolchainClusterCache controller to prevent it from reconciling unnecessarily. It's especially relevant since the health checker was included in the ToolchainCluster controller: https://github.com/codeready-toolchain/member-operator/blob/50180a07ca25f97123bf4cc614e801b542beb6cb/main.go#L231 which triggers ToolchainConfig status updates every 10 seconds.