### PR TITLE
[SANDBOX-1788] refactor the resource cache out of the OwnerFetcher

### DIFF
--- a/pkg/client/resource_cache.go
+++ b/pkg/client/resource_cache.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"sync"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -9,6 +10,7 @@ import (
 )
 
 type ResourceCache struct {
+	mutex           sync.Mutex                // guard the initialization ofthe resourceLists
 	resourceLists   []*metav1.APIResourceList // All available API in the cluster
 	discoveryClient discovery.ServerResourcesInterface
 }
@@ -87,13 +89,20 @@ func (rc *ResourceCache) GVKForGR(gr schema.GroupResource) (gvk schema.GroupVers
 }
 
 func (rc *ResourceCache) ensureResourceList() error {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+
 	if rc.resourceLists == nil {
 		// Get all API resources from the cluster using the discovery client. We need it for constructing GVRs for unstructured objects.
 		// Do it here once, so we do not have to list it multiple times before listing/getting every unstructured resource.
+		//
+		// The ServerPreferredResources() method is meant to return partial results on failure.
+		// We ignore them here for the sake of simplicity. Let's just retry to get the full results the next time.
 		resourceList, err := rc.discoveryClient.ServerPreferredResources()
 		if err != nil {
 			return err
 		}
+
 		rc.resourceLists = resourceList
 	}
 

--- a/pkg/client/resource_cache.go
+++ b/pkg/client/resource_cache.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+)
+
+type ResourceCache struct {
+	resourceLists   []*metav1.APIResourceList // All available API in the cluster
+	discoveryClient discovery.ServerResourcesInterface
+}
+
+// NewResourceCache creates a new ResourceCache  with the provided discovery client.
+// The discovery client is used to fetch available API resources.
+func NewResourceCache(discoveryClient discovery.ServerResourcesInterface) *ResourceCache {
+	return &ResourceCache{
+		discoveryClient: discoveryClient,
+	}
+}
+
+// GVRForKind returns a group-resource-version for the supplied kind and api version.
+func (rc *ResourceCache) GVRForKind(kind, apiVersion string) (gvr schema.GroupVersionResource, found bool, namespaced bool, err error) {
+	if err = rc.ensureResourceList(); err != nil {
+		return
+	}
+
+	// Parse the group and version from the APIVersion (e.g., "apps/v1" -> group: "apps", version: "v1")
+	var gv schema.GroupVersion
+	gv, err = schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		err = fmt.Errorf("failed to parse APIVersion %s: %w", apiVersion, err)
+		return
+	}
+
+	// Look for a matching resource
+	for _, resourceList := range rc.resourceLists {
+		if resourceList.GroupVersion == apiVersion {
+			for _, apiResource := range resourceList.APIResources {
+				if apiResource.Kind == kind {
+					// Construct the GVR
+					found = true
+					gvr = schema.GroupVersionResource{
+						Group:    gv.Group,
+						Version:  gv.Version,
+						Resource: apiResource.Name,
+					}
+					namespaced = apiResource.Namespaced
+
+					return
+				}
+			}
+		}
+	}
+
+	return
+}
+
+// GVKForGR given the group-resource, returns the first matching GVK for it.
+func (rc *ResourceCache) GVKForGR(gr schema.GroupResource) (gvk schema.GroupVersionKind, found bool, err error) {
+	if err = rc.ensureResourceList(); err != nil {
+		return
+	}
+
+	for _, resourceList := range rc.resourceLists {
+		var gv schema.GroupVersion
+		gv, err = schema.ParseGroupVersion(resourceList.GroupVersion)
+		if err != nil {
+			err = fmt.Errorf("failed to parse GroupVersion %s: %w", resourceList.GroupVersion, err)
+			return
+		}
+		if gv.Group != gr.Group {
+			continue
+		}
+		for _, res := range resourceList.APIResources {
+			if res.Name == gr.Resource {
+				gvk = schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: res.Kind}
+				found = true
+				return
+			}
+		}
+	}
+
+	return
+}
+
+func (rc *ResourceCache) ensureResourceList() error {
+	if rc.resourceLists == nil {
+		// Get all API resources from the cluster using the discovery client. We need it for constructing GVRs for unstructured objects.
+		// Do it here once, so we do not have to list it multiple times before listing/getting every unstructured resource.
+		resourceList, err := rc.discoveryClient.ServerPreferredResources()
+		if err != nil {
+			return err
+		}
+		rc.resourceLists = resourceList
+	}
+
+	return nil
+}

--- a/pkg/client/resource_cache_test.go
+++ b/pkg/client/resource_cache_test.go
@@ -217,4 +217,3 @@ func TestGVKForGR(t *testing.T) {
 		require.EqualError(t, err, "discovery failed")
 	})
 }
-

--- a/pkg/client/resource_cache_test.go
+++ b/pkg/client/resource_cache_test.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,7 +15,7 @@ import (
 type fakeDiscoveryClient struct {
 	resources []*metav1.APIResourceList
 	err       error
-	calls     int
+	calls     atomic.Int32
 }
 
 func (f *fakeDiscoveryClient) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
@@ -25,7 +27,7 @@ func (f *fakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []
 }
 
 func (f *fakeDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
-	f.calls++
+	f.calls.Add(1)
 	return f.resources, f.err
 }
 
@@ -131,7 +133,7 @@ func TestGVRForKind(t *testing.T) {
 		_, _, _, err = rc.GVRForKind("Deployment", "apps/v1")
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, dc.calls, "discovery should have been called only once")
+		assert.Equal(t, int32(1), dc.calls.Load(), "discovery should have been called only once")
 	})
 }
 
@@ -216,4 +218,24 @@ func TestGVKForGR(t *testing.T) {
 
 		require.EqualError(t, err, "discovery failed")
 	})
+}
+
+func TestThreadSafety(t *testing.T) {
+	// given
+	cl := &fakeDiscoveryClient{resources: []*metav1.APIResourceList{}}
+	rc := NewResourceCache(cl)
+
+	// when
+	t.Run("wrap", func(t *testing.T) { // wrap so that the parallel inner tests complete before we check in the then.
+		for i := range 20 {
+			t.Run(fmt.Sprintf("concurrent-%d", i), func(t *testing.T) {
+				t.Parallel()
+				_, _, _, err := rc.GVRForKind("SomeKind", "v1")
+				assert.NoError(t, err)
+			})
+		}
+	})
+
+	// then
+	assert.Equal(t, int32(1), cl.calls.Load())
 }

--- a/pkg/client/resource_cache_test.go
+++ b/pkg/client/resource_cache_test.go
@@ -1,0 +1,220 @@
+package client
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type fakeDiscoveryClient struct {
+	resources []*metav1.APIResourceList
+	err       error
+	calls     int
+}
+
+func (f *fakeDiscoveryClient) ServerResourcesForGroupVersion(string) (*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func (f *fakeDiscoveryClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return nil, nil, nil
+}
+
+func (f *fakeDiscoveryClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	f.calls++
+	return f.resources, f.err
+}
+
+func (f *fakeDiscoveryClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return nil, nil
+}
+
+func TestGVRForKind(t *testing.T) {
+	resources := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Namespaced: true},
+				{Name: "nodes", Kind: "Node", Namespaced: false},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment", Namespaced: true},
+				{Name: "daemonsets", Kind: "DaemonSet", Namespaced: true},
+			},
+		},
+	}
+
+	t.Run("finds namespaced core resource", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvr, found, namespaced, err := rc.GVRForKind("Pod", "v1")
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.True(t, namespaced)
+		assert.Equal(t, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}, gvr)
+	})
+
+	t.Run("finds cluster-scoped core resource", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvr, found, namespaced, err := rc.GVRForKind("Node", "v1")
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.False(t, namespaced)
+		assert.Equal(t, schema.GroupVersionResource{Group: "", Version: "v1", Resource: "nodes"}, gvr)
+	})
+
+	t.Run("finds resource in non-core group", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvr, found, namespaced, err := rc.GVRForKind("Deployment", "apps/v1")
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.True(t, namespaced)
+		assert.Equal(t, schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}, gvr)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		_, found, _, err := rc.GVRForKind("StatefulSet", "apps/v1")
+
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("not found in wrong api version", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		_, found, _, err := rc.GVRForKind("Deployment", "apps/v1beta1")
+
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid api version", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		_, _, _, err := rc.GVRForKind("Pod", "a/b/c")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse APIVersion")
+	})
+
+	t.Run("discovery error", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{err: errors.New("discovery failed")})
+
+		_, _, _, err := rc.GVRForKind("Pod", "v1")
+
+		require.EqualError(t, err, "discovery failed")
+	})
+
+	t.Run("caches discovery results", func(t *testing.T) {
+		dc := &fakeDiscoveryClient{resources: resources}
+		rc := NewResourceCache(dc)
+
+		_, _, _, err := rc.GVRForKind("Pod", "v1")
+		require.NoError(t, err)
+
+		_, _, _, err = rc.GVRForKind("Deployment", "apps/v1")
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, dc.calls, "discovery should have been called only once")
+	})
+}
+
+func TestGVKForGR(t *testing.T) {
+	resources := []*metav1.APIResourceList{
+		{
+			GroupVersion: "v1",
+			APIResources: []metav1.APIResource{
+				{Name: "pods", Kind: "Pod", Namespaced: true},
+				{Name: "services", Kind: "Service", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "apps/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "deployments", Kind: "Deployment", Namespaced: true},
+				{Name: "replicasets", Kind: "ReplicaSet", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "kubevirt.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "virtualmachines", Kind: "VirtualMachine", Namespaced: true},
+			},
+		},
+	}
+
+	t.Run("finds core group resource", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvk, found, err := rc.GVKForGR(schema.GroupResource{Group: "", Resource: "pods"})
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, gvk)
+	})
+
+	t.Run("finds non-core group resource", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvk, found, err := rc.GVKForGR(schema.GroupResource{Group: "apps", Resource: "deployments"})
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, gvk)
+	})
+
+	t.Run("finds resource with dotted group", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		gvk, found, err := rc.GVKForGR(schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachines"})
+
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, schema.GroupVersionKind{Group: "kubevirt.io", Version: "v1", Kind: "VirtualMachine"}, gvk)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		_, found, err := rc.GVKForGR(schema.GroupResource{Group: "apps", Resource: "statefulsets"})
+
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("wrong group", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{resources: resources})
+
+		_, found, err := rc.GVKForGR(schema.GroupResource{Group: "extensions", Resource: "deployments"})
+
+		require.NoError(t, err)
+		assert.False(t, found)
+		assert.NoError(t, err)
+	})
+
+	t.Run("discovery error", func(t *testing.T) {
+		rc := NewResourceCache(&fakeDiscoveryClient{err: errors.New("discovery failed")})
+
+		_, _, err := rc.GVKForGR(schema.GroupResource{Group: "apps", Resource: "deployments"})
+
+		require.EqualError(t, err, "discovery failed")
+	})
+}
+

--- a/pkg/owners/fetcher.go
+++ b/pkg/owners/fetcher.go
@@ -74,7 +74,7 @@ func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*Obj
 		return nil, err
 	}
 	if !found {
-		return nil, fmt.Errorf("GVR not found for owner reference: %s/%s", &ownerReference.APIVersion, &ownerReference.Kind)
+		return nil, fmt.Errorf("GVR not found for owner reference: %s/%s", ownerReference.APIVersion, ownerReference.Kind)
 	}
 
 	// Get the owner object; use namespace only for namespaced resources

--- a/pkg/owners/fetcher.go
+++ b/pkg/owners/fetcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/codeready-toolchain/toolchain-common/pkg/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -14,18 +15,24 @@ import (
 // OwnerFetcher fetches the owner references of Kubernetes objects by traversing
 // the owner reference chain up to the top-level owner.
 type OwnerFetcher struct {
-	resourceLists   []*metav1.APIResourceList // All available API in the cluster
-	discoveryClient discovery.ServerResourcesInterface
-	dynamicClient   dynamic.Interface
+	resourceCache *client.ResourceCache
+	dynamicClient dynamic.Interface
 }
 
 // NewOwnerFetcher creates a new OwnerFetcher with the provided discovery and dynamic clients.
 // The discovery client is used to fetch available API resources, and the dynamic client is used
 // to retrieve owner objects from the cluster.
+// NOTE: this is kept for backwards compatibility. Prefer using the NewOwnerFetcherWithCache() function.
 func NewOwnerFetcher(discoveryClient discovery.ServerResourcesInterface, dynamicClient dynamic.Interface) *OwnerFetcher {
+	return NewOwnerFetcherWithCache(dynamicClient, client.NewResourceCache(discoveryClient))
+}
+
+// NewOwnerFetcherWithCache creates a new OwnerFetcher with the provided resourceCache used to look up
+// the GVRs and the dynamicClient for retrieval of the owners from the cluster.
+func NewOwnerFetcherWithCache(dynamicClient dynamic.Interface, resourceCache *client.ResourceCache) *OwnerFetcher {
 	return &OwnerFetcher{
-		discoveryClient: discoveryClient,
-		dynamicClient:   dynamicClient,
+		resourceCache: resourceCache,
+		dynamicClient: dynamicClient,
 	}
 }
 
@@ -40,16 +47,6 @@ type ObjectWithGVR struct {
 // the immediate owner up to the top-level owner. It returns a slice of ObjectWithGVR in order
 // from top-level owner to immediate owner. Returns nil if the object has no owner.
 func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*ObjectWithGVR, error) {
-	if o.resourceLists == nil {
-		// Get all API resources from the cluster using the discovery client. We need it for constructing GVRs for unstructured objects.
-		// Do it here once, so we do not have to list it multiple times before listing/getting every unstructured resource.
-		resourceLists, err := o.discoveryClient.ServerPreferredResources()
-		if err != nil {
-			return nil, err
-		}
-		o.resourceLists = resourceLists
-	}
-
 	// get the controller owner (it's possible to have only one controller owner)
 	owners := obj.GetOwnerReferences()
 	var ownerReference metav1.OwnerReference
@@ -72,12 +69,16 @@ func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*Obj
 		return nil, nil // No owner
 	}
 	// Get the GVR for the owner
-	gvr, namespaced, err := gvrForKind(ownerReference.Kind, ownerReference.APIVersion, o.resourceLists)
+	gvr, found, namespaced, err := o.resourceCache.GVRForKind(ownerReference.Kind, ownerReference.APIVersion)
 	if err != nil {
 		return nil, err
 	}
+	if !found {
+		return nil, fmt.Errorf("GVR not found for owner reference: %s/%s", &ownerReference.APIVersion, &ownerReference.Kind)
+	}
+
 	// Get the owner object; use namespace only for namespaced resources
-	resourceClient := o.dynamicClient.Resource(*gvr)
+	resourceClient := o.dynamicClient.Resource(gvr)
 	var ownerObject *unstructured.Unstructured
 	nsdName := ownerReference.Name
 	if namespaced {
@@ -91,7 +92,7 @@ func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*Obj
 	}
 	owner := &ObjectWithGVR{
 		Object: ownerObject,
-		GVR:    gvr,
+		GVR:    &gvr,
 	}
 	// Recursively try to find the top owner
 	ownerOwners, err := o.GetOwners(ctx, ownerObject)
@@ -99,45 +100,4 @@ func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*Obj
 		return append(ownerOwners, owner), err
 	}
 	return append(ownerOwners, owner), nil
-}
-
-// gvrForKind returns GVR and whether the resource is namespaced for the kind,
-// if it's found in the available API list in the cluster.
-// Returns an error if not found or failed to parse the API version.
-func gvrForKind(kind, apiVersion string, resourceLists []*metav1.APIResourceList) (*schema.GroupVersionResource, bool, error) {
-	gvr, namespaced, err := findGVRForKind(kind, apiVersion, resourceLists)
-	if gvr == nil && err == nil {
-		return nil, false, fmt.Errorf("no resource found for kind %s in %s", kind, apiVersion)
-	}
-	return gvr, namespaced, err
-}
-
-// findGVRForKind returns GVR and whether the resource is namespaced for the kind,
-// if it's found in the available API list in the cluster.
-// If not found then returns nil, false, nil.
-// Returns nil, false, error if failed to parse the API version.
-func findGVRForKind(kind, apiVersion string, resourceLists []*metav1.APIResourceList) (*schema.GroupVersionResource, bool, error) {
-	// Parse the group and version from the APIVersion (e.g., "apps/v1" -> group: "apps", version: "v1")
-	gv, err := schema.ParseGroupVersion(apiVersion)
-	if err != nil {
-		return nil, false, fmt.Errorf("failed to parse APIVersion %s: %w", apiVersion, err)
-	}
-
-	// Look for a matching resource
-	for _, resourceList := range resourceLists {
-		if resourceList.GroupVersion == apiVersion {
-			for _, apiResource := range resourceList.APIResources {
-				if apiResource.Kind == kind {
-					// Construct the GVR
-					return &schema.GroupVersionResource{
-						Group:    gv.Group,
-						Version:  gv.Version,
-						Resource: apiResource.Name,
-					}, apiResource.Namespaced, nil
-				}
-			}
-		}
-	}
-
-	return nil, false, nil
 }

--- a/pkg/owners/fetcher.go
+++ b/pkg/owners/fetcher.go
@@ -74,7 +74,7 @@ func (o *OwnerFetcher) GetOwners(ctx context.Context, obj metav1.Object) ([]*Obj
 		return nil, err
 	}
 	if !found {
-		return nil, fmt.Errorf("GVR not found for owner reference: %s/%s", ownerReference.APIVersion, ownerReference.Kind)
+		return nil, fmt.Errorf("no resource found for kind %s in %s", ownerReference.Kind, ownerReference.APIVersion)
 	}
 
 	// Get the owner object; use namespace only for namespaced resources

--- a/pkg/owners/fetcher_test.go
+++ b/pkg/owners/fetcher_test.go
@@ -102,7 +102,6 @@ func TestGetOwners(t *testing.T) {
 			for i := range testData.expectedOwners {
 				assert.Equal(t, testData.expectedOwners[i].GetName(), owners[i].Object.GetName())
 			}
-
 		})
 	}
 }
@@ -144,7 +143,6 @@ func TestGetOwnersFailures(t *testing.T) {
 				fakeDiscovery := newFakeDiscoveryClient(withVMResourcesList(t)...)
 
 				t.Run("with one owner", func(t *testing.T) {
-
 					pod := givenPod.DeepCopy()
 					require.NoError(t, controllerruntime.SetControllerReference(ownerObject, pod, scheme.Scheme))
 					// when it's supposed to be "not found" then do not include it in the client
@@ -229,54 +227,6 @@ func TestGetOwnersFailures(t *testing.T) {
 	})
 }
 
-func TestGetAPIResourceList(t *testing.T) {
-	// given
-	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "test-namespace"}}
-	dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme)
-
-	t.Run("get APIs, pod with no owners", func(t *testing.T) {
-		// given
-		fakeDiscovery := newFakeDiscoveryClient(withVMResourcesList(t)...)
-		fetcher := NewOwnerFetcher(fakeDiscovery, dynamicClient)
-
-		// when
-		owners, err := fetcher.GetOwners(context.TODO(), pod)
-
-		// then
-		require.NoError(t, err)
-		require.NotEmpty(t, fetcher.resourceLists)
-		require.Empty(t, owners)
-
-		t.Run("no APIs retrival when once done", func(t *testing.T) {
-			// given
-			fakeDiscovery.ServerPreferredResourcesError = fmt.Errorf("some error")
-
-			// when
-			owners, err := fetcher.GetOwners(context.TODO(), pod)
-
-			// then
-			require.NoError(t, err)
-			require.NotEmpty(t, fetcher.resourceLists)
-			require.Empty(t, owners)
-		})
-	})
-
-	t.Run("failure when getting APIs", func(t *testing.T) {
-		// given
-		fakeDiscovery := newFakeDiscoveryClient(withVMResourcesList(t)...)
-		fakeDiscovery.ServerPreferredResourcesError = fmt.Errorf("some error")
-		fetcher := NewOwnerFetcher(fakeDiscovery, dynamicClient)
-
-		// when
-		owners, err := fetcher.GetOwners(context.TODO(), pod)
-
-		// then
-		require.EqualError(t, err, "some error")
-		require.Nil(t, fetcher.resourceLists)
-		require.Empty(t, owners)
-	})
-}
-
 func newVMResources(t *testing.T, name, namespace string) (*unstructured.Unstructured, *unstructured.Unstructured) {
 	vm := &unstructured.Unstructured{}
 	err := vm.UnmarshalJSON(virtualmachineJSON)
@@ -315,7 +265,7 @@ func apiSchemeResourceList(t *testing.T) []*metav1.APIResourceList {
 	require.NoError(t, toolchainv1alpha1.AddToScheme(scheme.Scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme.Scheme))
 	require.NoError(t, apiv1.AddToScheme(scheme.Scheme))
-	var resources = []*metav1.APIResourceList{}
+	resources := []*metav1.APIResourceList{}
 	for gvk := range scheme.Scheme.AllKnownTypes() {
 		resource, _ := meta.UnsafeGuessKindToResource(gvk)
 		resources = append(resources, &metav1.APIResourceList{
@@ -331,7 +281,6 @@ func apiSchemeResourceList(t *testing.T) []*metav1.APIResourceList {
 func withVMResourcesList(t *testing.T) []*metav1.APIResourceList {
 	return append(apiSchemeResourceList(t),
 		&metav1.APIResourceList{
-
 			GroupVersion: vmGVR.GroupVersion().String(),
 			APIResources: []metav1.APIResource{
 				{Name: "virtualmachineinstances", Namespaced: true, Kind: "VirtualMachineInstance"},


### PR DESCRIPTION
refactor the resource cache out of the OwnerFetcher so that it can be used for other purposes and shared.

I intend to use the new ResourceCache in the Guardian Cockpit for the reverse of what it was used for in the OwnerFetcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Resource discovery is now cached to reduce redundant API calls and speed up lookups.
  * Owner resolution now uses the cache for more consistent and efficient behavior.

* **Bug Fixes**
  * Owner lookup now returns an explicit error when a resource cannot be resolved, improving failure clarity.

* **Tests**
  * Added unit tests covering discovery caching, lookups across core/custom groups, error propagation, and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->