### PR TITLE
Adding the api replace/dependency in dependent repos

### DIFF
--- a/scripts/verify-replace.sh
+++ b/scripts/verify-replace.sh
@@ -5,6 +5,7 @@ GH_BASE_URL_KS=https://github.com/kubesaw/
 GH_BASE_URL_CRT=https://github.com/codeready-toolchain/
 declare -a REPOS=("${GH_BASE_URL_KS}ksctl" "${GH_BASE_URL_CRT}host-operator" "${GH_BASE_URL_CRT}member-operator" "${GH_BASE_URL_CRT}registration-service" "${GH_BASE_URL_CRT}toolchain-e2e")
 C_PATH=${PWD}
+API_REPLACE=$(grep 'replace' go.mod)
 ERROR_REPO_LIST=()
 ERROR_FILE_LIST=()
 STD_OUT_FILE_LIST=()
@@ -39,6 +40,7 @@ do
     fi
     echo "Initiating 'go mod replace' of current toolchain common version in dependent repos"
     go mod edit -replace github.com/codeready-toolchain/toolchain-common=${C_PATH}
+    echo ${API_REPLACE} >> go.mod
     make verify-dependencies 2> >(tee ${err_file}) 1> >(tee ${std_out_file})
     rc=$?
     if [ ${rc} -ne 0 ]; then


### PR DESCRIPTION
This change is to add the api repo replace along with toolchain common in the dependency check to cover the case where there are changes to api and to toolchain common both, so the verify script can check it correctly