### PR TITLE
feat: add string helper

### DIFF
--- a/pkg/utils/stringhelper.go
+++ b/pkg/utils/stringhelper.go
@@ -1,0 +1,13 @@
+package utils
+
+import "strings"
+
+// SplitCommaSeparatedList acts exactly the same as strings.Split(s, ",") but returns an empty slice for empty strings.
+// To be used when, for example, we want to get an empty slice for empty comma separated list:
+// strings.Split("", ",") returns [""] while SplitCommaSeparatedList("") returns []
+func SplitCommaSeparatedList(s string) []string {
+	if len(s) == 0 {
+		return []string{}
+	}
+	return strings.Split(s, ",")
+}

--- a/pkg/utils/stringhelper_test.go
+++ b/pkg/utils/stringhelper_test.go
@@ -1,0 +1,15 @@
+package utils_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/codeready-toolchain/toolchain-common/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReallySplit(t *testing.T) {
+	assert.Empty(t, utils.SplitCommaSeparatedList(""))
+	assert.Equal(t, strings.Split("1,2,3", ","), utils.SplitCommaSeparatedList("1,2,3"))
+	assert.Equal(t, strings.Split("1", ","), utils.SplitCommaSeparatedList("1"))
+}


### PR DESCRIPTION
Move string helper utility to common so that it can be used in other repos for splitting the features annotation into a slice.

Jira: https://issues.redhat.com/browse/KUBESAW-142

Related to:
https://github.com/codeready-toolchain/member-operator/pull/648
https://github.com/codeready-toolchain/toolchain-e2e/pull/1137