### PR TITLE
SANDBOX-1392: Drop dependency on Che instance

### DIFF
--- a/pkg/configuration/memberoperatorconfig/configuration.go
+++ b/pkg/configuration/memberoperatorconfig/configuration.go
@@ -75,12 +75,6 @@ func (c *Configuration) Autoscaler() AutoscalerConfig {
 	return AutoscalerConfig{autoscaler: c.cfg.Autoscaler}
 }
 
-func (c *Configuration) Che() CheConfig {
-	return CheConfig{
-		che: c.cfg.Che,
-	}
-}
-
 func (c *Configuration) Console() ConsoleConfig {
 	return ConsoleConfig{console: c.cfg.Console}
 }
@@ -156,26 +150,6 @@ func (gh GitHubSecret) githubSecret(secretKey string) string {
 func (gh GitHubSecret) AccessTokenKey() string {
 	key := commonconfig.GetString(gh.s.AccessTokenKey, "")
 	return gh.githubSecret(key)
-}
-
-type CheConfig struct {
-	che toolchainv1alpha1.CheConfig
-}
-
-func (a CheConfig) IsRequired() bool {
-	return commonconfig.GetBool(a.che.Required, false)
-}
-
-func (a CheConfig) Namespace() string {
-	return commonconfig.GetString(a.che.Namespace, "codeready-workspaces-operator")
-}
-
-func (a CheConfig) RouteName() string {
-	return commonconfig.GetString(a.che.RouteName, "codeready")
-}
-
-func (a CheConfig) IsDevSpacesMode() bool {
-	return a.Namespace() == "crw" && a.RouteName() == "devspaces"
 }
 
 type ConsoleConfig struct {

--- a/pkg/configuration/memberoperatorconfig/configuration_test.go
+++ b/pkg/configuration/memberoperatorconfig/configuration_test.go
@@ -84,51 +84,6 @@ func TestAutoscaler(t *testing.T) {
 	})
 }
 
-func TestChe(t *testing.T) {
-	t.Run("is required", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t)
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.False(t, memberOperatorCfg.Che().IsRequired())
-		})
-		t.Run("non-default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.Che().Required(true))
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.True(t, memberOperatorCfg.Che().IsRequired())
-		})
-	})
-	t.Run("namespace", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t)
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.Equal(t, "codeready-workspaces-operator", memberOperatorCfg.Che().Namespace())
-		})
-		t.Run("non-default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.Che().Namespace("crw"))
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.Equal(t, "crw", memberOperatorCfg.Che().Namespace())
-		})
-	})
-	t.Run("route name", func(t *testing.T) {
-		t.Run("default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t)
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.Equal(t, "codeready", memberOperatorCfg.Che().RouteName())
-		})
-		t.Run("non-default", func(t *testing.T) {
-			cfg := commonconfig.NewMemberOperatorConfigWithReset(t, testconfig.Che().RouteName("crw"))
-			memberOperatorCfg := Configuration{cfg: &cfg.Spec}
-
-			assert.Equal(t, "crw", memberOperatorCfg.Che().RouteName())
-		})
-	})
-}
-
 func TestGitHubSecret(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		cfg := commonconfig.NewMemberOperatorConfigWithReset(t)

--- a/pkg/test/config/memberoperatorconfig.go
+++ b/pkg/test/config/memberoperatorconfig.go
@@ -89,41 +89,6 @@ func (o AutoscalerOption) BufferReplicas(value int) AutoscalerOption {
 	return o
 }
 
-type CheOption struct {
-	*MemberOperatorConfigOptionImpl
-}
-
-func Che() *CheOption {
-	o := &CheOption{
-		MemberOperatorConfigOptionImpl: &MemberOperatorConfigOptionImpl{},
-	}
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.Che = toolchainv1alpha1.CheConfig{}
-	})
-	return o
-}
-
-func (o CheOption) Required(value bool) CheOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.Che.Required = &value
-	})
-	return o
-}
-
-func (o CheOption) Namespace(value string) CheOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.Che.Namespace = &value
-	})
-	return o
-}
-
-func (o CheOption) RouteName(value string) CheOption {
-	o.addFunction(func(config *toolchainv1alpha1.MemberOperatorConfig) {
-		config.Spec.Che.RouteName = &value
-	})
-	return o
-}
-
 type ConsoleOption struct {
 	*MemberOperatorConfigOptionImpl
 }


### PR DESCRIPTION
This PR is to remove the `che` related unused code 

Assisted by: Cursor, claude code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed Che/Dev Spaces configuration from the Member Operator settings, simplifying configuration options.
- Chores
  - Cleaned up obsolete Che-related configuration pathways and builder options.
- Tests
  - Removed Che/Dev Spaces test suite aligned with the configuration cleanup.

Note: If you previously relied on Che/Dev Spaces settings, these options are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->