### PR TITLE
SANDBOX-1282 | refactor: replace "wrapf" calls with stdlib wrap calls

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -97,7 +97,7 @@ func (c ApplyClient) ApplyObject(ctx context.Context, obj client.Object, options
 	gvk := obj.GetObjectKind().GroupVersionKind()
 	createdOrUpdated, err := c.applyObject(ctx, obj, options...)
 	if err != nil {
-		return createdOrUpdated, errors.Wrapf(err, "unable to create resource of kind: %s, version: %s", gvk.Kind, gvk.Version)
+		return createdOrUpdated, fmt.Errorf("unable to create resource of kind: %s, version: %s: %w", gvk.Kind, gvk.Version, err)
 	}
 	return createdOrUpdated, nil
 }
@@ -127,7 +127,7 @@ func (c ApplyClient) applyObject(ctx context.Context, obj client.Object, options
 			obj.SetResourceVersion("") // reset resource version when creating to avoid error: resourceVersion should not be set on objects to be created
 			return true, c.createObj(ctx, obj, config.owner)
 		}
-		return false, errors.Wrapf(err, "unable to get the resource '%v'", existing)
+		return false, fmt.Errorf("unable to get the resource '%v': %w", existing, err)
 	}
 
 	// as it already exists, check using the UpdateStrategy if it should be updated
@@ -164,7 +164,7 @@ func (c ApplyClient) applyObject(ctx context.Context, obj client.Object, options
 		return false, err
 	}
 	if err := c.Update(ctx, obj); err != nil {
-		return false, errors.Wrapf(err, "unable to update the resource '%v'", obj)
+		return false, fmt.Errorf("unable to update the resource '%v': %w", obj, err)
 	}
 
 	// check if it was changed or not
@@ -251,7 +251,7 @@ func (c ApplyClient) Apply(ctx context.Context, toolchainObjects []client.Object
 
 		result, err := c.ApplyObject(ctx, toolchainObject, ForceUpdate(true))
 		if err != nil {
-			return false, errors.Wrapf(err, "unable to create resource of kind: %s, version: %s", toolchainObject.GetObjectKind().GroupVersionKind().Kind, toolchainObject.GetObjectKind().GroupVersionKind().Version)
+			return false, fmt.Errorf("unable to create resource of kind: %s, version: %s: %w", toolchainObject.GetObjectKind().GroupVersionKind().Kind, toolchainObject.GetObjectKind().GroupVersionKind().Version, err)
 		}
 		createdOrUpdated = createdOrUpdated || result
 	}

--- a/pkg/cluster/service.go
+++ b/pkg/cluster/service.go
@@ -166,7 +166,7 @@ func NewClusterConfig(cl client.Client, toolchainCluster *toolchainv1alpha1.Tool
 	}
 	err := cl.Get(context.TODO(), name, secret)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get secret %s for cluster %s", name, toolchainCluster.Name)
+		return nil, fmt.Errorf("unable to get secret %s for cluster %s: %w", name, toolchainCluster.Name, err)
 	}
 
 	return loadConfigFromKubeConfig(toolchainCluster, secret, timeout)

--- a/pkg/template/nstemplatetiers/nstemplatetier_generator.go
+++ b/pkg/template/nstemplatetiers/nstemplatetier_generator.go
@@ -178,7 +178,7 @@ func loadTemplatesByTiers(metadata map[string]string, files map[string][]byte) (
 		case filename == "based_on_tier.yaml":
 			basedOnTier := &BasedOnTier{}
 			if err := yaml.Unmarshal(content, basedOnTier); err != nil {
-				return nil, errors.Wrapf(err, "unable to unmarshal '%s'", name)
+				return nil, fmt.Errorf("unable to unmarshal '%s': %w", name, err)
 			}
 			results[tier].rawTemplates.basedOnTier = &tmpl
 			results[tier].basedOnTier = basedOnTier
@@ -276,7 +276,7 @@ func (t *TierGenerator) createTierTemplates() error {
 		for _, tierTmpl := range tierTmpls.tierTemplates {
 			log.Info("creating TierTemplate", "namespace", tierTmpl.Namespace, "name", tierTmpl.Name)
 			if err := t.ensureObject(tierTmpl, tierName); err != nil {
-				return errors.Wrapf(err, "unable to create the '%s' TierTemplate in namespace '%s'", tierTmpl.Name, tierTmpl.Namespace)
+				return fmt.Errorf("unable to create the '%s' TierTemplate in namespace '%s': %w", tierTmpl.Name, tierTmpl.Namespace, err)
 			}
 			log.Info("TierTemplate resource created", "namespace", tierTmpl.Namespace, "name", tierTmpl.Name)
 		}
@@ -294,7 +294,7 @@ func (t *TierGenerator) newTierTemplate(decoder runtime.Decoder, basedOnTierFile
 	tmplObj := &templatev1.Template{}
 	_, _, err := decoder.Decode(tmpl.content, nil, tmplObj)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate '%s' TierTemplate manifest", name)
+		return nil, fmt.Errorf("unable to generate '%s' TierTemplate manifest: %w", name, err)
 	}
 	setParams(parameters, tmplObj)
 
@@ -376,7 +376,7 @@ func (t *TierGenerator) createNSTemplateTiers() error {
 		labels[toolchainv1alpha1.ProviderLabelKey] = toolchainv1alpha1.ProviderLabelValue
 		err := t.ensureObject(tier, tierName)
 		if err != nil {
-			return errors.Wrapf(err, "unable to create or update the '%s' NSTemplateTier", tierName)
+			return fmt.Errorf("unable to create or update the '%s' NSTemplateTier: %w", tierName, err)
 		}
 		tierLog := log.WithValues("name", tierName)
 		if tier.Spec.ClusterResources != nil {
@@ -426,7 +426,7 @@ func (t *TierGenerator) newNSTemplateTier(sourceTierName, tierName string, nsTem
 	tmplObj := &templatev1.Template{}
 	_, _, err := decoder.Decode(nsTemplateTier.content, nil, tmplObj)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to generate '%s' NSTemplateTier manifest", tierName)
+		return nil, fmt.Errorf("unable to generate '%s' NSTemplateTier manifest: %w", tierName, err)
 	}
 
 	tmplProcessor := commonTemplate.NewProcessor(t.scheme)


### PR DESCRIPTION
There is no need to keep the legacy "wrapf" calls to wrap errors anymore, so the idea is to remove them in favor of the wrapping calls of the stdlib.

## Related PRs

- https://github.com/codeready-toolchain/host-operator/pull/1257
- https://github.com/codeready-toolchain/member-operator/pull/744
- https://github.com/codeready-toolchain/toolchain-common/pull/526
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1275

## Jira ticket
[[SANDBOX-1282]](https://redhat.atlassian.net/browse/SANDBOX-1282)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal error handling across client, cluster, and template components to use native Go error wrapping semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->