### PR TITLE
KUBESAW-250: Updating GolangCiLint to v1.63.1

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.52.0
+        version: v1.63.1
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/pkg/status/componentconditions.go
+++ b/pkg/status/componentconditions.go
@@ -39,7 +39,7 @@ func ValidateComponentConditionReady(conditions ...toolchainv1alpha1.Condition) 
 	if !found {
 		return fmt.Errorf("a ready condition was not found")
 	} else if c.Status != corev1.ConditionTrue {
-		return fmt.Errorf(c.Message) // return an error with the message from the condition
+		return fmt.Errorf("%s", c.Message) // return an error with the message from the condition
 	}
 
 	return nil


### PR DESCRIPTION
Updating the GolangciLint to v1.63.1 across all repos and fixing the [linter error](https://github.com/codeready-toolchain/toolchain-common/actions/runs/12649409591/job/35245760745?pr=442#step:4:29) which were caught as a result of upgrading the linter

Similar PRs

- API - https://github.com/codeready-toolchain/api/pull/454
- Host-Operator - https://github.com/codeready-toolchain/host-operator/pull/1116
- Member-Operator - Member-Operator - https://github.com/codeready-toolchain/member-operator/pull/612
- Registration-Service - https://github.com/codeready-toolchain/registration-service/pull/491
- Toolchain E2e - https://github.com/codeready-toolchain/toolchain-e2e/pull/1092
- Ksctl - https://github.com/kubesaw/ksctl/pull/97