### PR TITLE
feat: add account_number claim 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20250506092100-39b4862e1271
+	github.com/codeready-toolchain/api v0.0.0-20250909075145-ca043a618f0f
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v52 v52.0.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.6.1 h1:zqIqSPIndyBh1bjLVVDHMPpVKqp8Su/V+6MeDzzQBQ0=
 github.com/cloudflare/circl v1.6.1/go.mod h1:uddAzsPgqdMAYatqJ0lsjX1oECcQLIlRpzZh3pJrofs=
-github.com/codeready-toolchain/api v0.0.0-20250506092100-39b4862e1271 h1:AHrFr/aPuJ4+0zHw4sFXcfMA92kChy12JAPS5bLODlw=
-github.com/codeready-toolchain/api v0.0.0-20250506092100-39b4862e1271/go.mod h1:20258od6i5+jP406Z76YaI2ow/vc7URwsDU2bokpkRE=
+github.com/codeready-toolchain/api v0.0.0-20250909075145-ca043a618f0f h1:IZ3Wq4iC0765HP369U3+08NFb0rK/NJCKfRjj8OdPVo=
+github.com/codeready-toolchain/api v0.0.0-20250909075145-ca043a618f0f/go.mod h1:20258od6i5+jP406Z76YaI2ow/vc7URwsDU2bokpkRE=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/test/auth/tokenmanager.go
+++ b/pkg/test/auth/tokenmanager.go
@@ -151,6 +151,13 @@ func WithAccountIDClaim(accountID string) ExtraClaim {
 	}
 }
 
+// WithAccountNumberClaim sets the `account_number` claim in the token to generate
+func WithAccountNumberClaim(accountNumber string) ExtraClaim {
+	return func(token *jwt.Token) {
+		token.Claims.(*MyClaims).AccountNumber = accountNumber
+	}
+}
+
 // WithAudClaim sets the `aud` claim in the token to generate
 func WithAudClaim(aud []string) ExtraClaim {
 	return func(token *jwt.Token) {
@@ -234,6 +241,7 @@ type MyClaims struct {
 	OriginalSub       string `json:"original_sub"`
 	UserID            string `json:"user_id"`
 	AccountID         string `json:"account_id"`
+	AccountNumber     string `json:"account_number,omitempty"`
 }
 
 // GenerateToken generates a default token.

--- a/pkg/test/auth/tokenmanager_test.go
+++ b/pkg/test/auth/tokenmanager_test.go
@@ -356,6 +356,25 @@ func TestTokenManagerTokens(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, "987654321", claims.AccountID)
 	})
+	t.Run("create token with account_number extra claim", func(t *testing.T) {
+		username := uuid.NewString()
+		identity0 := &Identity{
+			ID:       uuid.New(),
+			Username: username,
+		}
+		// generate the token
+		encodedToken, err := tokenManager.GenerateSignedToken(*identity0, kid0, WithAccountNumberClaim("987654320"))
+		require.NoError(t, err)
+		// unmarshall it again
+		decodedToken, err := jwt.ParseWithClaims(encodedToken, &MyClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return &(key0.PublicKey), nil
+		})
+		require.NoError(t, err)
+		require.True(t, decodedToken.Valid)
+		claims, ok := decodedToken.Claims.(*MyClaims)
+		require.True(t, ok)
+		require.Equal(t, "987654320", claims.AccountNumber)
+	})
 }
 
 func TestTokenManagerKeyService(t *testing.T) {

--- a/pkg/test/usersignup/usersignup.go
+++ b/pkg/test/usersignup/usersignup.go
@@ -281,6 +281,7 @@ func NewUserSignup(modifiers ...Modifier) *toolchainv1alpha1.UserSignup {
 				GivenName:         "Foo",
 				FamilyName:        "Bar",
 				Company:           "Red Hat",
+				AccountNumber:     "4242",
 			},
 		},
 	}


### PR DESCRIPTION
Add `account_number` claim in token parser and signup structs.

It will be used in registration service to grab the claim from the SSO token and send that back in the signup response from the `GET /signup` endpoint.

Jira: https://issues.redhat.com/browse/SANDBOX-1394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for an optional account number claim in generated tokens.
  - Improved propagation of the account number through user signup flows when available.

- Tests
  - Added coverage to validate tokens including the account number claim.

- Chores
  - Updated a core dependency to the latest available version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->