### PR TITLE
clean unnecessary copy

### DIFF
--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -219,7 +219,6 @@ func ListToolchainClusterConfigs(cl client.Client, namespace string, timeout tim
 	}
 	var configs []*Config
 	for _, cluster := range toolchainClusters.Items {
-		cluster := cluster // TODO We won't need it after upgrading to go 1.22: https://go.dev/blog/loopvar-preview
 		clusterConfig, err := NewClusterConfig(cl, &cluster, timeout)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description
- clean unnecessary copy. With go 1.22, we do not need it. For more info, check https://go.dev/blog/loopvar-preview


Related PRs:
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1133
- https://github.com/codeready-toolchain/host-operator/pull/1157
- https://github.com/codeready-toolchain/member-operator/pull/641
- https://github.com/kubesaw/ksctl/pull/108
- wa pr 149
