### PR TITLE
chore(build): migrate to golangci-lint@v2 and golangci-lint-action@v7

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -23,9 +23,9 @@ jobs:
         go-version-file: go.mod
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.63.1
+        version: v2.0.2
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=./.golangci.yml --verbose

--- a/.golangci.bck.yml
+++ b/.golangci.bck.yml
@@ -1,0 +1,35 @@
+run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 10m
+
+linters:
+  enable:
+    - megacheck
+    - gocyclo
+    - gofmt
+    - revive
+    - misspell
+  presets: # groups of linters. See https://golangci-lint.run/usage/linters/
+    - bugs
+    - unused
+  disable: 
+    - golint # deprecated, use 'revive'
+    - scopelint # deprecated, use 'exportloopref'
+    - contextcheck # too many false-positives
+    - noctx # not needed
+
+# all available settings of specific linters
+linters-settings:
+  unparam:
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: true
+  revive:
+    # https://golangci-lint.run/usage/linters/#revive
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
+      - name: dot-imports
+        disabled: true
+ 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,35 +1,62 @@
-run:
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 10m
-
+version: "2"
 linters:
   enable:
-    - megacheck
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - durationcheck
+    - errchkjson
+    - errorlint
+    - exhaustive
+    - gocheckcompilerdirectives
+    - gochecksumtype
     - gocyclo
-    - gofmt
-    - revive
+    - gosec
+    - gosmopolitan
+    - loggercheck
+    - makezero
     - misspell
-  presets: # groups of linters. See https://golangci-lint.run/usage/linters/
-    - bugs
-    - unused
-  disable: 
-    - golint # deprecated, use 'revive'
-    - scopelint # deprecated, use 'exportloopref'
-    - contextcheck # too many false-positives
-    - noctx # not needed
-
-# all available settings of specific linters
-linters-settings:
-  unparam:
-    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
-    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: true
-  revive:
-    # https://golangci-lint.run/usage/linters/#revive
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#dot-imports
-      - name: dot-imports
-        disabled: true
- 
+    - musttag
+    - nilerr
+    - nilnesserr
+    - protogetter
+    - reassign
+    - recvcheck
+    - revive
+    - rowserrcheck
+    - spancheck
+    - sqlclosecheck
+    - testifylint
+    - unparam
+    - zerologlint
+  disable:
+    - contextcheck
+    - noctx
+  settings:
+    revive:
+      rules:
+        - name: dot-imports
+          disabled: true
+    unparam:
+      check-exported: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/banneduser/banneduser_test.go
+++ b/pkg/banneduser/banneduser_test.go
@@ -105,8 +105,8 @@ func TestNewBannedUser(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, got)
 
-				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Namespace, got.ObjectMeta.Namespace)
-				assert.Equal(t, tt.expectedBannedUser.ObjectMeta.Name, got.ObjectMeta.Name)
+				assert.Equal(t, tt.expectedBannedUser.Namespace, got.Namespace)
+				assert.Equal(t, tt.expectedBannedUser.Name, got.Name)
 				assert.Equal(t, tt.expectedBannedUser.Spec.Email, got.Spec.Email)
 				assert.Equal(t, tt.expectedBannedUser.Spec.Reason, got.Spec.Reason)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -122,7 +122,7 @@ func (c ApplyClient) applyObject(ctx context.Context, obj client.Object, options
 	}
 	// gets current object (if exists)
 	namespacedName := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
-	if err := c.Client.Get(ctx, namespacedName, existing); err != nil {
+	if err := c.Get(ctx, namespacedName, existing); err != nil {
 		if apierrors.IsNotFound(err) {
 			obj.SetResourceVersion("") // reset resource version when creating to avoid error: resourceVersion should not be set on objects to be created
 			return true, c.createObj(ctx, obj, config.owner)
@@ -163,7 +163,7 @@ func (c ApplyClient) applyObject(ctx context.Context, obj client.Object, options
 	if err := RetainClusterIP(obj, existing); err != nil {
 		return false, err
 	}
-	if err := c.Client.Update(ctx, obj); err != nil {
+	if err := c.Update(ctx, obj); err != nil {
 		return false, errors.Wrapf(err, "unable to update the resource '%v'", obj)
 	}
 
@@ -233,12 +233,12 @@ func marshalObjectContent(newResource runtime.Object) ([]byte, error) {
 
 func (c ApplyClient) createObj(ctx context.Context, newResource client.Object, owner v1.Object) error {
 	if owner != nil {
-		err := controllerutil.SetControllerReference(owner, newResource, c.Client.Scheme())
+		err := controllerutil.SetControllerReference(owner, newResource, c.Scheme())
 		if err != nil {
 			return errors.Wrap(err, "unable to set controller references")
 		}
 	}
-	return c.Client.Create(ctx, newResource)
+	return c.Create(ctx, newResource)
 }
 
 // Apply applies the objects, ie, creates or updates them on the cluster

--- a/pkg/client/rest_client_test.go
+++ b/pkg/client/rest_client_test.go
@@ -58,7 +58,7 @@ func TestCreateTokenRequest(t *testing.T) {
 			// then
 			require.Error(t, err)                                                    // an error should be returned
 			assert.Equal(t, "unable to create token, got empty string", err.Error()) // error message should match expected one
-			assert.Equal(t, "", token)                                               // token should be empty
+			assert.Empty(t, token)                                                   // token should be empty
 		})
 	})
 }

--- a/pkg/configuration/load_test.go
+++ b/pkg/configuration/load_test.go
@@ -48,7 +48,7 @@ func TestLoadFromConfigMap(t *testing.T) {
 
 		// test that the secret was not found since no secret name was set
 		testTest := os.Getenv("HOST_OPERATOR_SUPER_SPECIAL_KEY")
-		assert.Equal(t, "", testTest)
+		assert.Empty(t, testTest)
 	})
 	t.Run("cannot get configmap", func(t *testing.T) {
 		// given
@@ -73,7 +73,7 @@ func TestLoadFromConfigMap(t *testing.T) {
 
 		// test env vars are parsed and created correctly
 		testTest := os.Getenv("MEMBER_OPERATOR_TEST_KEY_ONE")
-		assert.Equal(t, "", testTest)
+		assert.Empty(t, testTest)
 	})
 	t.Run("env overwrite", func(t *testing.T) {
 		// given

--- a/pkg/configuration/memberoperatorconfig/configuration_test.go
+++ b/pkg/configuration/memberoperatorconfig/configuration_test.go
@@ -134,7 +134,7 @@ func TestGitHubSecret(t *testing.T) {
 		cfg := commonconfig.NewMemberOperatorConfigWithReset(t)
 		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
 
-		assert.Equal(t, "", memberOperatorCfg.GitHubSecret().AccessTokenKey())
+		assert.Empty(t, memberOperatorCfg.GitHubSecret().AccessTokenKey())
 	})
 	t.Run("non-default", func(t *testing.T) {
 		cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.MemberStatus().
@@ -269,7 +269,7 @@ func TestWebhook(t *testing.T) {
 		memberOperatorCfg := Configuration{cfg: &cfg.Spec}
 
 		assert.True(t, memberOperatorCfg.Webhook().Deploy())
-		assert.Equal(t, "", memberOperatorCfg.Webhook().VMSSHKey())
+		assert.Empty(t, memberOperatorCfg.Webhook().VMSSHKey())
 	})
 	t.Run("non-default", func(t *testing.T) {
 		cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.Webhook().

--- a/pkg/notification/notification_builder.go
+++ b/pkg/notification/notification_builder.go
@@ -74,23 +74,23 @@ func (b *notificationBuilderImpl) Create(ctx context.Context, recipient string) 
 }
 
 func generateName(notification *toolchainv1alpha1.Notification) {
-	if notification.ObjectMeta.Name == "" {
+	if notification.Name == "" {
 		if username, found := notification.Spec.Context["UserName"]; found && username != "" {
 			notificationType, found := notification.Labels[toolchainv1alpha1.NotificationTypeLabelKey]
 			if found {
-				notification.ObjectMeta.GenerateName = fmt.Sprintf("%s-%s-", username, notificationType)
+				notification.GenerateName = fmt.Sprintf("%s-%s-", username, notificationType)
 				return
 			}
-			notification.ObjectMeta.GenerateName = fmt.Sprintf("%s-untyped", username)
+			notification.GenerateName = fmt.Sprintf("%s-untyped", username)
 			return
 		}
-		notification.ObjectMeta.GenerateName = fmt.Sprintf("%s-untyped", uuid.NewString())
+		notification.GenerateName = fmt.Sprintf("%s-untyped", uuid.NewString())
 	}
 }
 
 func (b *notificationBuilderImpl) WithName(name string) Builder {
 	b.options = append(b.options, func(n *toolchainv1alpha1.Notification) error {
-		n.ObjectMeta.Name = name
+		n.Name = name
 		return nil
 	})
 	return b
@@ -115,7 +115,7 @@ func (b *notificationBuilderImpl) WithSubjectAndContent(subject, content string)
 
 func (b *notificationBuilderImpl) WithNotificationType(notificationType string) Builder {
 	b.options = append(b.options, func(n *toolchainv1alpha1.Notification) error {
-		n.ObjectMeta.Labels[toolchainv1alpha1.NotificationTypeLabelKey] = notificationType
+		n.Labels[toolchainv1alpha1.NotificationTypeLabelKey] = notificationType
 		return nil
 	})
 	return b
@@ -148,7 +148,7 @@ func (b *notificationBuilderImpl) WithUserContext(userSignup *toolchainv1alpha1.
 		n.Spec.Context["LastName"] = userSignup.Spec.IdentityClaims.FamilyName
 		n.Spec.Context["CompanyName"] = userSignup.Spec.IdentityClaims.Company
 
-		n.ObjectMeta.Labels[toolchainv1alpha1.NotificationUserNameLabelKey] = userSignup.Status.CompliantUsername
+		n.Labels[toolchainv1alpha1.NotificationUserNameLabelKey] = userSignup.Status.CompliantUsername
 
 		if userSignup.Spec.IdentityClaims.Email != "" {
 			n.Spec.Context["UserEmail"] = userSignup.Spec.IdentityClaims.Email

--- a/pkg/proxy/workspace.go
+++ b/pkg/proxy/workspace.go
@@ -65,9 +65,9 @@ func WithBindings(bindings []toolchainv1alpha1.Binding) WorkspaceOption {
 
 func WithObjectMetaFrom(from metav1.ObjectMeta) WorkspaceOption {
 	return func(workspace *toolchainv1alpha1.Workspace) {
-		workspace.ObjectMeta.ResourceVersion = from.ResourceVersion
-		workspace.ObjectMeta.UID = from.UID
-		workspace.ObjectMeta.Generation = from.Generation
-		workspace.ObjectMeta.CreationTimestamp = from.CreationTimestamp
+		workspace.ResourceVersion = from.ResourceVersion
+		workspace.UID = from.UID
+		workspace.Generation = from.Generation
+		workspace.CreationTimestamp = from.CreationTimestamp
 	}
 }

--- a/pkg/status/versionchecks.go
+++ b/pkg/status/versionchecks.go
@@ -99,7 +99,7 @@ func getLatestCommit(ctx context.Context, GetCommit getCommitFunc, githubRepo cl
 		return nil, errors.New(errMsg)
 	}
 	if commitResponse.StatusCode != http.StatusOK {
-		err = errs.New(fmt.Sprintf("invalid response code from github commits API. resp.Response.StatusCode: %d, repoName: %s, repoBranch: %s", commitResponse.Response.StatusCode, githubRepo.Name, githubRepo.Branch))
+		err = errs.New(fmt.Sprintf("invalid response code from github commits API. resp.Response.StatusCode: %d, repoName: %s, repoBranch: %s", commitResponse.StatusCode, githubRepo.Name, githubRepo.Branch))
 		return nil, err
 	}
 

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator_test.go
@@ -244,7 +244,7 @@ func TestGenerateTiers(t *testing.T) {
 				tier := toolchainv1alpha1.NSTemplateTier{}
 				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
 				require.NoError(t, err)
-				assert.Equal(t, int64(1), tier.ObjectMeta.Generation)
+				assert.Equal(t, int64(1), tier.Generation)
 
 				// check the `clusterresources` templateRef
 				if tier.Name == "nocluster" {
@@ -292,7 +292,7 @@ func TestGenerateTiers(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, tierTmpls.Items, 16) // 4 items for advanced and base tiers + 3 for nocluster tier + 4 for appstudio
 			for _, tierTmpl := range tierTmpls.Items {
-				assert.Equal(t, int64(1), tierTmpl.ObjectMeta.Generation) // unchanged
+				assert.Equal(t, int64(1), tierTmpl.Generation) // unchanged
 			}
 
 			// verify that 4 NSTemplateTier CRs were created:
@@ -300,7 +300,7 @@ func TestGenerateTiers(t *testing.T) {
 				tier := toolchainv1alpha1.NSTemplateTier{}
 				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
 				require.NoError(t, err)
-				assert.Equal(t, int64(1), tier.ObjectMeta.Generation)
+				assert.Equal(t, int64(1), tier.Generation)
 
 				// check the `clusterresources` templateRef
 				if tier.Name == "nocluster" {
@@ -365,7 +365,7 @@ func TestGenerateTiers(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, tierTmpls.Items, 32) // two versions of: 4 items for advanced and base tiers + 3 for nocluster tier + 4 for appstudio
 			for _, tierTmpl := range tierTmpls.Items {
-				assert.Equal(t, int64(1), tierTmpl.ObjectMeta.Generation) // unchanged
+				assert.Equal(t, int64(1), tierTmpl.Generation) // unchanged
 			}
 
 			expectedTemplateRefs := map[string]map[string]interface{}{
@@ -416,7 +416,7 @@ func TestGenerateTiers(t *testing.T) {
 				tier := toolchainv1alpha1.NSTemplateTier{}
 				err = clt.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: tierName}, &tier)
 				require.NoError(t, err)
-				assert.Equal(t, int64(2), tier.ObjectMeta.Generation)
+				assert.Equal(t, int64(2), tier.Generation)
 
 				// check the `clusteresources` templateRefs
 				if tier.Name == "nocluster" {
@@ -881,8 +881,8 @@ func TestNewNSTemplateTiers(t *testing.T) {
 			tier := runtimeObjectToNSTemplateTier(t, s, tierObjs[0])
 
 			require.True(t, found)
-			assert.Equal(t, name, tier.ObjectMeta.Name)
-			assert.Equal(t, namespace, tier.ObjectMeta.Namespace)
+			assert.Equal(t, name, tier.Name)
+			assert.Equal(t, namespace, tier.Namespace)
 			for _, ns := range tier.Spec.Namespaces {
 				assert.NotEmpty(t, ns.TemplateRef, "expected namespace reference not empty for tier %v", name)
 			}

--- a/pkg/test/client_test.go
+++ b/pkg/test/client_test.go
@@ -175,7 +175,7 @@ func TestNewClient(t *testing.T) {
 			dep2.ResourceVersion = ""
 			require.NoError(t, fclient.Create(context.TODO(), dep2))
 
-			require.NoError(t, fclient.DeleteAllOf(context.TODO(), retrieved, client.InNamespace("somenamespace"), client.MatchingLabels(retrieved.ObjectMeta.Labels)))
+			require.NoError(t, fclient.DeleteAllOf(context.TODO(), retrieved, client.InNamespace("somenamespace"), client.MatchingLabels(retrieved.Labels)))
 			err := fclient.Get(context.TODO(), types.NamespacedName{Namespace: "somenamespace", Name: created.Name}, retrieved)
 			require.Error(t, err)
 			assert.True(t, errs.IsNotFound(err))

--- a/pkg/test/condition.go
+++ b/pkg/test/condition.go
@@ -17,7 +17,7 @@ import (
 // because the LastTransitionTime of the actual conditions can be modified but the conditions
 // still should be treated as matched
 func AssertConditionsMatch(t T, actual []toolchainv1alpha1.Condition, expected ...toolchainv1alpha1.Condition) {
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for _, c := range expected {
 		AssertContainsCondition(t, actual, c)
 	}

--- a/pkg/test/nstemplateset/nstemplateset.go
+++ b/pkg/test/nstemplateset/nstemplateset.go
@@ -135,10 +135,10 @@ func WithFinalizer() Option {
 
 func WithAnnotation(key, value string) Option {
 	return func(nstmplSet *toolchainv1alpha1.NSTemplateSet) {
-		if nstmplSet.ObjectMeta.Annotations == nil {
-			nstmplSet.ObjectMeta.Annotations = map[string]string{}
+		if nstmplSet.Annotations == nil {
+			nstmplSet.Annotations = map[string]string{}
 		}
-		nstmplSet.ObjectMeta.Annotations[key] = value
+		nstmplSet.Annotations[key] = value
 
 	}
 }

--- a/pkg/test/nstemplateset/nstemplateset_assertion.go
+++ b/pkg/test/nstemplateset/nstemplateset_assertion.go
@@ -82,7 +82,7 @@ func (a *Assertion) HasConditions(expected ...toolchainv1alpha1.Condition) *Asse
 func (a *Assertion) HasNoOwnerReferences() *Assertion {
 	err := a.loadNSTemplateSet()
 	require.NoError(a.t, err)
-	assert.Empty(a.t, a.nsTmplSet.ObjectMeta.OwnerReferences)
+	assert.Empty(a.t, a.nsTmplSet.OwnerReferences)
 	return a
 }
 

--- a/pkg/test/space/space.go
+++ b/pkg/test/space/space.go
@@ -33,15 +33,15 @@ func WithSpecTargetClusterRoles(roles []string) Option {
 
 func WithName(name string) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		space.ObjectMeta.Name = name
-		space.ObjectMeta.GenerateName = ""
+		space.Name = name
+		space.GenerateName = ""
 	}
 }
 
 func WithGenerateName(namePrefix string) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		space.ObjectMeta.Name = ""
-		space.ObjectMeta.GenerateName = namePrefix + "-"
+		space.Name = ""
+		space.GenerateName = namePrefix + "-"
 	}
 }
 
@@ -53,19 +53,19 @@ func WithSpecParentSpace(name string) Option {
 
 func WithLabel(key, value string) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		if space.ObjectMeta.Labels == nil {
-			space.ObjectMeta.Labels = map[string]string{}
+		if space.Labels == nil {
+			space.Labels = map[string]string{}
 		}
-		space.ObjectMeta.Labels[key] = value
+		space.Labels[key] = value
 	}
 }
 
 func WithAnnotation(key, value string) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		if space.ObjectMeta.Annotations == nil {
-			space.ObjectMeta.Annotations = map[string]string{}
+		if space.Annotations == nil {
+			space.Annotations = map[string]string{}
 		}
-		space.ObjectMeta.Annotations[key] = value
+		space.Annotations[key] = value
 	}
 }
 
@@ -90,10 +90,10 @@ func WithDisableInheritance(disableInheritance bool) Option {
 func WithTierHashLabelFor(tier *toolchainv1alpha1.NSTemplateTier) Option {
 	return func(space *toolchainv1alpha1.Space) {
 		h, _ := hash.ComputeHashForNSTemplateTier(tier) // we can assume the JSON marshalling will always work
-		if space.ObjectMeta.Labels == nil {
-			space.ObjectMeta.Labels = map[string]string{}
+		if space.Labels == nil {
+			space.Labels = map[string]string{}
 		}
-		space.ObjectMeta.Labels[hash.TemplateTierHashLabelKey(tier.Name)] = h
+		space.Labels[hash.TemplateTierHashLabelKey(tier.Name)] = h
 	}
 }
 
@@ -161,7 +161,7 @@ func WithStateLabel(stateValue string) Option {
 
 func CreatedBefore(before time.Duration) Option {
 	return func(space *toolchainv1alpha1.Space) {
-		space.ObjectMeta.CreationTimestamp = metav1.Time{Time: time.Now().Add(-before)}
+		space.CreationTimestamp = metav1.Time{Time: time.Now().Add(-before)}
 	}
 }
 

--- a/pkg/test/spacebindingrequest/spacebindingrequest.go
+++ b/pkg/test/spacebindingrequest/spacebindingrequest.go
@@ -41,10 +41,10 @@ func WithSpaceRole(spaceRole string) Option {
 
 func WithLabel(key, value string) Option {
 	return func(space *toolchainv1alpha1.SpaceBindingRequest) {
-		if space.ObjectMeta.Labels == nil {
-			space.ObjectMeta.Labels = map[string]string{}
+		if space.Labels == nil {
+			space.Labels = map[string]string{}
 		}
-		space.ObjectMeta.Labels[key] = value
+		space.Labels[key] = value
 	}
 }
 

--- a/pkg/test/status.go
+++ b/pkg/test/status.go
@@ -24,7 +24,7 @@ func AssertHostOperatorStatusMatch(t T, actual toolchainv1alpha1.HostOperatorSta
 // We can't use assert.ElementsMatch because the LastTransitionTime of the actual
 // conditions can be modified but the conditions still should be treated as matched
 func AssertMembersMatch(t T, actual []toolchainv1alpha1.Member, expected ...toolchainv1alpha1.Member) {
-	require.Equal(t, len(expected), len(actual))
+	require.Len(t, actual, len(expected))
 	for _, c := range expected {
 		AssertContainsMember(t, actual, c)
 	}

--- a/pkg/test/usersignup/usersignup.go
+++ b/pkg/test/usersignup/usersignup.go
@@ -152,7 +152,7 @@ func WithStateLabel(stateValue string) Modifier {
 func WithEmail(email string) Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
 		emailHash := hash.EncodeString(email)
-		userSignup.ObjectMeta.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey] = emailHash
+		userSignup.Labels[toolchainv1alpha1.UserSignupUserEmailHashLabelKey] = emailHash
 		userSignup.Spec.IdentityClaims.Email = email
 	}
 }
@@ -204,13 +204,13 @@ func WithScheduledDeactivationTimestamp(scheduledDeactivationTimestamp *metav1.T
 
 func CreatedBefore(before time.Duration) Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		userSignup.ObjectMeta.CreationTimestamp = metav1.Time{Time: time.Now().Add(-before)}
+		userSignup.CreationTimestamp = metav1.Time{Time: time.Now().Add(-before)}
 	}
 }
 
 func BeingDeleted() Modifier {
 	return func(userSignup *toolchainv1alpha1.UserSignup) {
-		userSignup.ObjectMeta.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+		userSignup.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 	}
 }
 


### PR DESCRIPTION
upgraded `.golangci.yml` with `golangci-lint migrate`

include fixes suggested by `golangci-lint run -c ./.golangci.yml`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
