### PR TITLE
Introduce a make command for pre-requisite of verify-replace

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -31,3 +31,7 @@ vet:
 ## downloads all the repos that depend on toolchain-common, installs the current version of the library and runs all the verifications in order to check for compatibility and breaking changes
 verify-replace-run:
 	./scripts/verify-replace.sh; 
+
+.PHONY: pre-verify
+pre-verify:
+	echo "No Pre-requisite needed"


### PR DESCRIPTION
Introduce a make command for pre-requisite of verify-replace script

Initially this was not required to be run from the api repo, but now this same error started appearing while running from api repo too hence adding the make command to be similar to [PR](https://github.com/codeready-toolchain/host-operator/pull/1091)