### PR TITLE
KUBESAW-250: Fixing the linter error Linter for v1.63.1

### DIFF
--- a/pkg/status/componentconditions.go
+++ b/pkg/status/componentconditions.go
@@ -39,7 +39,7 @@ func ValidateComponentConditionReady(conditions ...toolchainv1alpha1.Condition) 
 	if !found {
 		return fmt.Errorf("a ready condition was not found")
 	} else if c.Status != corev1.ConditionTrue {
-		return fmt.Errorf(c.Message) // return an error with the message from the condition
+		return fmt.Errorf("%s", c.Message) // return an error with the message from the condition
 	}
 
 	return nil


### PR DESCRIPTION
Would be upgrading to golangci-lint version 1.63.3 . This PR is to fix the [linter error](https://github.com/codeready-toolchain/toolchain-common/actions/runs/12649409591/job/35245760745?pr=442#step:4:29) which were caught as a result of upgrading the linter 

Related PR -
- Toolchain-Common - https://github.com/codeready-toolchain/toolchain-common/pull/442 