### PR TITLE
Revert "Use LabelsAndGenerationPredicate for ToolchainClusterCache co…

### DIFF
--- a/controllers/toolchainclustercache/toolchaincluster_cache_controller.go
+++ b/controllers/toolchainclustercache/toolchaincluster_cache_controller.go
@@ -6,7 +6,6 @@ import (
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	"github.com/codeready-toolchain/toolchain-common/pkg/cluster"
-	commonpredicates "github.com/codeready-toolchain/toolchain-common/pkg/predicate"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -32,7 +31,7 @@ func NewReconciler(mgr manager.Manager, namespace string, timeout time.Duration)
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&toolchainv1alpha1.ToolchainCluster{}, builder.WithPredicates(namespacePredicate{namespace: r.namespace}, commonpredicates.LabelsAndGenerationPredicate{})).
+		For(&toolchainv1alpha1.ToolchainCluster{}, builder.WithPredicates(namespacePredicate{namespace: r.namespace})).
 		Complete(r)
 }
 


### PR DESCRIPTION
…ntroller (#437)"

This reverts commit 463b623cd97191b601e6a2b08b5142c39486b56f.

It breaks the cluster status checks. See the discussion https://redhat-internal.slack.com/archives/C06MJ2DVBU4/p1733903646722119?thread_ts=1733844483.420089&cid=C06MJ2DVBU4