### PR TITLE
SANDBOX1318: update filter function to accept runtimeclient object/runtimeobject

### DIFF
--- a/pkg/template/filter.go
+++ b/pkg/template/filter.go
@@ -1,6 +1,11 @@
 package template
 
-import "k8s.io/apimachinery/pkg/runtime"
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 var (
 	// RetainNamespaces a func to retain only namespaces
@@ -20,17 +25,48 @@ var (
 type FilterFunc func(runtime.RawExtension) bool
 
 // Filter filters the given objs to return only those matching the given filters (if any)
-func Filter(objs []runtime.RawExtension, filters ...FilterFunc) []runtime.RawExtension {
-	result := make([]runtime.RawExtension, 0, len(objs))
+// Accepts []runtime.RawExtension, []runtime.Object, or []runtimeclient.Object
+func Filter(objs interface{}, filters ...FilterFunc) []runtime.RawExtension {
+	// Convert input to []runtime.RawExtension
+	var rawExtensions []runtime.RawExtension
+
+	switch v := objs.(type) {
+	case []runtime.RawExtension:
+		rawExtensions = v
+	case []runtime.Object, []runtimeclient.Object:
+		// Handle both runtime.Object and runtimeclient.Object the same way
+		// since runtimeclient.Object embeds runtime.Object
+		var objects []runtime.Object
+		if runtimeObjs, ok := v.([]runtime.Object); ok {
+			objects = runtimeObjs
+		} else {
+			// Convert []runtimeclient.Object to []runtime.Object
+			clientObjs := v.([]runtimeclient.Object)
+			objects = make([]runtime.Object, len(clientObjs))
+			for i, obj := range clientObjs {
+				objects[i] = obj
+			}
+		}
+
+		rawExtensions = make([]runtime.RawExtension, len(objects))
+		for i, obj := range objects {
+			rawExtensions[i] = runtime.RawExtension{Object: obj}
+		}
+	default:
+		panic(fmt.Sprintf("unsupported type %T for Filter function. Supported types: []runtime.RawExtension, []runtime.Object, []runtimeclient.Object", objs))
+	}
+
+	// Apply filters - single implementation for all types
+	result := make([]runtime.RawExtension, 0, len(rawExtensions))
 loop:
-	for _, obj := range objs {
+	for _, obj := range rawExtensions {
 		for _, filter := range filters {
 			if !filter(obj) {
 				continue loop
 			}
-
 		}
 		result = append(result, obj)
 	}
+
 	return result
 }

--- a/pkg/template/filter_test.go
+++ b/pkg/template/filter_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestFilter(t *testing.T) {
@@ -213,6 +214,170 @@ func TestFilter(t *testing.T) {
 			result := template.Filter(objs, template.RetainAllButNamespaces)
 			// then
 			require.Empty(t, result)
+		})
+	})
+}
+
+func TestFilterWithRuntimeObjects(t *testing.T) {
+	ns1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "ns1",
+			},
+		},
+	}
+	ns2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "ns2",
+			},
+		},
+	}
+	rb1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "RoleBinding",
+			"metadata": map[string]interface{}{
+				"name": "rb1",
+			},
+		},
+	}
+	rb2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "RoleBinding",
+			"metadata": map[string]interface{}{
+				"name": "rb2",
+			},
+		},
+	}
+
+	t.Run("filter runtime.Object slice with no filter", func(t *testing.T) {
+		// given
+		objs := []runtime.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs)
+
+		// then
+		require.Len(t, result, 4)
+		assert.Equal(t, ns1, result[0].Object)
+		assert.Equal(t, rb1, result[1].Object)
+		assert.Equal(t, ns2, result[2].Object)
+		assert.Equal(t, rb2, result[3].Object)
+	})
+
+	t.Run("filter runtime.Object slice retaining namespaces", func(t *testing.T) {
+		// given
+		objs := []runtime.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs, template.RetainNamespaces)
+
+		// then
+		require.Len(t, result, 2)
+		assert.Equal(t, ns1, result[0].Object)
+		assert.Equal(t, ns2, result[1].Object)
+	})
+
+	t.Run("filter runtime.Object slice retaining all but namespaces", func(t *testing.T) {
+		// given
+		objs := []runtime.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs, template.RetainAllButNamespaces)
+
+		// then
+		require.Len(t, result, 2)
+		assert.Equal(t, rb1, result[0].Object)
+		assert.Equal(t, rb2, result[1].Object)
+	})
+}
+
+func TestFilterWithClientObjects(t *testing.T) {
+	ns1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "ns1",
+			},
+		},
+	}
+	ns2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "Namespace",
+			"metadata": map[string]interface{}{
+				"name": "ns2",
+			},
+		},
+	}
+	rb1 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "RoleBinding",
+			"metadata": map[string]interface{}{
+				"name": "rb1",
+			},
+		},
+	}
+	rb2 := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind": "RoleBinding",
+			"metadata": map[string]interface{}{
+				"name": "rb2",
+			},
+		},
+	}
+
+	t.Run("filter runtimeclient.Object slice with no filter", func(t *testing.T) {
+		// given
+		objs := []runtimeclient.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs)
+
+		// then
+		require.Len(t, result, 4)
+		assert.Equal(t, ns1, result[0].Object)
+		assert.Equal(t, rb1, result[1].Object)
+		assert.Equal(t, ns2, result[2].Object)
+		assert.Equal(t, rb2, result[3].Object)
+	})
+
+	t.Run("filter runtimeclient.Object slice retaining namespaces", func(t *testing.T) {
+		// given
+		objs := []runtimeclient.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs, template.RetainNamespaces)
+
+		// then
+		require.Len(t, result, 2)
+		assert.Equal(t, ns1, result[0].Object)
+		assert.Equal(t, ns2, result[1].Object)
+	})
+
+	t.Run("filter runtimeclient.Object slice retaining all but namespaces", func(t *testing.T) {
+		// given
+		objs := []runtimeclient.Object{ns1, rb1, ns2, rb2}
+
+		// when
+		result := template.Filter(objs, template.RetainAllButNamespaces)
+
+		// then
+		require.Len(t, result, 2)
+		assert.Equal(t, rb1, result[0].Object)
+		assert.Equal(t, rb2, result[1].Object)
+	})
+}
+
+func TestFilterUnsupportedType(t *testing.T) {
+	t.Run("panic on unsupported type", func(t *testing.T) {
+		// given
+		unsupportedSlice := []string{"not", "supported"}
+
+		// when/then
+		assert.Panics(t, func() {
+			template.Filter(unsupportedSlice)
 		})
 	})
 }


### PR DESCRIPTION
This PR is related to the discussion https://github.com/codeready-toolchain/member-operator/pull/680#discussion_r2250938871 
to improve the filter function 

related PR
Member-operator: https://github.com/codeready-toolchain/member-operator/pull/692
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filtering now accepts multiple object-slice types (in addition to the previous format), broadening compatibility with Kubernetes object representations while preserving prior behavior.
  * Unsupported input types produce a clear, descriptive error.

* **Tests**
  * Added table-driven tests covering all supported input representations and error cases, improving coverage and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->