### PR TITLE
SANDBOX-1769 | feature: "disabled integrations" builder for the tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 )
 
 require (
-	github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174
+	github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-github/v52 v52.0.0

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174 h1:hed3ZyardxswS6yMB0ME9l3vEkO+pFouyk4dvIiAQOo=
-github.com/codeready-toolchain/api v0.0.0-20260305144020-4ff0e6b6e174/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6 h1:d4DTT/6zhDFTN9rlCggsz/PLZGUCRccbSATcDmdTjzI=
+github.com/codeready-toolchain/api v0.0.0-20260415142422-12ff40f3bdb6/go.mod h1:PMg6kNHuCGNlu3MOdrCisqGkBpvzB0qS1+E6nrXxPAc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/test/config/toolchainconfig.go
+++ b/pkg/test/config/toolchainconfig.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"os"
+	"slices"
 	"testing"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -272,6 +273,13 @@ func (o RegistrationServiceOption) Replicas(value int32) RegistrationServiceOpti
 func (o RegistrationServiceOption) RegistrationServiceURL(value string) RegistrationServiceOption {
 	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
 		config.Spec.Host.RegistrationService.RegistrationServiceURL = &value
+	})
+	return o
+}
+
+func (o RegistrationServiceOption) DisabledIntegrations(values []string) RegistrationServiceOption {
+	o.addFunction(func(config *toolchainv1alpha1.ToolchainConfig) {
+		config.Spec.Host.RegistrationService.DisabledIntegrations = slices.Clone(values)
 	})
 	return o
 }


### PR DESCRIPTION
Adds the required test builder for the "disabled integrations" feature, to make testing easier.

## Related PRs

- https://github.com/codeready-toolchain/api/pull/502
  - https://github.com/codeready-toolchain/api/pull/503 (this one)
- https://github.com/codeready-toolchain/toolchain-common/pull/524
- https://github.com/codeready-toolchain/host-operator/pull/1255
- https://github.com/codeready-toolchain/host-operator/pull/1256
- https://github.com/codeready-toolchain/registration-service/pull/590
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1274

## Jira ticket
[[SANDBOX-1769]](https://redhat.atlassian.net/browse/SANDBOX-1769)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform dependencies to improve stability and compatibility
  * Enhanced internal configuration testing infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->